### PR TITLE
fix(ort): validate arch and improve update detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,33 @@ jobs:
           CGO_ENABLED: '1'
         run: go build -ldflags "-s -w -X github.com/howznguyen/knowns/internal/util.Version=${env:GITHUB_SHA}" -o bin/knowns.exe ./cmd/knowns
 
+      - name: Download ONNX Runtime (Unix)
+        if: runner.os != 'Windows'
+        env:
+          ORT_VERSION: "1.25.0"
+        run: |
+          BASE_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}"
+          ARCHIVE="onnxruntime-linux-x64-${ORT_VERSION}.tgz"
+          curl -L --retry 5 --retry-delay 5 -o "/tmp/${ARCHIVE}" "${BASE_URL}/${ARCHIVE}"
+          tar -xzf "/tmp/${ARCHIVE}" -C /tmp
+          mkdir -p ./bin
+          cp "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}" ./bin/libonnxruntime.so
+          echo "KNOWNS_ORT_LIB=$(pwd)/bin/libonnxruntime.so" >> "$GITHUB_ENV"
+
+      - name: Download ONNX Runtime (Windows)
+        if: runner.os == 'Windows'
+        env:
+          ORT_VERSION: "1.25.0"
+        shell: bash
+        run: |
+          BASE_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}"
+          ARCHIVE="onnxruntime-win-x64-${ORT_VERSION}.zip"
+          curl -L --retry 5 --retry-delay 5 -o "/tmp/${ARCHIVE}" "${BASE_URL}/${ARCHIVE}"
+          unzip -q "/tmp/${ARCHIVE}" -d /tmp
+          mkdir -p ./bin
+          cp "/tmp/onnxruntime-win-x64-${ORT_VERSION}/lib/onnxruntime.dll" ./bin/onnxruntime.dll
+          echo "KNOWNS_ORT_LIB=$(pwd)/bin/onnxruntime.dll" >> "$GITHUB_ENV"
+
       - name: Go vet (Unix)
         if: runner.os != 'Windows'
         run: go vet ./...
@@ -103,6 +130,18 @@ jobs:
 
       - name: Build Go binary (with embedded UI)
         run: make build
+
+      - name: Download ONNX Runtime for semantic tests
+        env:
+          ORT_VERSION: "1.25.0"
+        run: |
+          BASE_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}"
+          ARCHIVE="onnxruntime-linux-x64-${ORT_VERSION}.tgz"
+          curl -L --retry 5 --retry-delay 5 -o "/tmp/${ARCHIVE}" "${BASE_URL}/${ARCHIVE}"
+          tar -xzf "/tmp/${ARCHIVE}" -C /tmp
+          cp "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}" ./bin/libonnxruntime.so
+          echo "✓ ONNX Runtime ${ORT_VERSION} installed next to binary"
+          ls -la ./bin/
 
       - name: Install Playwright browsers
         run: cd ui && bunx playwright install --with-deps chromium

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,19 @@ jobs:
             exit 1
           fi
 
+      - name: Download ONNX Runtime for tests
+        env:
+          ORT_VERSION: "1.25.0"
+        run: |
+          BASE_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}"
+          ARCHIVE="onnxruntime-linux-x64-${ORT_VERSION}.tgz"
+          curl -L --retry 5 --retry-delay 5 -o "/tmp/${ARCHIVE}" "${BASE_URL}/${ARCHIVE}"
+          tar -xzf "/tmp/${ARCHIVE}" -C /tmp
+          mkdir -p ./bin
+          cp "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}" ./bin/libonnxruntime.so
+          echo "KNOWNS_ORT_LIB=$(pwd)/bin/libonnxruntime.so" >> "$GITHUB_ENV"
+          echo "✓ ONNX Runtime ${ORT_VERSION} installed for tests"
+
       - name: Run Go tests
         run: go test -v -race ./...
 
@@ -220,82 +233,44 @@ jobs:
 
       - name: Bundle ONNX Runtime native library
         env:
-          # onnxruntime_go v1.27.0 bundles onnxruntime 1.25.0 shared libs,
-          # but only for arm64 (Linux/macOS) and x64 (Windows).
-          # For x64 Linux/macOS we download from the official releases.
           ORT_VERSION: "1.25.0"
         run: |
-          ORT_MOD_DIR=$(go list -m -f '{{.Dir}}' github.com/yalue/onnxruntime_go | tr '\\' '/')
           ARTIFACT_DIR="artifacts/${{ matrix.npm_pkg }}"
-          FOUND=""
+          BASE_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}"
 
-          echo "=== Bundling ONNX Runtime for ${{ matrix.goos }}/${{ matrix.goarch }} ==="
+          echo "=== Bundling ONNX Runtime ${ORT_VERSION} for ${{ matrix.goos }}/${{ matrix.goarch }} ==="
 
-          # --- Try Go module test_data first (arm64 libs + Windows dll) ---
-          if [ "${{ matrix.goos }}" = "linux" ]; then
-            for candidate in \
-              "${ORT_MOD_DIR}/test_data/onnxruntime_arm64.so" \
-              "${ORT_MOD_DIR}/test_data/libonnxruntime_arm64.so" \
-              "${ORT_MOD_DIR}/test_data/libonnxruntime.so" \
-              "${ORT_MOD_DIR}/test_data/onnxruntime.so"; do
-              if [ -f "$candidate" ]; then
-                cp "$candidate" "${ARTIFACT_DIR}/libonnxruntime.so"
-                echo "Copied $(basename "$candidate") -> libonnxruntime.so"
-                FOUND=1
-                break
-              fi
-            done
-          elif [ "${{ matrix.goos }}" = "darwin" ]; then
-            for candidate in \
-              "${ORT_MOD_DIR}/test_data/onnxruntime_arm64.dylib" \
-              "${ORT_MOD_DIR}/test_data/libonnxruntime_arm64.dylib" \
-              "${ORT_MOD_DIR}/test_data/onnxruntime.dylib" \
-              "${ORT_MOD_DIR}/test_data/libonnxruntime.dylib"; do
-              if [ -f "$candidate" ]; then
-                cp "$candidate" "${ARTIFACT_DIR}/libonnxruntime.dylib"
-                echo "Copied $(basename "$candidate") -> libonnxruntime.dylib"
-                FOUND=1
-                break
-              fi
-            done
-          elif [ "${{ matrix.goos }}" = "windows" ]; then
-            if [ -f "${ORT_MOD_DIR}/test_data/onnxruntime.dll" ]; then
-              cp "${ORT_MOD_DIR}/test_data/onnxruntime.dll" "${ARTIFACT_DIR}/onnxruntime.dll"
-              echo "Copied onnxruntime.dll from Go module"
-              FOUND=1
-            fi
-          fi
+          if [ "${{ matrix.goos }}" = "linux" ] && [ "${{ matrix.goarch }}" = "amd64" ]; then
+            ARCHIVE="onnxruntime-linux-x64-${ORT_VERSION}.tgz"
+            curl -L --retry 5 --retry-delay 5 -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
+            tar -xzf "$ARCHIVE"
+            cp "onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}" "${ARTIFACT_DIR}/libonnxruntime.so"
+            echo "Downloaded libonnxruntime.so (${ORT_VERSION}) for linux/amd64"
 
-          # --- Fallback: download from official ONNX Runtime releases ---
-          if [ -z "$FOUND" ]; then
-            echo "Library not found in Go module, downloading onnxruntime ${ORT_VERSION} from GitHub..."
-            BASE_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}"
+          elif [ "${{ matrix.goos }}" = "linux" ] && [ "${{ matrix.goarch }}" = "arm64" ]; then
+            ARCHIVE="onnxruntime-linux-aarch64-${ORT_VERSION}.tgz"
+            curl -L --retry 5 --retry-delay 5 -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
+            tar -xzf "$ARCHIVE"
+            cp "onnxruntime-linux-aarch64-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}" "${ARTIFACT_DIR}/libonnxruntime.so"
+            echo "Downloaded libonnxruntime.so (${ORT_VERSION}) for linux/arm64"
 
-            if [ "${{ matrix.goos }}" = "linux" ] && [ "${{ matrix.goarch }}" = "amd64" ]; then
-              ARCHIVE="onnxruntime-linux-x64-${ORT_VERSION}.tgz"
-              curl -L --retry 5 --retry-delay 5 -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
-              tar -xzf "$ARCHIVE"
-              cp "onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}" "${ARTIFACT_DIR}/libonnxruntime.so"
-              echo "Downloaded and copied libonnxruntime.so (${ORT_VERSION}) for linux/amd64"
+          elif [ "${{ matrix.goos }}" = "darwin" ] && [ "${{ matrix.goarch }}" = "arm64" ]; then
+            ARCHIVE="onnxruntime-osx-arm64-${ORT_VERSION}.tgz"
+            curl -L --retry 5 --retry-delay 5 -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
+            tar -xzf "$ARCHIVE"
+            cp "onnxruntime-osx-arm64-${ORT_VERSION}/lib/libonnxruntime.${ORT_VERSION}.dylib" "${ARTIFACT_DIR}/libonnxruntime.dylib"
+            echo "Downloaded libonnxruntime.dylib (${ORT_VERSION}) for darwin/arm64"
 
-            elif [ "${{ matrix.goos }}" = "linux" ] && [ "${{ matrix.goarch }}" = "arm64" ]; then
-              ARCHIVE="onnxruntime-linux-aarch64-${ORT_VERSION}.tgz"
-              curl -L --retry 5 --retry-delay 5 -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
-              tar -xzf "$ARCHIVE"
-              cp "onnxruntime-linux-aarch64-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}" "${ARTIFACT_DIR}/libonnxruntime.so"
-              echo "Downloaded and copied libonnxruntime.so (${ORT_VERSION}) for linux/arm64"
+          elif [ "${{ matrix.goos }}" = "windows" ] && [ "${{ matrix.goarch }}" = "amd64" ]; then
+            ARCHIVE="onnxruntime-win-x64-${ORT_VERSION}.zip"
+            curl -L --retry 5 --retry-delay 5 -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
+            unzip -q "$ARCHIVE"
+            cp "onnxruntime-win-x64-${ORT_VERSION}/lib/onnxruntime.dll" "${ARTIFACT_DIR}/onnxruntime.dll"
+            echo "Downloaded onnxruntime.dll (${ORT_VERSION}) for windows/amd64"
 
-            elif [ "${{ matrix.goos }}" = "darwin" ] && [ "${{ matrix.goarch }}" = "arm64" ]; then
-              ARCHIVE="onnxruntime-osx-arm64-${ORT_VERSION}.tgz"
-              curl -L --retry 5 --retry-delay 5 -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
-              tar -xzf "$ARCHIVE"
-              cp "onnxruntime-osx-arm64-${ORT_VERSION}/lib/libonnxruntime.${ORT_VERSION}.dylib" "${ARTIFACT_DIR}/libonnxruntime.dylib"
-              echo "Downloaded and copied libonnxruntime.dylib (${ORT_VERSION}) for darwin/arm64"
-
-            else
-              echo "FATAL: No download strategy for ${{ matrix.goos }}/${{ matrix.goarch }}"
-              exit 1
-            fi
+          else
+            echo "FATAL: No download strategy for ${{ matrix.goos }}/${{ matrix.goarch }}"
+            exit 1
           fi
 
           # Verify the native lib was bundled
@@ -556,6 +531,26 @@ jobs:
             tar -tzf "$archive" | grep -Fx "./knowns.exe" >/dev/null || { echo "$archive missing knowns.exe"; exit 1; }
             tar -tzf "$archive" | grep -Fx "./onnxruntime.dll" >/dev/null || { echo "$archive missing onnxruntime.dll"; exit 1; }
           done
+
+          # Verify ELF architecture matches package platform.
+          # e_machine at ELF offset 18: 0x3E = x86_64, 0xB7 = aarch64.
+          verify_elf_arch() {
+            local archive="$1" file="$2" expected_hex="$3" label="$4"
+            tmpdir=$(mktemp -d)
+            tar -xzf "$archive" -C "$tmpdir"
+            machine=$(od -An -tx1 -j18 -N2 "$tmpdir/$file" | tr -d ' ')
+            rm -rf "$tmpdir"
+            if [ "$machine" != "$expected_hex" ]; then
+              echo "FATAL: $archive contains $file with wrong ELF arch (got $machine, expected $expected_hex for $label)"
+              exit 1
+            fi
+            echo "✓ $archive $file arch=$label"
+          }
+
+          verify_elf_arch knowns-linux-x64.tar.gz  ./libonnxruntime.so "3e00" "x86_64"
+          verify_elf_arch knowns-linux-arm64.tar.gz ./libonnxruntime.so "b700" "aarch64"
+          verify_elf_arch knowns-linux-x64.tar.gz   ./knowns            "3e00" "x86_64"
+          verify_elf_arch knowns-linux-arm64.tar.gz  ./knowns            "b700" "aarch64"
 
       - name: Ensure GitHub release exists
         if: github.event_name == 'release'

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/howznguyen/knowns/internal/runtimequeue"
 	"github.com/howznguyen/knowns/internal/util"
 	"github.com/spf13/cobra"
@@ -88,14 +90,55 @@ func runUpgrade() error {
 	if meta == nil {
 		meta = inferScriptInstallMetadata()
 	}
-	if meta != nil && meta.IsScriptManaged() {
+
+	method, installCmd := util.DetectInstallMethod()
+
+	// If we detected a method and running interactively, confirm with user.
+	if method != util.InstallMethodUnknown && isTTY() {
+		label := installMethodLabel(method)
+		fmt.Printf("  %s Detected install method: %s\n", StyleInfo.Render("ℹ"), StyleBold.Render(label))
+		yes, cancelled := confirmPrompt("  Proceed with this method?")
+		if cancelled {
+			return errUpdateCancelled
+		}
+		if !yes {
+			var err error
+			method, installCmd, err = promptInstallMethod()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// If still unknown, prompt user to choose.
+	if method == util.InstallMethodUnknown {
+		if !isTTY() {
+			return fmt.Errorf("could not detect how knowns was installed; reinstall using one of:\n  %s\n  brew install knowns-dev/tap/knowns\n  npm i -g knowns\n  bun add -g knowns", scriptInstallCmd())
+		}
+		fmt.Printf("  %s Could not detect install method.\n", StyleWarning.Render("⚠"))
+		var err error
+		method, installCmd, err = promptInstallMethod()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Script-managed: self-update binary + ORT lib from GitHub release tarball.
+	if method == util.InstallMethodScript {
+		if meta == nil {
+			meta = &util.InstallMetadata{}
+		}
+		meta.Method = "script"
+		meta.ManagedBy = "knowns-script"
 		return runScriptManagedUpgrade(meta)
 	}
 
-	installCmd := util.DetectInstallCmd()
-	if isHomebrewInstallCommand(installCmd) {
+	// Homebrew: delegate to brew.
+	if method == util.InstallMethodBrew {
 		return runHomebrewUpgrade(installCmd)
 	}
+
+	// Package manager (npm/bun/pnpm/yarn): run the upgrade command.
 	fmt.Printf("%s Running: %s\n", StyleBold.Render("Upgrading..."), StyleInfo.Render(installCmd))
 
 	parts := strings.Fields(installCmd)
@@ -117,20 +160,232 @@ func runUpgrade() error {
 		return fmt.Errorf("upgrade failed: %w", err)
 	}
 
+	// Persist install method for future updates.
+	if meta == nil {
+		meta = &util.InstallMetadata{}
+	}
+	meta.Method = string(method)
+	meta.ManagedBy = string(method)
+	meta.Version = strings.TrimPrefix(util.NormalizeVersionTag(util.FetchLatestVersion()), "v")
+	_ = util.SaveInstallMetadata(meta)
+
 	fmt.Println(StyleSuccess.Render("✓") + " Upgrade complete.")
 	return nil
 }
 
+// confirmPrompt asks a yes/no question using bubbletea.
+// Returns (yes, cancelled). cancelled=true means Ctrl+C or Esc.
+func confirmPrompt(question string) (bool, bool) {
+	if !isTTY() {
+		return true, false
+	}
+	drainStdin()
+	m := &confirmModel{question: question, yes: true}
+	p := tea.NewProgram(m, tea.WithInput(os.Stdin))
+	result, err := p.Run()
+	if err != nil {
+		return false, true
+	}
+	cm := result.(*confirmModel)
+	return cm.yes, cm.cancelled
+}
+
+type confirmModel struct {
+	question  string
+	yes       bool
+	done      bool
+	cancelled bool
+}
+
+func (m *confirmModel) Init() tea.Cmd { return nil }
+
+func (m *confirmModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.done {
+		return m, tea.Quit
+	}
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "y", "Y", "enter":
+			m.yes = true
+			m.done = true
+			return m, tea.Quit
+		case "n", "N":
+			m.yes = false
+			m.done = true
+			return m, tea.Quit
+		case "ctrl+c", "esc":
+			m.cancelled = true
+			m.done = true
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m *confirmModel) View() tea.View {
+	if m.done {
+		if m.cancelled {
+			return tea.NewView(fmt.Sprintf("%s %s\n", m.question, StyleWarning.Render("Cancelled")))
+		}
+		choice := StyleSuccess.Render("Yes")
+		if !m.yes {
+			choice = StyleWarning.Render("No")
+		}
+		return tea.NewView(fmt.Sprintf("%s %s\n", m.question, choice))
+	}
+	return tea.NewView(fmt.Sprintf("%s %s ", m.question, StyleDim.Render("[Y/n]")))
+}
+
+// errUpdateCancelled is returned when the user cancels the update.
+var errUpdateCancelled = fmt.Errorf("update cancelled")
+
+// promptInstallMethod shows a selectable list using bubbletea.
+// Returns InstallMethodUnknown if the user cancels.
+func promptInstallMethod() (util.InstallMethod, string, error) {
+	if !isTTY() {
+		return util.InstallMethodScript, "knowns update", nil
+	}
+	drainStdin()
+	options := []installOption{
+		{util.InstallMethodScript, "Install script", scriptInstallCmd()},
+		{util.InstallMethodBrew, "Homebrew", "brew upgrade knowns-dev/tap/knowns"},
+		{util.InstallMethodNPM, "npm", "npm i -g knowns"},
+		{util.InstallMethodBun, "bun", "bun add -g knowns"},
+		{util.InstallMethodPNPM, "pnpm", "pnpm add -g knowns"},
+		{util.InstallMethodYarn, "yarn", "yarn global add knowns"},
+	}
+	m := &selectModel{options: options}
+	p := tea.NewProgram(m, tea.WithInput(os.Stdin))
+	result, err := p.Run()
+	if err != nil {
+		return util.InstallMethodUnknown, "", errUpdateCancelled
+	}
+	sm := result.(*selectModel)
+	if sm.cancelled {
+		return util.InstallMethodUnknown, "", errUpdateCancelled
+	}
+	chosen := sm.options[sm.cursor]
+	return chosen.method, chosen.cmd, nil
+}
+
+type installOption struct {
+	method util.InstallMethod
+	label  string
+	cmd    string
+}
+
+type selectModel struct {
+	options   []installOption
+	cursor    int
+	done      bool
+	cancelled bool
+}
+
+func (m *selectModel) Init() tea.Cmd { return nil }
+
+func (m *selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.done {
+		return m, tea.Quit
+	}
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.options)-1 {
+				m.cursor++
+			}
+		case "enter":
+			m.done = true
+			return m, tea.Quit
+		case "ctrl+c", "esc":
+			m.cancelled = true
+			m.done = true
+			return m, tea.Quit
+		case "1", "2", "3", "4", "5", "6":
+			idx := int(msg.String()[0] - '1')
+			if idx >= 0 && idx < len(m.options) {
+				m.cursor = idx
+				m.done = true
+				return m, tea.Quit
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m *selectModel) View() tea.View {
+	if m.done {
+		if m.cancelled {
+			return tea.NewView(fmt.Sprintf("  %s\n", StyleWarning.Render("Cancelled")))
+		}
+		chosen := m.options[m.cursor]
+		return tea.NewView(fmt.Sprintf("  %s %s %s\n",
+			StyleSuccess.Render("✓"),
+			StyleBold.Render(chosen.label),
+			StyleDim.Render("("+chosen.cmd+")"),
+		))
+	}
+	var b strings.Builder
+	b.WriteString("\n  Choose your install method:\n\n")
+	for i, opt := range m.options {
+		cursor := "  "
+		label := opt.label
+		if i == m.cursor {
+			cursor = StyleBold.Render("▸ ")
+			label = StyleBold.Render(opt.label)
+		}
+		b.WriteString(fmt.Sprintf("  %s%s %s\n",
+			cursor,
+			label,
+			StyleDim.Render("("+opt.cmd+")"),
+		))
+	}
+	b.WriteString(fmt.Sprintf("\n  %s\n", StyleDim.Render("↑/↓ to move, enter to select, 1-6 to jump")))
+	return tea.NewView(b.String())
+}
+
+// installMethodLabel returns a human-readable label for an install method.
+func installMethodLabel(method util.InstallMethod) string {
+	switch method {
+	case util.InstallMethodScript:
+		return "Install script"
+	case util.InstallMethodBrew:
+		return "Homebrew"
+	case util.InstallMethodNPM:
+		return "npm"
+	case util.InstallMethodBun:
+		return "bun"
+	case util.InstallMethodPNPM:
+		return "pnpm"
+	case util.InstallMethodYarn:
+		return "yarn"
+	default:
+		return "unknown"
+	}
+}
+
+// scriptInstallCmd returns the install script command for the current platform.
+func scriptInstallCmd() string {
+	if runtime.GOOS == "windows" {
+		return "irm https://knowns.sh/script/install.ps1 | iex"
+	}
+	return "curl -fsSL https://knowns.sh/script/install | sh"
+}
+
 func recommendedUpdateCommand() string {
-	meta, err := util.LoadInstallMetadata()
-	if err == nil && meta != nil && meta.IsScriptManaged() {
-		return "knowns update"
+	method, cmd := util.DetectInstallMethod()
+	if method == util.InstallMethodBrew {
+		return "brew update && HOMEBREW_NO_AUTO_UPDATE=1 " + cmd
 	}
-	installCmd := util.DetectInstallCmd()
-	if isHomebrewInstallCommand(installCmd) {
-		return "brew update && HOMEBREW_NO_AUTO_UPDATE=1 " + installCmd
+	if cmd != "" {
+		return cmd
 	}
-	return installCmd
+	return "knowns update"
 }
 
 func isHomebrewInstallCommand(cmd string) bool {
@@ -193,7 +448,7 @@ func runScriptManagedUpgrade(meta *util.InstallMetadata) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s Running: %s\n", StyleBold.Render("Upgrading..."), StyleInfo.Render(url))
+	fmt.Printf("%s %s\n", StyleBold.Render("Upgrading..."), StyleInfo.Render(scriptInstallCmd()))
 	if err := downloadAndReplaceBinary(url, binaryPath); err != nil {
 		return err
 	}
@@ -321,6 +576,30 @@ func downloadAndReplaceBinary(url, binaryPath string) error {
 	if err := replaceBinary(extractedPath, binaryPath); err != nil {
 		return fmt.Errorf("replace binary: %w", err)
 	}
+
+	// Also install colocated ONNX Runtime native libraries from the tarball.
+	destDir := filepath.Dir(binaryPath)
+	entries, _ := os.ReadDir(tmpDir)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			continue
+		}
+		isORT := strings.HasPrefix(name, "libonnxruntime") || name == "onnxruntime.dll"
+		if !isORT {
+			continue
+		}
+		src := filepath.Join(tmpDir, name)
+		dst := filepath.Join(destDir, name)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			continue
+		}
+		if err := os.WriteFile(dst, data, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to update %s: %v\n", name, err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/search/onnx_runtime.go
+++ b/internal/search/onnx_runtime.go
@@ -196,7 +196,19 @@ func ensureORTEnvironment() error {
 		ort.SetSharedLibraryPath(lib)
 	} else {
 		libName := ortSharedLibName()
-		fmt.Fprintf(os.Stderr, "warning: bundled %s not found next to executable, sibling lib dirs, or ~/.knowns/bin; falling back to system search which may load an incompatible version\n", libName)
+		// Check if a library file exists but was skipped due to arch mismatch.
+		archMismatch := false
+		if home, err := os.UserHomeDir(); err == nil {
+			candidate := filepath.Join(home, ".knowns", "bin", libName)
+			if ortIsFile(candidate) && !ortMatchesArch(candidate) {
+				archMismatch = true
+			}
+		}
+		if archMismatch {
+			fmt.Fprintf(os.Stderr, "warning: %s found but has wrong CPU architecture (expected %s); reinstall knowns for the correct platform or set KNOWNS_ORT_LIB\n", libName, runtime.GOARCH)
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: bundled %s not found next to executable, sibling lib dirs, or ~/.knowns/bin; falling back to system search which may load an incompatible version\n", libName)
+		}
 	}
 	if err := ort.InitializeEnvironment(); err != nil {
 		hint := ""
@@ -230,38 +242,51 @@ func ResolveORTLibraryPath() string {
 
 	name := ortSharedLibName()
 
+	// ortCandidate checks that the file exists and matches the current arch.
+	ortCandidate := func(path string) bool {
+		return ortIsFile(path) && ortMatchesArch(path)
+	}
+
 	if exe, err := os.Executable(); err == nil {
 		if real, err := filepath.EvalSymlinks(exe); err == nil {
 			exe = real
 		}
 		dir := filepath.Dir(exe)
 		candidate := filepath.Join(dir, name)
-		if ortIsFile(candidate) {
+		if ortCandidate(candidate) {
 			return candidate
 		}
 		// Check sibling directories relative to the binary's parent.
 		// Homebrew uses ../libexec, other package managers may use ../lib.
 		for _, sibling := range []string{"libexec", "lib"} {
 			candidate = filepath.Join(dir, "..", sibling, name)
-			if ortIsFile(candidate) {
+			if ortCandidate(candidate) {
 				return candidate
 			}
 		}
 		if runtime.GOOS == "linux" {
 			if matches, _ := filepath.Glob(filepath.Join(dir, "libonnxruntime.so*")); len(matches) > 0 {
-				return matches[0]
+				for _, m := range matches {
+					if ortMatchesArch(m) {
+						return m
+					}
+				}
 			}
 		}
 	}
 
 	if home, err := os.UserHomeDir(); err == nil {
 		candidate := filepath.Join(home, ".knowns", "bin", name)
-		if ortIsFile(candidate) {
+		if ortCandidate(candidate) {
 			return candidate
 		}
 		if runtime.GOOS == "linux" {
 			if matches, _ := filepath.Glob(filepath.Join(home, ".knowns", "bin", "libonnxruntime.so*")); len(matches) > 0 {
-				return matches[0]
+				for _, m := range matches {
+					if ortMatchesArch(m) {
+						return m
+					}
+				}
 			}
 		}
 	}
@@ -453,4 +478,45 @@ func readPadTokenID(modelDir string) (int64, error) {
 func ortIsFile(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
+}
+
+// ortMatchesArch returns true if the shared library at path matches the
+// current process architecture. On Linux it reads the ELF header (first 20
+// bytes) and compares e_machine. On other platforms it always returns true
+// (no cheap pre-check available).
+func ortMatchesArch(path string) bool {
+	if runtime.GOOS != "linux" {
+		return true
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	// ELF header: 0-3 magic, 4 class, 5 data, ..., 18-19 e_machine (LE).
+	var hdr [20]byte
+	if n, err := f.Read(hdr[:]); err != nil || n < 20 {
+		return false
+	}
+	// Verify ELF magic.
+	if hdr[0] != 0x7f || hdr[1] != 'E' || hdr[2] != 'L' || hdr[3] != 'F' {
+		return false
+	}
+	// e_machine at offset 18, little-endian.
+	machine := uint16(hdr[18]) | uint16(hdr[19])<<8
+
+	// Map current GOARCH to expected ELF e_machine.
+	var expected uint16
+	switch runtime.GOARCH {
+	case "amd64":
+		expected = 0x3E // EM_X86_64
+	case "arm64":
+		expected = 0xB7 // EM_AARCH64
+	case "386":
+		expected = 0x03 // EM_386
+	default:
+		return true // unknown arch, skip check
+	}
+	return machine == expected
 }

--- a/internal/util/update_notifier.go
+++ b/internal/util/update_notifier.go
@@ -166,41 +166,125 @@ func CompareVersions(a, b string) int {
 	return 0
 }
 
-// DetectInstallCmd returns the appropriate upgrade command based on how knowns was installed.
-func DetectInstallCmd() string {
-	exe, _ := os.Executable()
-	exePath := strings.ToLower(exe)
+// InstallMethod describes how knowns was installed.
+type InstallMethod string
 
-	// 1. Homebrew: binary in /homebrew/ or /Cellar/
-	if strings.Contains(exePath, "/homebrew/") || strings.Contains(exePath, "/cellar/") {
-		return "brew upgrade knowns-dev/tap/knowns"
+const (
+	InstallMethodScript  InstallMethod = "script"
+	InstallMethodBrew    InstallMethod = "brew"
+	InstallMethodNPM     InstallMethod = "npm"
+	InstallMethodBun     InstallMethod = "bun"
+	InstallMethodYarn    InstallMethod = "yarn"
+	InstallMethodPNPM    InstallMethod = "pnpm"
+	InstallMethodUnknown InstallMethod = "unknown"
+)
+
+// DetectInstallMethod returns the detected install method and the corresponding
+// upgrade command. It prioritizes runtime detection (binary path, environment)
+// over persisted metadata, so switching install methods (e.g. script → brew)
+// is detected correctly without stale install.json data.
+func DetectInstallMethod() (InstallMethod, string) {
+	// 1. Collect candidate paths: current executable + resolved symlink.
+	candidates := []string{}
+	if exe, err := os.Executable(); err == nil {
+		candidates = append(candidates, exe)
+		if real, err := filepath.EvalSymlinks(exe); err == nil && real != exe {
+			candidates = append(candidates, real)
+		}
+	}
+	// Also check persisted binary path from install.json.
+	meta, _ := LoadInstallMetadata()
+	if meta != nil && meta.BinaryPath != "" {
+		candidates = append(candidates, meta.BinaryPath)
 	}
 
-	// 2. Check npm_config_user_agent (set when running via npx/npm scripts)
+	home, _ := os.UserHomeDir()
+
+	// 2. Detect from binary path (most reliable).
+	// Normalize to forward slashes for consistent matching across platforms.
+	for _, path := range candidates {
+		pathLower := strings.ToLower(filepath.ToSlash(path))
+
+		// Homebrew (macOS/Linux only)
+		if strings.Contains(pathLower, "/homebrew/") || strings.Contains(pathLower, "/cellar/") || strings.Contains(pathLower, "/linuxbrew/") {
+			return InstallMethodBrew, "brew upgrade knowns-dev/tap/knowns"
+		}
+
+		// Package managers from path
+		switch {
+		case strings.Contains(pathLower, "/pnpm/") || strings.Contains(pathLower, "/pnpm-global/") || strings.Contains(pathLower, "\\pnpm\\"):
+			return InstallMethodPNPM, "pnpm add -g knowns"
+		case strings.Contains(pathLower, "/.yarn/") || strings.Contains(pathLower, "/yarn/"):
+			return InstallMethodYarn, "yarn global add knowns"
+		case strings.Contains(pathLower, "/.bun/") || strings.Contains(pathLower, "/bun/"):
+			return InstallMethodBun, "bun add -g knowns"
+		case strings.Contains(pathLower, "/npm/") || strings.Contains(pathLower, "/node_modules/"):
+			return InstallMethodNPM, "npm i -g knowns"
+		}
+
+		// Script install: binary in ~/.knowns/bin/
+		if home != "" {
+			defaultDir := filepath.ToSlash(filepath.Join(home, ".knowns", "bin"))
+			if strings.HasPrefix(pathLower, strings.ToLower(defaultDir)+"/") ||
+				pathLower == strings.ToLower(defaultDir+"/knowns") ||
+				pathLower == strings.ToLower(defaultDir+"/knowns.exe") {
+				return InstallMethodScript, "knowns update"
+			}
+		}
+	}
+
+	// 3. Check npm_config_user_agent (set when running via npx/npm scripts).
 	ua := os.Getenv("npm_config_user_agent")
 	switch {
 	case strings.HasPrefix(ua, "pnpm/"):
-		return "pnpm add -g knowns"
+		return InstallMethodPNPM, "pnpm add -g knowns"
 	case strings.HasPrefix(ua, "yarn/"):
-		return "yarn global add knowns"
+		return InstallMethodYarn, "yarn global add knowns"
 	case strings.HasPrefix(ua, "bun/"):
-		return "bun add -g knowns"
+		return InstallMethodBun, "bun add -g knowns"
 	case strings.HasPrefix(ua, "npm/"):
-		return "npm i -g knowns"
+		return InstallMethodNPM, "npm i -g knowns"
 	}
 
-	// 3. Detect from binary path (for global installs where env var is gone)
-	switch {
-	case strings.Contains(exePath, "/pnpm/") || strings.Contains(exePath, "/pnpm-global/"):
-		return "pnpm add -g knowns"
-	case strings.Contains(exePath, "/.yarn/") || strings.Contains(exePath, "/yarn/"):
-		return "yarn global add knowns"
-	case strings.Contains(exePath, "/.bun/") || strings.Contains(exePath, "/bun/"):
-		return "bun add -g knowns"
-	case strings.Contains(exePath, "/npm/") || strings.Contains(exePath, "/node_modules/"):
-		return "npm i -g knowns"
+	// 4. Fallback to persisted metadata (only if runtime detection found nothing).
+	if meta != nil {
+		if meta.ManagedBy != "" {
+			switch {
+			case meta.IsScriptManaged():
+				return InstallMethodScript, "knowns update"
+			case strings.Contains(meta.ManagedBy, "brew"):
+				return InstallMethodBrew, "brew upgrade knowns-dev/tap/knowns"
+			case strings.Contains(meta.ManagedBy, "bun"):
+				return InstallMethodBun, "bun add -g knowns"
+			case strings.Contains(meta.ManagedBy, "pnpm"):
+				return InstallMethodPNPM, "pnpm add -g knowns"
+			case strings.Contains(meta.ManagedBy, "yarn"):
+				return InstallMethodYarn, "yarn global add knowns"
+			case strings.Contains(meta.ManagedBy, "npm"):
+				return InstallMethodNPM, "npm i -g knowns"
+			}
+		}
+		if meta.Method == "script" {
+			return InstallMethodScript, "knowns update"
+		}
 	}
 
-	// 4. Default to npm
-	return "npm i -g knowns"
+	// 5. Last resort: check if install.json exists at all.
+	if home != "" {
+		installJSON := filepath.Join(home, ".knowns", "install.json")
+		if _, err := os.Stat(installJSON); err == nil {
+			return InstallMethodScript, "knowns update"
+		}
+	}
+
+	return InstallMethodUnknown, ""
+}
+
+// DetectInstallCmd returns the appropriate upgrade command based on how knowns was installed.
+func DetectInstallCmd() string {
+	_, cmd := DetectInstallMethod()
+	if cmd == "" {
+		return "npm i -g knowns"
+	}
+	return cmd
 }


### PR DESCRIPTION
# fix(ort): validate arch and improve update detection

- Add ELF architecture check to skip wrong-arch ORT libraries on Linux
- CI: always download ORT from official releases instead of Go module test_data
- CI: add ELF e_machine verification in tarball contents check
- CI: download ORT library for unit and E2E tests
- Update: copy ORT native libs alongside binary during self-update
- Update: detect install method from binary path with bubbletea confirm/select UI
- Update: prioritize runtime path detection over stale install.json metadata
- Update: normalize paths for cross-platform Windows support

## Description

Fixes ONNX Runtime architecture mismatch on Linux where the x64 release tarball shipped an arm64 `libonnxruntime.so`, causing `dlopen` to fail with a misleading "No such file or directory" error.

**Root cause:** The CI build pipeline tried Go module `test_data` first (which only contains arm64 libs for Linux), and copied the arm64 `.so` into the x64 package without verifying architecture.

**Changes:**

**Runtime (`onnx_runtime.go`):**
- `ortMatchesArch()` reads the ELF header (20 bytes) to verify `e_machine` matches the host CPU (x86_64 vs aarch64)
- `ResolveORTLibraryPath()` skips libraries with wrong architecture instead of returning them
- `ensureORTEnvironment()` prints a clear warning when a library exists but has wrong architecture

**CI (`publish.yml`, `ci.yml`):**
- Always download ONNX Runtime v1.25.0 from official GitHub releases for all platforms, removing the fragile Go module `test_data` fallback
- Added ELF `e_machine` verification in the "Verify tarball contents" step to catch arch mismatches before publishing
- Added ORT library download for unit tests and E2E semantic search tests in both CI and publish workflows

**Update (`update.go`, `update_notifier.go`):**
- `downloadAndReplaceBinary()` now copies `libonnxruntime.*` / `onnxruntime.dll` from the tarball alongside the binary during self-update
- New `DetectInstallMethod()` prioritizes runtime binary path analysis over persisted `install.json` metadata, correctly handling install method switches (e.g. script → Homebrew)
- Interactive bubbletea UI for confirming detected install method with option to choose from a selectable list (brew, npm, bun, pnpm, yarn, install script)
- Ctrl+C / Esc cancels the update cleanly
- Path matching normalizes separators via `filepath.ToSlash()` for Windows compatibility

## Related Issue

Fixes ONNX Runtime `dlopen` failure on Linux x64 where the bundled `.so` was arm64.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

**Install method confirm:**
```
ℹ Detected install method: Homebrew
Proceed with this method? [Y/n]
```

**Install method select (when user presses N or method unknown):**
```
Choose your install method:

▸ Install script  (curl -fsSL https://knowns.sh/script/install | sh)
  Homebrew        (brew upgrade knowns-dev/tap/knowns)
  npm             (npm i -g knowns)
  bun             (bun add -g knowns)
  pnpm            (pnpm add -g knowns)
  yarn            (yarn global add knowns)

↑/↓ to move, enter to select, 1-6 to jump
```

## Additional Notes

- `ortMatchesArch()` only validates on Linux (ELF). macOS (Mach-O) and Windows (PE) always return true since architecture mismatches are less common on those platforms.
- The install method is persisted to `~/.knowns/install.json` after a successful update, so subsequent updates skip detection.
- Non-TTY environments (CI, pipes) skip the interactive prompt and either auto-proceed or return an error with install instructions.
