### PR TITLE
Update build-cli.js

### DIFF
--- a/scripts/build-cli.js
+++ b/scripts/build-cli.js
@@ -36,10 +36,10 @@ const stripShebangPlugin = {
 const shebang = "#!/usr/bin/env node\n";
 
 // Banner to create require for ESM (shebang added after build)
-const esmBanner = `import { createRequire } from 'module';
+const esmBanner = `import { createRequire as __createRequire } from 'module';
 import { fileURLToPath as __fileURLToPath } from 'url';
 import { dirname as __dirname_fn } from 'path';
-const require = createRequire(import.meta.url);
+const require = __createRequire(import.meta.url);
 const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __dirname_fn(__filename);
 `;


### PR DESCRIPTION
## Description

File changed: scripts/build-cli.js

Change: Rename createRequire → __createRequire in banner to avoid conflict with fdir package
```
- import { createRequire } from 'module';
+ import { createRequire as __createRequire } from 'module';
- const require = createRequire(import.meta.url);
+ const require = __createRequire(import.meta.url);
```

Why: The fdir package also imports createRequire, causing SyntaxError: Identifier 'createRequire' has already been declared on Node.js 24

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
