### PR TITLE
feat(doc): add --smart flag for auto-optimized doc reading

### DIFF
--- a/src/templates/guidelines/cli/commands-reference.md
+++ b/src/templates/guidelines/cli/commands-reference.md
@@ -111,16 +111,11 @@ Step-by-step guide...
 **Reading workflow:**
 
 ```bash
-# Step 1: Check size first
-knowns doc <path> --info --plain
-# → If <2000 tokens: read directly with --plain
-# → If >2000 tokens: continue to step 2
+# Always use --smart (handles both small and large docs automatically)
+knowns doc <path> --plain --smart
 
-# Step 2: Get table of contents
-knowns doc <path> --toc --plain
-
-# Step 3: Read specific section
-knowns doc <path> --section "2" --plain
+# If doc is large, --smart returns TOC, then read specific section:
+knowns doc <path> --plain --section "2"
 ```
 
 ---
@@ -169,29 +164,39 @@ knowns doc list --plain               # List all
 knowns doc list --tag api --plain     # Filter by tag
 ```
 
-### Large Documents (--info, --toc, --section)
+### Reading Documents (--smart)
 
-For large documents, check size first with `--info`, then use `--toc` and `--section`:
+**ALWAYS use `--smart` when reading documents.** It automatically handles both small and large docs:
 
 ```bash
-# Step 1: Check document size and token count
-knowns doc readme --info --plain
-# Output: Size: 42,461 chars (~12,132 tokens) | Headings: 83
-# Recommendation: Document is large. Use --toc first, then --section.
-
-# Step 2: View table of contents
-knowns doc readme --toc --plain
-
-# Step 3: Read specific section by title or number
-knowns doc readme --section "5. Sync" --plain
-knowns doc readme --section "3" --plain
+# Always use --smart (recommended)
+knowns doc <path> --plain --smart
 ```
 
-**Decision flow:**
+**Behavior:**
 
-- `--info` → Check size (~tokens) → If >2000 tokens, use --toc/--section
-- `--toc` → Get heading list → Choose section to read
-- `--section` → Read only what you need
+- **Small doc (≤2000 tokens)**: Returns full content automatically
+- **Large doc (>2000 tokens)**: Returns stats + TOC, then use `--section` to read specific parts
+
+```bash
+# Example with large doc:
+knowns doc readme --plain --smart
+# Output: Size: ~12,132 tokens | TOC with numbered sections
+# Hint: Use --section <number> to read specific section
+
+# Then read specific section:
+knowns doc readme --plain --section 3
+```
+
+### Manual Control (--info, --toc, --section)
+
+If you need manual control instead of `--smart`:
+
+```bash
+knowns doc <path> --info --plain     # Check size/tokens
+knowns doc <path> --toc --plain      # View table of contents
+knowns doc <path> --section "3" --plain  # Read specific section
+```
 
 ---
 

--- a/src/templates/guidelines/cli/context-optimization.md
+++ b/src/templates/guidelines/cli/context-optimization.md
@@ -43,26 +43,27 @@ Read file with offset=100 limit=50
 
 ---
 
-## Large Documents (--info, --toc, --section)
+## Reading Documents (--smart)
 
-For large documents, check size first with `--info`:
+**ALWAYS use `--smart` when reading documents.** It automatically handles both small and large docs:
 
 ```bash
-# ❌ Reading entire large document (may be truncated)
+# ❌ Reading without --smart (may get truncated large doc)
 knowns doc readme --plain
 
-# ✅ Step 1: Check document size first
-knowns doc readme --info --plain
-# Output: Size: 42,461 chars (~12,132 tokens) | Headings: 83
+# ✅ Always use --smart
+knowns doc readme --plain --smart
+# Small doc → returns full content
+# Large doc → returns stats + TOC
 
-# ✅ Step 2: View table of contents (if >2000 tokens)
-knowns doc readme --toc --plain
-
-# ✅ Step 3: Read only the section you need
-knowns doc readme --section "3. Config" --plain
+# ✅ If doc is large, read specific section:
+knowns doc readme --plain --section 3
 ```
 
-**Decision flow:** `--info` → check tokens → if >2000, use `--toc` then `--section`
+**`--smart` behavior:**
+
+- **≤2000 tokens**: Returns full content automatically
+- **>2000 tokens**: Returns stats + TOC, then use `--section <number>`
 
 ---
 
@@ -104,9 +105,9 @@ knowns task edit 42 --append-notes "✓ Auth middleware + JWT validation done"
 ## Quick Rules
 
 1. **Always `--plain`** - Never use `--json` unless specifically needed
-2. **Search first** - Don't read all docs hoping to find info
-3. **Read selectively** - Use offset/limit for large files
-4. **Use --info first** - Check doc size before reading, then --toc/--section if needed
+2. **Always `--smart`** - Use `--smart` when reading docs (auto-handles size)
+3. **Search first** - Don't read all docs hoping to find info
+4. **Read selectively** - Use offset/limit for large files
 5. **Write concise** - Compact notes, not essays
 6. **Don't repeat** - Reference context already loaded
 7. **Summarize** - Key points, not full quotes

--- a/src/templates/guidelines/mcp/commands-reference.md
+++ b/src/templates/guidelines/mcp/commands-reference.md
@@ -113,42 +113,45 @@ Get a documentation file by path.
 
 Path can be filename or folder/filename (without .md extension).
 
-### Large Documents (info, toc, section)
+### Reading Documents (smart)
 
-For large documents, check size first with `info`, then use `toc` and `section`:
+**ALWAYS use `smart: true` when reading documents.** It automatically handles both small and large docs:
 
 ```json
-// Step 1: Check document size and token count
+// Always use smart (recommended)
 {
   "path": "readme",
-  "info": true
-}
-// Response: { stats: { chars: 42461, estimatedTokens: 12132, headingCount: 83 }, recommendation: "..." }
-
-// Step 2: Get table of contents
-{
-  "path": "readme",
-  "toc": true
-}
-
-// Step 3: Read specific section by title or number
-{
-  "path": "readme",
-  "section": "5. Sync"
+  "smart": true
 }
 ```
 
-| Parameter | Description                                              |
-| --------- | -------------------------------------------------------- |
-| `info`    | Set `true` to get stats (size, tokens, headings) only    |
-| `toc`     | Set `true` to get table of contents only                 |
-| `section` | Section title or number to read (e.g., "5. Sync" or "3") |
+**Behavior:**
 
-**Decision flow:**
+- **Small doc (≤2000 tokens)**: Returns full content automatically
+- **Large doc (>2000 tokens)**: Returns stats + TOC with numbered sections
 
-- `info: true` → Check estimatedTokens → If >2000, use toc/section
-- `toc: true` → Get heading list → Choose section to read
-- `section: "X"` → Read only what you need
+```json
+// If doc is large, smart returns TOC, then read specific section:
+{
+  "path": "readme",
+  "section": "3"
+}
+```
+
+| Parameter | Description                                                    |
+| --------- | -------------------------------------------------------------- |
+| `smart`   | **Recommended.** Auto-return full content or TOC based on size |
+| `section` | Read specific section by number (e.g., "3") or title           |
+
+### Manual Control (info, toc, section)
+
+If you need manual control instead of `smart`:
+
+```json
+{ "path": "readme", "info": true }     // Check size/tokens
+{ "path": "readme", "toc": true }      // View table of contents
+{ "path": "readme", "section": "3" }   // Read specific section
+```
 
 ---
 
@@ -220,15 +223,10 @@ Step-by-step guide...
 **Reading workflow:**
 
 ```json
-// Step 1: Check size first
-{ "path": "<path>", "info": true }
-// → If estimatedTokens <2000: read directly (no options)
-// → If estimatedTokens >2000: continue to step 2
+// Always use smart (handles both small and large docs automatically)
+{ "path": "<path>", "smart": true }
 
-// Step 2: Get table of contents
-{ "path": "<path>", "toc": true }
-
-// Step 3: Read specific section
+// If doc is large, smart returns TOC, then read specific section:
 { "path": "<path>", "section": "2" }
 ```
 

--- a/src/templates/guidelines/mcp/context-optimization.md
+++ b/src/templates/guidelines/mcp/context-optimization.md
@@ -34,26 +34,27 @@ mcp__knowns__list_tasks({
 
 ---
 
-## Large Documents (info, toc, section)
+## Reading Documents (smart)
 
-For large documents, check size first with `info`:
+**ALWAYS use `smart: true` when reading documents.** It automatically handles both small and large docs:
 
 ```json
-// DON'T: Read entire large document (may be truncated)
+// DON'T: Read without smart (may get truncated large doc)
 mcp__knowns__get_doc({ "path": "readme" })
 
-// DO: Step 1 - Check document size first
-mcp__knowns__get_doc({ "path": "readme", "info": true })
-// Response: { stats: { estimatedTokens: 12132 }, recommendation: "..." }
+// DO: Always use smart
+mcp__knowns__get_doc({ "path": "readme", "smart": true })
+// Small doc → returns full content
+// Large doc → returns stats + TOC
 
-// DO: Step 2 - Get table of contents (if >2000 tokens)
-mcp__knowns__get_doc({ "path": "readme", "toc": true })
-
-// DO: Step 3 - Read only the section you need
-mcp__knowns__get_doc({ "path": "readme", "section": "3. Config" })
+// DO: If doc is large, read specific section
+mcp__knowns__get_doc({ "path": "readme", "section": "3" })
 ```
 
-**Decision flow:** `info: true` → check tokens → if >2000, use `toc` then `section`
+**`smart: true` behavior:**
+
+- **≤2000 tokens**: Returns full content automatically
+- **>2000 tokens**: Returns stats + TOC, then use `section` parameter
 
 ---
 
@@ -93,10 +94,10 @@ knowns task edit 42 --append-notes "Done: Auth middleware + JWT validation"
 
 ## Quick Rules
 
-1. **Search first** - Don't read all docs hoping to find info
-2. **Use filters** - Don't list everything then filter manually
-3. **Read selectively** - Only fetch what you need
-4. **Use info first** - Check doc size before reading, then toc/section if needed
+1. **Always `smart: true`** - Use smart when reading docs (auto-handles size)
+2. **Search first** - Don't read all docs hoping to find info
+3. **Use filters** - Don't list everything then filter manually
+4. **Read selectively** - Only fetch what you need
 5. **Write concise** - Compact notes, not essays
 6. **Don't repeat** - Reference context already loaded
 7. **Summarize** - Key points, not full quotes


### PR DESCRIPTION
## Description

- Add --smart flag to CLI and MCP for intelligent doc reading
- Small docs (≤2000 tokens) return full content automatically
- Large docs (>2000 tokens) return stats + TOC with section hints
- Fix --section to support numeric index from TOC display
- Add token count to doc list output for AI context awareness
- Update CLI and MCP guidelines to recommend --smart usage

## Related Issue

<!-- Link to the issue this PR addresses -->

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
