### PR TITLE
fix(mcp): preserve fields on update and persist working memory

### DIFF
--- a/.knowns/config.json
+++ b/.knowns/config.json
@@ -39,7 +39,7 @@
       "dimensions": 384,
       "maxTokens": 512
     },
-    "serverPort": 6420,
+    "serverPort": 3333,
     "platforms": [
       "claude-code",
       "gemini",

--- a/internal/mcp/handlers/doc.go
+++ b/internal/mcp/handlers/doc.go
@@ -344,7 +344,9 @@ func RegisterDocTools(s *server.MCPServer, getStore func() *storage.Store) {
 			if hasSection && sectionTarget != "" && hasContent {
 				// Replace a specific section.
 				doc.Content = replaceSection(doc.Content, sectionTarget, newContent)
-			} else if hasContent {
+			} else if hasContent && newContent != "" {
+				// Only update content if explicitly provided with non-empty value.
+				// Empty content update is ignored to preserve existing content.
 				doc.Content = newContent
 			}
 

--- a/internal/mcp/handlers/task.go
+++ b/internal/mcp/handlers/task.go
@@ -117,6 +117,12 @@ func RegisterTaskTools(s *server.MCPServer, getStore func() *storage.Store) {
 			if v, ok := intArg(args, "order"); ok {
 				task.Order = &v
 			}
+			if v, ok := stringArg(args, "plan"); ok {
+				task.ImplementationPlan = v
+			}
+			if v, ok := stringArg(args, "notes"); ok {
+				task.ImplementationNotes = v
+			}
 
 			if err := store.Tasks.Create(task); err != nil {
 				return errFailed("create task", err)

--- a/internal/mcp/handlers/working_memory.go
+++ b/internal/mcp/handlers/working_memory.go
@@ -3,10 +3,12 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/howznguyen/knowns/internal/models"
+	"github.com/howznguyen/knowns/internal/storage"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -75,12 +77,14 @@ func (w *WorkingMemoryStore) Clear() int {
 }
 
 // RegisterWorkingMemoryTools registers session-scoped working memory tools.
-func RegisterWorkingMemoryTools(s *server.MCPServer, getWM func() *WorkingMemoryStore) {
+// getStore returns the storage store for persistent working memory.
+// getWM returns the in-memory store (used for session-scoped caching).
+func RegisterWorkingMemoryTools(s *server.MCPServer, getStore func() *storage.Store, getWM func() *WorkingMemoryStore) {
 
 	// ── add_working_memory ──────────────────────────────────────────────
 	s.AddTool(
 		mcp.NewTool("add_working_memory",
-			mcp.WithDescription("Add a working memory entry (session-scoped, ephemeral)."),
+			mcp.WithDescription("Add a working memory entry (persistent, survives restarts)."),
 			mcp.WithString("content",
 				mcp.Required(),
 				mcp.Description("Memory content"),
@@ -97,6 +101,10 @@ func RegisterWorkingMemoryTools(s *server.MCPServer, getWM func() *WorkingMemory
 			),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			store := getStore()
+			if store == nil {
+				return noProjectError()
+			}
 			wm := getWM()
 
 			content, err := req.RequireString("content")
@@ -111,6 +119,7 @@ func RegisterWorkingMemoryTools(s *server.MCPServer, getWM func() *WorkingMemory
 
 			entry := &models.MemoryEntry{
 				Title:    title,
+				Layer:    models.MemoryLayerWorking,
 				Category: category,
 				Content:  content,
 				Tags:     tags,
@@ -119,6 +128,12 @@ func RegisterWorkingMemoryTools(s *server.MCPServer, getWM func() *WorkingMemory
 				entry.Tags = []string{}
 			}
 
+			// Save to persistent storage.
+			if err := store.Memory.Create(entry); err != nil {
+				return errFailed("create working memory", err)
+			}
+
+			// Also add to in-memory cache.
 			wm.Add(entry)
 
 			out, _ := json.MarshalIndent(entry, "", "  ")
@@ -136,15 +151,18 @@ func RegisterWorkingMemoryTools(s *server.MCPServer, getWM func() *WorkingMemory
 			),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			wm := getWM()
+			store := getStore()
+			if store == nil {
+				return noProjectError()
+			}
 
 			id, err := req.RequireString("id")
 			if err != nil {
 				return errResult("id is required")
 			}
 
-			entry, ok := wm.Get(id)
-			if !ok {
+			entry, err := store.Memory.Get(id)
+			if err != nil {
 				return errResult("working memory entry not found: " + id)
 			}
 
@@ -156,11 +174,21 @@ func RegisterWorkingMemoryTools(s *server.MCPServer, getWM func() *WorkingMemory
 	// ── list_working_memories ───────────────────────────────────────────
 	s.AddTool(
 		mcp.NewTool("list_working_memories",
-			mcp.WithDescription("List all working memory entries (session-scoped)."),
+			mcp.WithDescription("List all working memory entries."),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			wm := getWM()
-			entries := wm.List()
+			store := getStore()
+			if store == nil {
+				return noProjectError()
+			}
+
+			entries, err := store.Memory.List(models.MemoryLayerWorking)
+			if err != nil {
+				return errFailed("list working memories", err)
+			}
+			if entries == nil {
+				entries = []*models.MemoryEntry{}
+			}
 
 			out, _ := json.MarshalIndent(entries, "", "  ")
 			return mcp.NewToolResultText(string(out)), nil
@@ -177,6 +205,10 @@ func RegisterWorkingMemoryTools(s *server.MCPServer, getWM func() *WorkingMemory
 			),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			store := getStore()
+			if store == nil {
+				return noProjectError()
+			}
 			wm := getWM()
 
 			id, err := req.RequireString("id")
@@ -184,9 +216,12 @@ func RegisterWorkingMemoryTools(s *server.MCPServer, getWM func() *WorkingMemory
 				return errResult("id is required")
 			}
 
-			if !wm.Delete(id) {
+			if err := store.Memory.Delete(id); err != nil {
 				return errResult("working memory entry not found: " + id)
 			}
+
+			// Also remove from in-memory cache.
+			wm.Delete(id)
 
 			result := map[string]any{
 				"deleted": true,
@@ -200,15 +235,26 @@ func RegisterWorkingMemoryTools(s *server.MCPServer, getWM func() *WorkingMemory
 	// ── clear_working_memory ────────────────────────────────────────────
 	s.AddTool(
 		mcp.NewTool("clear_working_memory",
-			mcp.WithDescription("Clear all working memory entries for this session."),
+			mcp.WithDescription("Clear all working memory entries."),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			store := getStore()
+			if store == nil {
+				return noProjectError()
+			}
 			wm := getWM()
-			count := wm.Clear()
+
+			count, err := store.Memory.Clean()
+			if err != nil {
+				return errFailed("clear working memories", err)
+			}
+
+			// Also clear in-memory cache.
+			wm.Clear()
 
 			result := map[string]any{
 				"cleared": count,
-				"message": "All working memory entries cleared.",
+				"message": fmt.Sprintf("Cleared %d working memory entries.", count),
 			}
 			out, _ := json.MarshalIndent(result, "", "  ")
 			return mcp.NewToolResultText(string(out)), nil

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -78,7 +78,7 @@ func NewMCPServer(projectHint string) *MCPServer {
 
 	// Working memory is session-scoped (in-memory only).
 	workingMemory := handlers.NewWorkingMemoryStore()
-	handlers.RegisterWorkingMemoryTools(s.srv, func() *handlers.WorkingMemoryStore {
+	handlers.RegisterWorkingMemoryTools(s.srv, getStore, func() *handlers.WorkingMemoryStore {
 		return workingMemory
 	})
 

--- a/ui/src/pages/MemoryPage.tsx
+++ b/ui/src/pages/MemoryPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { memoryApi, type MemoryEntry } from "@/ui/api/client";
 import { Brain, ChevronUp, ChevronDown, Trash2, Plus, Loader2, X } from "lucide-react";
 import { cn } from "@/ui/lib/utils";
+import MDRender from "@/ui/components/editor/MDRender";
 
 const layerColors: Record<string, { bg: string; text: string; border: string }> = {
 	working: {
@@ -279,9 +280,7 @@ export default function MemoryPage() {
 						</div>
 						<h2 className="text-xl font-semibold mb-3">{selected.title || "Untitled"}</h2>
 						{selected.content && (
-							<div className="prose prose-sm dark:prose-invert max-w-none">
-								<pre className="whitespace-pre-wrap text-sm font-sans">{selected.content}</pre>
-							</div>
+							<MDRender markdown={selected.content} className="prose prose-sm dark:prose-invert max-w-none" />
 						)}
 						{selected.tags && selected.tags.length > 0 && (
 							<div className="flex gap-1.5 mt-4 pt-4 border-t border-border">


### PR DESCRIPTION
## Description

- Fix create_task ignoring plan and notes parameters
- Fix update_doc clearing content when empty string sent
- Persist working memory to .knowns/.working-memory/ so it survives restarts
- Clean command properly removes working memory files

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):