### PR TITLE
fix(search): resolve onnx runtime lib in sibling dirs

### DIFF
--- a/KNOWNS.md
+++ b/KNOWNS.md
@@ -34,7 +34,7 @@ Canonical repository guidance for agents working in this project.
 ## TL;DR
 
 - Read `KNOWNS.md` first.
-- Call MCP `project({ action: "status" })` (or `knowns status --json`) at session start to check project readiness, available capabilities, and knowledge counts.
+- Call MCP `status` (or `knowns status --json`) at session start to check project readiness, available capabilities, and knowledge counts.
 - Use Knowns as the memory layer for humans and the AI-friendly working layer for agents.
 - Search before reading; read only the sections and docs relevant to the current task.
 - Never manually edit Knowns-managed task or doc markdown.
@@ -63,13 +63,13 @@ Canonical repository guidance for agents working in this project.
 
 ## Tool Selection
 
-- Use MCP `project({ action: "status" })` at session start to check project readiness and available capabilities before acting.
+- Use MCP `status` at session start to check project readiness and available capabilities before acting.
 - Use Knowns MCP tools first for tasks, docs, templates, validation, and time tracking.
 - Use file reading and search tools for local code and text inspection.
 - Use shell commands for git, tests, builds, generators, and other terminal operations.
 - Prefer targeted retrieval over loading large files in full.
 - Use `knowns search` for discovery and quick relevance checks.
-- Use MCP `search({ action: "retrieve" })` when a workflow needs structured context with citations and context-pack assembly. Fall back to CLI `knowns retrieve` if MCP is unavailable.
+- Use MCP `retrieve` tool when a workflow needs structured context with citations and context-pack assembly. Fall back to CLI `knowns retrieve` if MCP is unavailable.
 - Prefer `--json` for structured CLI reads consumed by agents, scripts, or workflows, including `get`, `list`, `search`, and `retrieve` commands.
 - Prefer `--plain` for human-facing inspection, quick content reads, and logs when JSON is unnecessary.
 - Do not rely on styled default CLI output for automation or parsing.
@@ -92,6 +92,7 @@ Canonical repository guidance for agents working in this project.
 - Memory complements docs: memory is for fast agent recall, docs are for structured human-readable reference.
 - Never duplicate the full doc content into memory — store a summary and reference the doc with `@doc/<path>`.
 - During any skill: if you discover a reusable pattern, decision, convention, or failure, save it with `memory({ action: "add", layer: "project" })`. Capture knowledge as it emerges, don't wait for extraction.
+- Proactively save durable memory without waiting for the user to say "save this" when confidence is high.
 - Use `project` for repo-specific rules, architecture decisions, conventions, recurring failure patterns, and implementation constraints.
 - Use `global` for stable user preferences or workflow rules that should carry across repositories and future sessions.
 - Ask the user only when the information appears durable but the correct scope (`working`, `project`, or `global`) is genuinely ambiguous.

--- a/internal/search/onnx_runtime.go
+++ b/internal/search/onnx_runtime.go
@@ -196,7 +196,7 @@ func ensureORTEnvironment() error {
 		ort.SetSharedLibraryPath(lib)
 	} else {
 		libName := ortSharedLibName()
-		fmt.Fprintf(os.Stderr, "warning: bundled %s not found next to executable or in ~/.knowns/bin; falling back to system search which may load an incompatible version\n", libName)
+		fmt.Fprintf(os.Stderr, "warning: bundled %s not found next to executable, sibling lib dirs, or ~/.knowns/bin; falling back to system search which may load an incompatible version\n", libName)
 	}
 	if err := ort.InitializeEnvironment(); err != nil {
 		hint := ""
@@ -238,6 +238,14 @@ func ResolveORTLibraryPath() string {
 		candidate := filepath.Join(dir, name)
 		if ortIsFile(candidate) {
 			return candidate
+		}
+		// Check sibling directories relative to the binary's parent.
+		// Homebrew uses ../libexec, other package managers may use ../lib.
+		for _, sibling := range []string{"libexec", "lib"} {
+			candidate = filepath.Join(dir, "..", sibling, name)
+			if ortIsFile(candidate) {
+				return candidate
+			}
 		}
 		if runtime.GOOS == "linux" {
 			if matches, _ := filepath.Glob(filepath.Join(dir, "libonnxruntime.so*")); len(matches) > 0 {


### PR DESCRIPTION
## Description

- Homebrew installs dylib in ../libexec, not next to binary
- Check ../libexec and ../lib relative to executable path

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):