### PR TITLE
fix(publish): configure windows arm64 cgo toolchain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,12 +141,14 @@ jobs:
             npm_pkg: knowns-win-x64
             ext: ".exe"
             cgo_enabled: "1"
+            msvc_arch: x64
           - runner: windows-11-arm
             goos: windows
             goarch: arm64
             npm_pkg: knowns-win-arm64
             ext: ".exe"
             cgo_enabled: "1"
+            msvc_arch: arm64
     runs-on: ${{ matrix.runner }}
     defaults:
       run:
@@ -159,6 +161,20 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.26"
+
+      - name: Setup MSVC toolchain
+        if: matrix.goos == 'windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.msvc_arch }}
+
+      - name: Prefer clang for Windows cgo builds
+        if: matrix.goos == 'windows'
+        run: |
+          {
+            echo "CC=clang"
+            echo "CXX=clang++"
+          } >> "$GITHUB_ENV"
 
       - name: Setup Bun
         if: matrix.goos == 'windows'


### PR DESCRIPTION
Set up the Windows MSVC environment and prefer clang for Windows cgo builds so the ARM64 release binary can keep semantic search support instead of falling back to a non-cgo build.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
