### PR TITLE
docs(release): document v0.18.0 features

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -517,7 +517,7 @@ jobs:
                 \"fields\": [
                   {
                     \"name\": \"Install/Update\",
-                    \"value\": \"\`\`\`bash\\n# npm\\nnpm install -g knowns@${VERSION}\\n\\n# bun\\nbun add -g knowns@${VERSION}\\n\\n# brew\\nbrew upgrade knowns\\n\`\`\`\",
+                    \"value\": \"\`\`\`bash\\n# npm\\nnpm install -g knowns@${VERSION}\\n\\n# bun\\nbun add -g knowns@${VERSION}\\n\\n# brew\\nbrew upgrade knowns-dev/tap/knowns\\n\`\`\`\",
                     \"inline\": false
                   },
                   {

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ Transform AI from a tool into a true engineering collaborator.
 
 Keep your knowledge private and fully under your control.
 
+## What's New In v0.18.0
+
+- Workspace-aware browser mode: run `knowns browser` outside a repo, scan for projects, and switch workspaces from the UI without restarting the server.
+- AST code intelligence: index Go, TypeScript, JavaScript, and Python symbols with `knowns code ingest`, keep them fresh with `knowns code watch`, and inspect relationships with `knowns code search`, `knowns code deps`, and `knowns code symbols`.
+- Code graph support: the browser graph can now include indexed code nodes and dependency edges alongside tasks, docs, and memories.
+- Chat runtime upgrades: the chat UI includes stronger tool-output rendering, timeline/history navigation, and clearer OpenCode runtime status.
+
 ---
 
 ## How It Works
@@ -147,11 +154,17 @@ curl -fsSL https://knowns.sh/script/install | sh
 
 # Or with wget
 wget -qO- https://knowns.sh/script/install | sh
+
+# Install a specific version
+curl -fsSL https://knowns.sh/script/install | KNOWNS_VERSION=0.18.0 sh
 ```
 
 ```powershell
 # PowerShell installer (Windows)
 irm https://knowns.sh/script/install.ps1 | iex
+
+# Install a specific version
+$env:KNOWNS_VERSION = "0.18.0"; irm https://knowns.sh/script/install.ps1 | iex
 ```
 
 ### Uninstall
@@ -213,8 +226,9 @@ knowns browser --open   # Start Web UI and open browser
 | **Memory System**   | 3-layer memory (project/working/global) for AI recall |
 | **AI Integration**  | Full MCP Server with AC/plan/notes operations      |
 | **AI Workspaces**   | Multi-phase agent orchestration with live terminal |
+| **Code Intelligence** | AST indexing, code search, and dependency graph   |
 | **Web UI**          | Kanban board, doc browser, mermaid diagrams        |
-| **Knowledge Graph** | Visual graph of tasks, docs, memories + relationships (search, impact analysis, clusters) |
+| **Knowledge Graph** | Visual graph of tasks, docs, memories, and optional code relationships |
 
 ---
 
@@ -248,6 +262,12 @@ knowns import list                          # List imports
 knowns time start <id> && knowns time stop
 knowns search "query" --plain
 knowns validate                             # Check broken refs
+
+# Code intelligence
+knowns code ingest
+knowns code search "oauth login" --neighbors 5
+knowns code deps --type calls
+knowns code symbols --kind function
 
 # AI Guidelines
 knowns agents --sync                        # Sync/generate instruction files

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -606,6 +606,132 @@ knowns model remove gte-small
 
 ---
 
+## Code Intelligence Commands
+
+### `knowns code`
+
+Code intelligence commands for AST-based indexing and graph analysis.
+
+```bash
+knowns code <command>
+```
+
+**Available subcommands:**
+
+- `knowns code ingest` - index supported code files into the local search/code graph
+- `knowns code watch` - watch code files and auto-index on changes
+- `knowns code search <query>` - search indexed code with optional neighbor expansion
+- `knowns code deps` - inspect indexed dependency edges such as `calls` or `imports`
+- `knowns code symbols` - inspect indexed symbols by file or kind
+
+### `knowns code ingest`
+
+Index code files using AST-based code intelligence.
+
+```bash
+knowns code ingest [options]
+```
+
+| Option            | Description                                          |
+| ----------------- | ---------------------------------------------------- |
+| `--dry-run`       | Preview what would be indexed without writing to disk |
+| `--include-tests` | Include test files in the code index                 |
+
+**Examples:**
+
+```bash
+knowns code ingest
+knowns code ingest --dry-run
+knowns code ingest --include-tests
+```
+
+### `knowns code watch`
+
+Watch code files and auto-index on changes.
+
+```bash
+knowns code watch [options]
+```
+
+| Option         | Description                           |
+| -------------- | ------------------------------------- |
+| `--debounce`   | Debounce delay in milliseconds        |
+
+**Examples:**
+
+```bash
+knowns code watch
+knowns code watch --debounce 500
+```
+
+### `knowns code search`
+
+Search indexed code and optionally expand related neighbors from the code graph.
+
+```bash
+knowns code search <query> [options]
+```
+
+| Option           | Description                              |
+| ---------------- | ---------------------------------------- |
+| `--limit`        | Limit direct code matches                |
+| `--neighbors`    | Max neighbors per match (1-hop)          |
+| `--edge-types`   | Comma-separated edge types to expand     |
+| `--keyword`      | Force keyword-only code search           |
+| `--show-snippet` | Show snippet/preview for each match      |
+
+**Examples:**
+
+```bash
+knowns code search "oauth login"
+knowns code search backfill --neighbors 5 --edge-types calls,imports
+knowns code search token --keyword --show-snippet
+```
+
+### `knowns code deps`
+
+Inspect indexed code dependency data.
+
+```bash
+knowns code deps [options]
+```
+
+| Option      | Description                  |
+| ----------- | ---------------------------- |
+| `--type`    | Filter dependency edge type  |
+| `--limit`   | Limit dependency results     |
+
+**Examples:**
+
+```bash
+knowns code deps
+knowns code deps --type calls
+```
+
+### `knowns code symbols`
+
+Inspect indexed code symbols.
+
+```bash
+knowns code symbols [options]
+```
+
+| Option      | Description                  |
+| ----------- | ---------------------------- |
+| `--path`    | Filter symbols by file path  |
+| `--kind`    | Filter symbols by kind       |
+| `--limit`   | Limit symbol results         |
+
+**Examples:**
+
+```bash
+knowns code symbols
+knowns code symbols --path internal/server/server.go
+knowns code symbols --kind function
+```
+
+---
+
 ## Template Commands
 
 ### `knowns template list`
@@ -820,6 +946,9 @@ knowns browser [options]
 | `--no-open`  | Don't automatically open browser         |
 | `--port`     | Custom port (default: `3001` or config)  |
 | `--restart`  | Restart server if already running        |
+| `--project`  | Open a specific project path directly    |
+| `--scan`     | Comma-separated directories to scan for projects |
+| `--watch`    | Enable code watcher for auto-indexing    |
 
 **Examples:**
 
@@ -829,6 +958,15 @@ knowns browser
 
 # Start and open browser
 knowns browser --open
+
+# Start outside a repo and scan common workspaces
+knowns browser --scan ~/Workspaces,~/Projects --open
+
+# Open a specific project directly
+knowns browser --project ~/Workspaces/my-app --open
+
+# Run browser with code auto-indexing enabled
+knowns browser --watch
 ```
 
 ### `knowns mcp`

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -1,12 +1,13 @@
 # Semantic Search Guide
 
-Search tasks and docs by **meaning**, not just keywords. Uses local AI models for privacy and offline capability.
+Search tasks, docs, memories, and optionally indexed code by **meaning**, not just keywords. Uses local AI models for privacy and offline capability.
 
 ## Table of Contents
 
 - [Getting Started](#getting-started)
 - [Model Management](#model-management)
 - [Search Usage](#search-usage)
+- [Code Intelligence](#code-intelligence)
 - [Configuration](#configuration)
 - [How It Works](#how-it-works)
 - [Troubleshooting](#troubleshooting)
@@ -205,6 +206,7 @@ Index includes:
 - **Local docs** - All docs in `.knowns/docs/`
 - **Imported docs** - All docs from `.knowns/imports/*/docs/`
 - **Memories** - All memory entries in `.knowns/memories/`
+- **Code** - Indexed symbols and relationships after running `knowns code ingest`
 
 Index updates automatically when:
 
@@ -239,6 +241,57 @@ Combines two approaches:
 2. **Keyword**: Exact term matching for precision
 
 Results are merged and ranked by combined score.
+
+---
+
+## Code Intelligence
+
+`v0.18.0` adds an optional AST-based code intelligence layer on top of semantic search.
+
+### Build the code index
+
+```bash
+knowns code ingest
+```
+
+This indexes supported code files and stores symbols plus dependency edges for:
+
+- Go
+- TypeScript
+- JavaScript
+- Python
+
+Preview without writing:
+
+```bash
+knowns code ingest --dry-run
+```
+
+### Keep code index fresh
+
+```bash
+knowns code watch
+```
+
+Or run the browser with the watcher enabled:
+
+```bash
+knowns browser --watch
+```
+
+### Search indexed code
+
+```bash
+knowns code search "oauth login" --neighbors 5
+knowns code deps --type calls
+knowns code symbols --kind function
+```
+
+### When code appears in results
+
+Code results are opt-in. They appear only after you build the code index with `knowns code ingest`.
+
+If you never run ingest, normal search behavior stays the same.
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -100,6 +100,13 @@ knowns task list
 knowns browser --open
 ```
 
+### New in v0.18.0
+
+- Run `knowns browser` outside a repo and switch between registered workspaces in the UI.
+- Build a code index with `knowns code ingest` and explore symbols, dependencies, and code search results.
+- Use `knowns browser --watch` or `knowns code watch` to keep code search data fresh while you work.
+- Explore richer chat history and runtime status from the browser chat page.
+
 ---
 
 ## CLI Command Reference

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -1,6 +1,6 @@
 # Web UI Guide
 
-Knowns includes a local browser UI for tasks and docs.
+Knowns includes a local browser UI for tasks, docs, workspaces, code graph exploration, and chat.
 
 ---
 
@@ -12,6 +12,15 @@ knowns browser
 
 # Start and open browser
 knowns browser --open
+
+# Open a specific project directly
+knowns browser --project ~/Workspaces/my-app --open
+
+# Scan project folders when starting outside a repo
+knowns browser --scan ~/Workspaces,~/Projects --open
+
+# Enable background code auto-indexing while the UI is running
+knowns browser --watch
 ```
 
 Default port is `3001` unless overridden by `settings.serverPort` or `--port`.
@@ -25,6 +34,9 @@ knowns browser --port 3002
 knowns browser --no-open
 knowns browser --restart
 knowns browser --dev
+knowns browser --project ~/Workspaces/my-app
+knowns browser --scan ~/Workspaces,~/Projects
+knowns browser --watch
 ```
 
 ---
@@ -33,19 +45,42 @@ knowns browser --dev
 
 - task board and task details
 - document browsing and markdown rendering
-- knowledge graph visualization (tasks, docs, memories relationships)
+- workspace picker and project switching
+- knowledge graph visualization (tasks, docs, memories, and optional code relationships)
 - memory management (3-layer: working, project, global)
 - search and navigation shortcuts
+- chat UI with timeline/history navigation and runtime status
 - real-time updates from local project data
+
+### Workspace Switching
+
+You can launch `knowns browser` from outside any repo. In that mode, the UI can:
+
+- list known workspaces from the local registry
+- scan common folders or user-provided paths for `.knowns/` projects
+- switch between projects without restarting the server
+
+This is useful when you work across multiple repos and want one Knowns UI session to move between them.
 
 ### Knowledge Graph
 
-The `/graph` page visualizes relationships between tasks, docs, and memories using Cytoscape.js:
+The `/graph` page visualizes relationships between tasks, docs, memories, and indexed code using Cytoscape.js:
 
-- **Node types**: tasks (circle), docs (rounded rectangle), memories (hexagon)
-- **Edge types**: parent (solid), spec (dashed), mention (dotted)
+- **Node types**: tasks (circle), docs (rounded rectangle), memories (hexagon), code (when indexed)
+- **Edge types**: parent (solid), spec (dashed), mention (dotted), code dependency edges (when code graph is enabled)
 - **Features**: search highlighting, impact analysis (2-hop BFS), cluster detection
 - **Interactions**: hover to highlight neighbors, drag nodes, click for details
+
+If you have run `knowns code ingest`, the graph can include indexed code symbols and relationships in addition to the usual knowledge graph entities.
+
+### Chat and Runtime Status
+
+The chat page includes runtime-aware improvements shipped in `v0.18.0`:
+
+- clearer rendering for tool-heavy assistant messages
+- a timeline/history dialog for jumping through long sessions
+- runtime status surfaces for OpenCode readiness and degraded states
+- better multi-session and sidebar behavior for longer conversations
 
 The exact page layout can evolve, but the browser UI is powered by the local Knowns server and reads from your current project.
 

--- a/internal/mcp/handlers/search.go
+++ b/internal/mcp/handlers/search.go
@@ -196,6 +196,7 @@ func RegisterSearchTools(s *server.MCPServer, getStore func() *storage.Store) {
 			),
 			mcp.WithArray("sourceTypes",
 				mcp.Description("Optional source types: doc, task, memory"),
+				mcp.WithStringEnumItems([]string{"doc", "task", "memory"}),
 			),
 			mcp.WithBoolean("expandReferences",
 				mcp.Description("Whether to include linked docs/tasks/memories as expanded context"),

--- a/internal/util/update_notifier.go
+++ b/internal/util/update_notifier.go
@@ -173,7 +173,7 @@ func DetectInstallCmd() string {
 
 	// 1. Homebrew: binary in /homebrew/ or /Cellar/
 	if strings.Contains(exePath, "/homebrew/") || strings.Contains(exePath, "/cellar/") {
-		return "brew upgrade knowns"
+		return "brew upgrade knowns-dev/tap/knowns"
 	}
 
 	// 2. Check npm_config_user_agent (set when running via npx/npm scripts)


### PR DESCRIPTION
## Description

Document the v0.18.0 workspace, code intelligence, and chat UX updates, and fix the retrieve MCP schema plus Homebrew upgrade command so release guidance matches shipped behavior.
