### PR TITLE
fix(publish): use llvm-mingw for windows cgo builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,14 +141,16 @@ jobs:
             npm_pkg: knowns-win-x64
             ext: ".exe"
             cgo_enabled: "1"
-            msvc_arch: x64
+            llvm_mingw_archive: llvm-mingw-20260407-ucrt-x86_64.zip
+            llvm_mingw_prefix: x86_64-w64-mingw32
           - runner: windows-11-arm
             goos: windows
             goarch: arm64
             npm_pkg: knowns-win-arm64
             ext: ".exe"
             cgo_enabled: "1"
-            msvc_arch: arm64
+            llvm_mingw_archive: llvm-mingw-20260407-ucrt-aarch64.zip
+            llvm_mingw_prefix: aarch64-w64-mingw32
     runs-on: ${{ matrix.runner }}
     defaults:
       run:
@@ -162,18 +164,25 @@ jobs:
         with:
           go-version: "1.26"
 
-      - name: Setup MSVC toolchain
-        if: matrix.goos == 'windows'
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: ${{ matrix.msvc_arch }}
-
-      - name: Prefer clang for Windows cgo builds
+      - name: Install llvm-mingw toolchain
         if: matrix.goos == 'windows'
         run: |
+          curl -L --retry 5 --retry-delay 5 \
+            -o llvm-mingw.zip \
+            "https://github.com/mstorsjo/llvm-mingw/releases/download/20260407/${{ matrix.llvm_mingw_archive }}"
+          unzip -q llvm-mingw.zip -d "$RUNNER_TEMP/llvm-mingw"
+          TOOLCHAIN_DIR=$(find "$RUNNER_TEMP/llvm-mingw" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+          if [ -z "$TOOLCHAIN_DIR" ]; then
+            echo "Failed to extract llvm-mingw toolchain"
+            exit 1
+          fi
           {
-            echo "CC=clang"
-            echo "CXX=clang++"
+            echo "$TOOLCHAIN_DIR/bin"
+          } >> "$GITHUB_PATH"
+          {
+            echo "CC=${{ matrix.llvm_mingw_prefix }}-clang"
+            echo "CXX=${{ matrix.llvm_mingw_prefix }}-clang++"
+            echo "AR=${{ matrix.llvm_mingw_prefix }}-ar"
           } >> "$GITHUB_ENV"
 
       - name: Setup Bun


### PR DESCRIPTION
Switch Windows release builds to llvm-mingw so Go cgo uses a MinGW-compatible linker flow on both x64 and arm64. This avoids the MSVC clang/linker mismatch that breaks semantic-search-enabled binaries during publish.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
