### PR TITLE
feat(settings): add first-run setup pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,12 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Cache semantic models
+        uses: actions/cache@v4
+        with:
+          path: ~/.knowns/models
+          key: semantic-models-${{ runner.os }}-all-MiniLM-L6-v2-v1
+
       - name: Install llvm-mingw toolchain
         if: runner.os == 'Windows'
         shell: bash

--- a/.knowns/config.json
+++ b/.knowns/config.json
@@ -46,12 +46,6 @@
     },
     "serverPort": 6420,
     "platforms": [
-      "claude-code",
-      "opencode",
-      "codex",
-      "kiro",
-      "gemini",
-      "copilot",
       "agents"
     ],
     "enableChatUI": false,

--- a/.knowns/docs/features/model-command.md
+++ b/.knowns/docs/features/model-command.md
@@ -1,10 +1,8 @@
 ---
 title: Model Command
+description: CLI command for managing embedding models - list, download, set, add custom models
 createdAt: '2026-02-24T07:29:13.547Z'
-updatedAt: '2026-03-08T18:22:07.249Z'
-description: >-
-  CLI command for managing embedding models - list, download, set, add custom
-  models
+updatedAt: '2026-06-04T04:50:30.572Z'
 tags:
   - feature
   - cli
@@ -12,6 +10,7 @@ tags:
   - embedding
   - search
 ---
+
 # Model Command
 
 Manage embedding models for semantic search.
@@ -241,3 +240,8 @@ knowns search --reindex
 
 - @doc/specs/semantic-search - Semantic search specification
 - @doc/guides/cli-guide - CLI usage guide
+
+
+### `knowns settings` Local ONNX picker
+
+`knowns settings` also manages semantic search. When the provider is Local ONNX, the settings flow shows all supported ONNX models with dimensions, max tokens, approximate size, and downloaded/not downloaded status. Selecting a missing model asks for confirmation and can download it with the existing semantic model download flow before saving the full local semantic config.

--- a/.knowns/docs/guides/cli-guide.md
+++ b/.knowns/docs/guides/cli-guide.md
@@ -1,13 +1,14 @@
 ---
 title: Knowns CLI Guide
-createdAt: '2025-12-26T19:43:25.470Z'
-updatedAt: '2026-03-08T18:22:39.448Z'
 description: Complete guide for using Knowns CLI
+createdAt: '2025-12-26T19:43:25.470Z'
+updatedAt: '2026-06-04T09:57:29.075Z'
 tags:
   - guide
   - cli
   - tutorial
 ---
+
 # Knowns CLI Guide
 
 Knowns is a CLI tool for managing tasks, documentation, and time tracking for development teams.
@@ -33,37 +34,38 @@ knowns init [project-name]
 
 ### Interactive Wizard
 
-When running without a name, the wizard prompts for:
+When running without a name, the wizard prompts for project basics and project instruction files:
 
-```
-Knowns Project Setup Wizard
-   Configure your project settings
+```text
+Knowns Project Setup
+   Quick configuration
 
 ? Project name > my-project
-? Git tracking mode > Git Tracked (recommended for teams)
-? AI Guidelines type > CLI / MCP
-? Select AI agent files > CLAUDE.md, AGENTS.md
+? Git tracking mode > Git Tracked  · tasks, docs, templates
+? Project instruction files > CLAUDE.md, AGENTS.md
 ```
+
+`KNOWNS.md` is always created as the canonical project guidance file when instruction shims are created. Compatibility shims such as `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `OPENCODE.md`, and `.github/copilot-instructions.md` defer behavior rules back to `KNOWNS.md`.
 
 **Example session:**
-```
+```text
 $ knowns init
 
-Knowns Project Setup Wizard
-   Configure your project settings
+Knowns Project Setup
+   Quick configuration
 
 ? Project name > my-app
-? Git tracking mode > Git Tracked (recommended for teams)
-? AI Guidelines type > MCP
-? Select AI agent files > CLAUDE.md, AGENTS.md
+? Git tracking mode > Git Tracked  · tasks, docs, templates
+? Project instruction files > CLAUDE.md, AGENTS.md
 
-Created .mcp.json for Claude Code MCP auto-discovery
 Project initialized: my-app
+Created: KNOWNS.md
 Created: CLAUDE.md
 Created: AGENTS.md
 
 Get started:
   knowns task create "My first task"
+  knowns setup all
 ```
 
 ### Wizard Options
@@ -71,9 +73,8 @@ Get started:
 | Option | Description |
 |--------|-------------|
 | **Project name** | Name of your project |
-| **Git tracking mode** | `git-tracked` (team) or `git-ignored` (personal) |
-| **AI Guidelines type** | `CLI` (commands) or `MCP` (MCP tools) |
-| **AI agent files** | Files to update with guidelines |
+| **Git tracking mode** | `git-tracked`, `git-ignored`, or `none` |
+| **Project instruction files** | Compatibility shims to create; defaults to `CLAUDE.md` and `AGENTS.md` |
 
 ### Quick Init (Non-Interactive)
 
@@ -81,25 +82,21 @@ Get started:
 knowns init my-project --no-wizard
 ```
 
-### MCP Auto-Setup
+Non-interactive init uses global project defaults when configured, otherwise it creates the default project guidance set: `KNOWNS.md`, `CLAUDE.md`, and `AGENTS.md`.
 
-When selecting **MCP** in the wizard, a `.mcp.json` file is automatically created:
+### AI Integration Setup
 
-```json
-{
-  "mcpServers": {
-    "knowns": {
-      "command": "knowns",
-      "args": ["mcp"]
-    }
-  }
-}
+`knowns init` does not create project-level AI integration config such as `.mcp.json`, `.codex/config.toml`, or runtime hooks. Use `knowns setup` for those artifacts:
+
+```bash
+knowns setup all            # configure all selected project integrations
+knowns setup agents         # create/sync KNOWNS.md + AGENTS.md only
+knowns setup codex --global # install Codex integration at user scope
 ```
 
-This enables Claude Code to auto-discover the MCP server.
+This keeps global runtime setup separate from repo-specific project guidance.
 
 ---
-
 ## MCP Setup
 
 ### Quick Setup

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Every time you start a new AI coding session, you re-explain your architecture, 
 If you believe AI should truly understand software projects, consider giving **Knowns** a star.
 
 <p align="center">
-  <img src="./images/task-workflow.gif" alt="Knowns task workflow demo" width="100%">
+  <video src="https://res.cloudinary.com/dkxhoyenc/video/upload/v1780569111/knowns-full-pipeline_uwhyk1.mp4" controls muted loop playsinline width="100%">
+    <a href="https://res.cloudinary.com/dkxhoyenc/video/upload/v1780569111/knowns-full-pipeline_uwhyk1.mp4">Watch the Knowns full pipeline demo</a>
+  </video>
 </p>
 
 ## Table of Contents
@@ -150,6 +152,7 @@ knowns --version
 # Initialize in your project
 cd your-project
 knowns init
+# Creates .knowns/ plus KNOWNS.md, CLAUDE.md, and AGENTS.md by default
 
 # or run without a global install
 npx knowns init
@@ -450,8 +453,10 @@ knowns lsp list
 knowns lsp install <language>
 # Use the MCP code tool for symbols, definitions, references, diagnostics, and edits
 
-# AI Guidelines
-knowns setup
+# AI setup
+knowns setup agents        # KNOWNS.md + AGENTS.md only
+knowns setup codex --global # user-level Codex MCP/skills/hooks
+knowns setup               # full interactive project integration setup
 knowns sync
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ Every time you start a new AI coding session, you re-explain your architecture, 
 If you believe AI should truly understand software projects, consider giving **Knowns** a star.
 
 <p align="center">
-  <video src="https://res.cloudinary.com/dkxhoyenc/video/upload/v1780569111/knowns-full-pipeline_uwhyk1.mp4" controls muted loop playsinline width="100%">
-    <a href="https://res.cloudinary.com/dkxhoyenc/video/upload/v1780569111/knowns-full-pipeline_uwhyk1.mp4">Watch the Knowns full pipeline demo</a>
-  </video>
+  <a href="https://player.cloudinary.com/embed/?cloud_name=dkxhoyenc&public_id=knowns-full-pipeline_uwhyk1">
+    <img src="./images/knowns-full-pipeline-20s.gif" alt="Knowns full pipeline demo preview" width="100%">
+  </a>
+</p>
+<p align="center">
+  <em>Click the preview to watch the full pipeline demo video.</em>
 </p>
 
 ## Table of Contents

--- a/README.vi.md
+++ b/README.vi.md
@@ -31,7 +31,9 @@ Mỗi lần mở session mới với AI, bạn lại phải giải thích lại 
 Nếu bạn nghĩ AI nên thực sự hiểu software project, cho **Knowns** một star nhé.
 
 <p align="center">
-  <img src="./images/task-workflow.gif" alt="Knowns task workflow demo" width="100%">
+  <video src="https://res.cloudinary.com/dkxhoyenc/video/upload/v1780569111/knowns-full-pipeline_uwhyk1.mp4" controls muted loop playsinline width="100%">
+    <a href="https://res.cloudinary.com/dkxhoyenc/video/upload/v1780569111/knowns-full-pipeline_uwhyk1.mp4">Xem demo full pipeline của Knowns</a>
+  </video>
 </p>
 
 ## Mục lục
@@ -150,6 +152,7 @@ knowns --version
 # Init trong project
 cd your-project
 knowns init
+# Mặc định tạo .knowns/ cùng KNOWNS.md, CLAUDE.md, AGENTS.md
 
 # Hoặc chạy không cần cài global
 npx knowns init
@@ -450,8 +453,10 @@ knowns lsp list
 knowns lsp install <language>
 knowns lsp cleanup
 
-# AI Guidelines
-knowns setup
+# AI setup
+knowns setup agents        # chỉ KNOWNS.md + AGENTS.md
+knowns setup codex --global # Codex MCP/skills/hooks ở user scope
+knowns setup               # interactive project integration setup đầy đủ
 knowns sync
 ```
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -31,9 +31,12 @@ Mỗi lần mở session mới với AI, bạn lại phải giải thích lại 
 Nếu bạn nghĩ AI nên thực sự hiểu software project, cho **Knowns** một star nhé.
 
 <p align="center">
-  <video src="https://res.cloudinary.com/dkxhoyenc/video/upload/v1780569111/knowns-full-pipeline_uwhyk1.mp4" controls muted loop playsinline width="100%">
-    <a href="https://res.cloudinary.com/dkxhoyenc/video/upload/v1780569111/knowns-full-pipeline_uwhyk1.mp4">Xem demo full pipeline của Knowns</a>
-  </video>
+  <a href="https://player.cloudinary.com/embed/?cloud_name=dkxhoyenc&public_id=knowns-full-pipeline_uwhyk1">
+    <img src="./images/knowns-full-pipeline-20s.gif" alt="Knowns full pipeline demo preview" width="100%">
+  </a>
+</p>
+<p align="center">
+  <em>Click preview để xem video full pipeline.</em>
 </p>
 
 ## Mục lục

--- a/docs/en/getting-started/quick-start.md
+++ b/docs/en/getting-started/quick-start.md
@@ -14,10 +14,11 @@ The init flow configures:
 
 - project name
 - git tracking mode (with per-section toggles)
+- project instruction files (`KNOWNS.md`, default `CLAUDE.md` + `AGENTS.md`)
 - semantic search
 - embedding model
 
-> **Note:** AI platform integrations (instructions, MCP configs, skills) are configured separately via `knowns setup`.
+> **Note:** `knowns init` creates project guidance files. AI platform integrations such as MCP configs, skills, and runtime hooks are configured separately via `knowns setup`.
 
 ## 2. Create a task
 

--- a/docs/en/guides/user-guide.md
+++ b/docs/en/guides/user-guide.md
@@ -21,9 +21,10 @@ The CLI, MCP server, and browser UI all operate on the same project state.
   - project structure creation
   - settings application
   - git integration configuration
+  - project instruction file creation (`KNOWNS.md`, default `CLAUDE.md` + `AGENTS.md`)
   - semantic index building (if enabled)
 
-After init, run `knowns setup` to configure AI platform integrations (skills, MCP configs, instruction files).
+After init, run `knowns setup <target>` to configure AI platform integrations such as skills, MCP configs, and runtime hooks. Use `knowns setup agents` if you only need `KNOWNS.md` + `AGENTS.md`.
 
 ## Terminal behavior
 

--- a/docs/en/integrations/compatibility.md
+++ b/docs/en/integrations/compatibility.md
@@ -43,11 +43,11 @@ For Antigravity, the MCP config is global:
 
 ### `knowns init`
 
-Creates the project structure, git tracking, and semantic search setup.
+Creates the project structure, git tracking, semantic search setup, and selected project instruction shims (`KNOWNS.md`, default `CLAUDE.md` + `AGENTS.md`).
 
 ### `knowns setup`
 
-Generates AI platform artifacts (skills, instructions, MCP configs, runtime hooks).
+Generates AI platform artifacts such as skills, MCP configs, platform-specific configs, runtime hooks, and any additional instruction files for the selected target. Use `knowns setup agents` when you only need `KNOWNS.md` + `AGENTS.md`.
 
 ### `knowns sync`
 

--- a/docs/en/integrations/guidance-files.md
+++ b/docs/en/integrations/guidance-files.md
@@ -17,9 +17,11 @@ Knowns uses one canonical file plus several compatibility files for AI runtimes.
 ## Refresh generated content
 
 ```bash
+knowns init
+knowns setup agents
 knowns setup
 knowns sync
 knowns sync --instructions
 ```
 
-Use `knowns setup` to generate platform files initially, or `knowns sync` to refresh them.
+Use `knowns init` to create initial project guidance files. Use `knowns setup agents` to create or refresh only `KNOWNS.md` + `AGENTS.md`, `knowns setup <target>` for full platform integrations, or `knowns sync` to refresh generated files from config.

--- a/docs/en/integrations/platforms.md
+++ b/docs/en/integrations/platforms.md
@@ -30,17 +30,21 @@ Knowns can generate and sync different artifacts for different AI platforms via 
 
 ## Setup
 
-AI integration files are generated via `knowns setup`, not during `knowns init`:
+`knowns init` creates project guidance files so agents can read repo rules immediately. AI integration artifacts are generated via `knowns setup`:
 
 ```bash
 knowns setup claude    # CLAUDE.md, .mcp.json, skills, hooks
 knowns setup opencode  # OPENCODE.md, opencode.json, skills, hooks
+knowns setup codex     # AGENTS.md, .codex/config.toml, skills, hooks
 knowns setup kiro      # .kiro steering/settings, skills, hooks
 knowns setup copilot   # .github/copilot-instructions.md
+knowns setup agents    # KNOWNS.md + AGENTS.md only
 knowns setup all       # All supported platforms
 ```
 
 ## Notes
 
 - `.agents/skills` is the primary path for agent-compatible platforms
-- `knowns init` no longer generates AI integration files — use `knowns setup` after init
+- `knowns init` creates selected instruction shims by default (`KNOWNS.md`, `CLAUDE.md`, `AGENTS.md`)
+- use `knowns setup <target>` for project-level MCP/config files, skills, and runtime hooks
+- use `knowns setup codex --global` when Codex integration should live only at user scope

--- a/docs/en/reference/commands.md
+++ b/docs/en/reference/commands.md
@@ -69,6 +69,17 @@ knowns update
 knowns update --check
 ```
 
+### `knowns settings`
+
+Opens the interactive project settings center.
+
+```bash
+knowns settings
+knowns settings --global
+```
+
+Use `knowns settings` for human-friendly project edits: project name, git tracking, AI platforms, search, code intelligence, Browser/Chat UI, and maintenance guidance. In Search settings, Local ONNX models are listed with downloaded/not downloaded status; selecting a missing model can download it before saving. Use `knowns settings --global` for defaults reused by future `knowns init` runs. Use `knowns config get/set/list/reset` when you need scriptable config access.
+
 ## Tasks
 
 ### Create

--- a/docs/en/reference/commands.md
+++ b/docs/en/reference/commands.md
@@ -24,8 +24,11 @@ What `init` configures:
 
 - project name
 - git tracking mode (with per-section toggles)
+- project instruction files (`KNOWNS.md`, default `CLAUDE.md` + `AGENTS.md`)
 - semantic search
 - embedding model
+
+`knowns init` creates project guidance files, but leaves MCP configs, skills, and runtime hooks to `knowns setup`.
 
 ### `knowns setup`
 
@@ -35,8 +38,11 @@ Configures AI tool integrations for an initialized project.
 knowns setup              # Interactive platform selector
 knowns setup claude       # Claude Code: CLAUDE.md, .mcp.json, skills, hooks
 knowns setup opencode     # OpenCode: OPENCODE.md, opencode.json, skills, hooks
+knowns setup codex        # Codex: AGENTS.md, .codex/config.toml, skills, hooks
 knowns setup kiro         # Kiro: .kiro steering/settings, skills, hooks
 knowns setup copilot      # GitHub Copilot: .github/copilot-instructions.md
+knowns setup agents       # KNOWNS.md + AGENTS.md only
+knowns setup codex --global # Codex user-level MCP/skills/hooks
 knowns setup all          # All supported platforms
 ```
 

--- a/docs/en/reference/configuration.md
+++ b/docs/en/reference/configuration.md
@@ -88,6 +88,8 @@ Relevant fields:
 Common behavior:
 
 - `knowns init` can set these values
+- `knowns settings` shows supported Local ONNX models with downloaded/not downloaded status
+- Selecting a missing Local ONNX model in `knowns settings` asks before downloading and saving it
 - `knowns sync` can re-apply the semantic setup
 - `knowns search --reindex` rebuilds the local index
 
@@ -139,21 +141,30 @@ You can edit `.knowns/config.json` directly if you know what you are doing, but 
 
 - `knowns init` for first-time setup (project structure + git tracking)
 - `knowns setup` for AI platform integrations
-- `knowns config set` to toggle features
+- `knowns settings` for the interactive project settings center
+- `knowns settings --global` for defaults reused by future `knowns init` runs
+- `knowns config get/set/list/reset` for scriptable config access
 - `knowns sync` to re-apply config to the current machine
 
-### Config toggle shorthands
+### Settings and config shorthands
 
 ```bash
-# Interactive feature toggle UI
-knowns config toggle
+# Interactive project settings UI
+knowns settings
 # Shows:
-#   AI Chat  [off]
-#   LSP (Experimental)  [on]
-#   Semantic Search  [on]
+#   Project
+#   Git Tracking
+#   AI Platforms
+#   Search
+#   Code Intelligence
+#   Browser / Chat UI
+#   Maintenance
 #   Done
 
-# Or set directly via CLI
+# Defaults for future projects
+knowns settings --global
+
+# Or set directly via the scriptable config API
 knowns config set embedding true       # Enable semantic search
 knowns config set lsp true             # Enable LSP globally
 knowns config set lsp.go true          # Enable LSP for Go
@@ -165,6 +176,8 @@ knowns config set gitTracking.memories false
 ```
 
 Changing `gitTracking.*` toggles automatically regenerates `.gitignore`.
+
+Interactive `knowns init` needs a terminal at least 90 columns wide. If the terminal is too small, Knowns prints resize and `--no-wizard` guidance and stops without initializing by defaults.
 
 ### When to use `knowns sync`
 
@@ -187,6 +200,7 @@ Current skills mapping:
 ```bash
 knowns init
 knowns setup
+knowns settings
 knowns sync
 knowns config set <key> <value>
 knowns config get <key>

--- a/docs/en/reference/configuration.md
+++ b/docs/en/reference/configuration.md
@@ -140,7 +140,9 @@ Controls whether generated artifacts should be refreshed after upgrading the CLI
 You can edit `.knowns/config.json` directly if you know what you are doing, but the normal path is:
 
 - `knowns init` for first-time setup (project structure + git tracking)
-- `knowns setup` for AI platform integrations
+- `knowns init` also creates selected project instruction shims (`KNOWNS.md`, default `CLAUDE.md` + `AGENTS.md`)
+- `knowns setup` for AI platform integrations such as MCP/config files, skills, and runtime hooks
+- `knowns setup agents` when you only need `KNOWNS.md` + `AGENTS.md`
 - `knowns settings` for the interactive project settings center
 - `knowns settings --global` for defaults reused by future `knowns init` runs
 - `knowns config get/set/list/reset` for scriptable config access

--- a/docs/en/reference/sync.md
+++ b/docs/en/reference/sync.md
@@ -10,7 +10,7 @@ Use `knowns sync` after:
 - upgrading the CLI
 - wanting generated files to match config again
 
-For AI platform setup (skills, instructions, MCP configs), use `knowns setup` instead.
+For initial project guidance files, use `knowns init` or `knowns setup agents`. For full AI platform setup (skills, MCP configs, runtime hooks), use `knowns setup <target>`.
 
 ## Common forms
 

--- a/docs/vi/getting-started/quick-start.md
+++ b/docs/vi/getting-started/quick-start.md
@@ -14,10 +14,11 @@ Init wizard cho phép cấu hình:
 
 - tên project
 - git tracking mode (với per-section toggles)
+- project instruction files (`KNOWNS.md`, mặc định `CLAUDE.md` + `AGENTS.md`)
 - semantic search
 - embedding model
 
-> **Lưu ý:** AI platform integrations (instructions, MCP configs, skills) được cấu hình riêng qua `knowns setup`.
+> **Lưu ý:** `knowns init` tạo project guidance files. AI platform integrations như MCP configs, skills, runtime hooks được cấu hình riêng qua `knowns setup`.
 
 ## 2. Tạo task
 

--- a/docs/vi/guides/user-guide.md
+++ b/docs/vi/guides/user-guide.md
@@ -21,9 +21,10 @@ CLI, MCP server, và Web UI đều thao tác trên cùng một project state.
   - tạo cấu trúc project
   - apply config
   - cấu hình git integration
+  - tạo project instruction files (`KNOWNS.md`, mặc định `CLAUDE.md` + `AGENTS.md`)
   - build semantic index (nếu bật)
 
-Sau init, chạy `knowns setup` để cấu hình AI platform integrations (skills, MCP configs, instruction files).
+Sau init, chạy `knowns setup <target>` để cấu hình AI platform integrations như skills, MCP configs, runtime hooks. Dùng `knowns setup agents` nếu chỉ cần `KNOWNS.md` + `AGENTS.md`.
 
 ## Terminal
 

--- a/docs/vi/integrations/compatibility.md
+++ b/docs/vi/integrations/compatibility.md
@@ -43,11 +43,11 @@ Antigravity dùng global config:
 
 ### `knowns init`
 
-Tạo project structure, git tracking, và semantic search setup.
+Tạo project structure, git tracking, semantic search setup, và selected project instruction shims (`KNOWNS.md`, mặc định `CLAUDE.md` + `AGENTS.md`).
 
 ### `knowns setup`
 
-Tạo AI platform artifacts (skills, instructions, MCP configs, runtime hooks).
+Tạo AI platform artifacts như skills, MCP configs, platform-specific configs, runtime hooks, và instruction files bổ sung cho target được chọn. Dùng `knowns setup agents` khi chỉ cần `KNOWNS.md` + `AGENTS.md`.
 
 ### `knowns sync`
 

--- a/docs/vi/integrations/guidance-files.md
+++ b/docs/vi/integrations/guidance-files.md
@@ -17,9 +17,11 @@ Knowns dùng một file canonical và nhiều compatibility files cho các AI ru
 ## Refresh
 
 ```bash
+knowns init
+knowns setup agents
 knowns setup
 knowns sync
 knowns sync --instructions
 ```
 
-Dùng `knowns setup` để tạo platform files lần đầu, hoặc `knowns sync` để refresh.
+Dùng `knowns init` để tạo project guidance files ban đầu. Dùng `knowns setup agents` để tạo hoặc refresh chỉ `KNOWNS.md` + `AGENTS.md`, `knowns setup <target>` cho full platform integrations, hoặc `knowns sync` để refresh generated files từ config.

--- a/docs/vi/integrations/platforms.md
+++ b/docs/vi/integrations/platforms.md
@@ -30,17 +30,21 @@ Knowns generate và sync artifacts khác nhau cho từng AI platform qua `knowns
 
 ## Setup
 
-AI integration files được tạo qua `knowns setup`, không phải trong `knowns init`:
+`knowns init` tạo project guidance files để agent đọc rule của repo ngay. AI integration artifacts được tạo qua `knowns setup`:
 
 ```bash
 knowns setup claude    # CLAUDE.md, .mcp.json, skills, hooks
 knowns setup opencode  # OPENCODE.md, opencode.json, skills, hooks
+knowns setup codex     # AGENTS.md, .codex/config.toml, skills, hooks
 knowns setup kiro      # .kiro steering/settings, skills, hooks
 knowns setup copilot   # .github/copilot-instructions.md
+knowns setup agents    # chỉ KNOWNS.md + AGENTS.md
 knowns setup all       # Tất cả platforms
 ```
 
 ## Ghi chú
 
 - `.agents/skills` là primary path cho agent-compatible platforms
-- `knowns init` không còn generate AI integration files — dùng `knowns setup` sau init
+- `knowns init` tạo selected instruction shims mặc định (`KNOWNS.md`, `CLAUDE.md`, `AGENTS.md`)
+- dùng `knowns setup <target>` cho project-level MCP/config files, skills, runtime hooks
+- dùng `knowns setup codex --global` khi Codex integration chỉ nên nằm ở user scope

--- a/docs/vi/reference/commands.md
+++ b/docs/vi/reference/commands.md
@@ -17,6 +17,9 @@ knowns init --force
 knowns setup
 knowns setup claude
 knowns setup opencode
+knowns setup codex
+knowns setup agents
+knowns setup codex --global
 knowns setup all
 knowns sync
 knowns sync --skills
@@ -27,6 +30,8 @@ knowns update --check
 knowns settings
 knowns settings --global
 ```
+
+`knowns init` tạo `.knowns/`, config, git tracking, semantic setup, và project instruction files (`KNOWNS.md`, mặc định `CLAUDE.md` + `AGENTS.md`). `knowns setup <target>` tạo project-level integration artifacts như MCP/config files, skills, runtime hooks. Dùng `knowns setup agents` khi chỉ muốn `KNOWNS.md` + `AGENTS.md`, hoặc `knowns setup codex --global` khi Codex integration nên nằm ở user scope.
 
 `knowns settings` mở settings center để chỉnh project name, git tracking, AI platforms, search, code intelligence, Browser/Chat UI, và maintenance guidance. Trong Search settings, Local ONNX models hiển thị trạng thái downloaded/not downloaded; nếu chọn model chưa download, Knowns có thể hỏi xác nhận rồi download trước khi lưu. `knowns settings --global` lưu defaults cho các lần `knowns init` sau. Dùng `knowns config get/set/list/reset` khi cần thao tác config bằng script hoặc agent.
 

--- a/docs/vi/reference/commands.md
+++ b/docs/vi/reference/commands.md
@@ -24,7 +24,11 @@ knowns sync --instructions
 knowns sync --model
 knowns update
 knowns update --check
+knowns settings
+knowns settings --global
 ```
+
+`knowns settings` mở settings center để chỉnh project name, git tracking, AI platforms, search, code intelligence, Browser/Chat UI, và maintenance guidance. Trong Search settings, Local ONNX models hiển thị trạng thái downloaded/not downloaded; nếu chọn model chưa download, Knowns có thể hỏi xác nhận rồi download trước khi lưu. `knowns settings --global` lưu defaults cho các lần `knowns init` sau. Dùng `knowns config get/set/list/reset` khi cần thao tác config bằng script hoặc agent.
 
 ## Task
 

--- a/docs/vi/reference/configuration.md
+++ b/docs/vi/reference/configuration.md
@@ -69,6 +69,8 @@ Per-section git tracking toggles. Kiểm soát subdirectories nào trong `.known
 Config cho local semantic search: `enabled`, `model`, `provider`, `dimensions`.
 
 - `knowns init` set các giá trị này
+- `knowns settings` hiển thị Local ONNX models kèm trạng thái downloaded/not downloaded
+- Nếu chọn Local ONNX model chưa download trong `knowns settings`, Knowns hỏi xác nhận rồi download trước khi lưu
 - `knowns sync` re-apply semantic setup
 - `knowns search --reindex` rebuild local index
 
@@ -92,21 +94,30 @@ Có thể edit `.knowns/config.json` trực tiếp, nhưng flow thường là:
 
 - `knowns init` cho lần đầu (project structure + git tracking)
 - `knowns setup` cho AI platform integrations
-- `knowns config set` để toggle features
+- `knowns settings` để mở settings center tương tác cho project hiện tại
+- `knowns settings --global` để lưu defaults dùng lại cho các lần `knowns init` sau
+- `knowns config get/set/list/reset` cho script hoặc agent
 - `knowns sync` để re-apply config
 
-## Config toggle shorthands
+## Settings và config shorthands
 
 ```bash
-# Interactive feature toggle UI
-knowns config toggle
+# Interactive project settings UI
+knowns settings
 # Hiển thị:
-#   AI Chat  [off]
-#   LSP (Experimental)  [on]
-#   Semantic Search  [on]
+#   Project
+#   Git Tracking
+#   AI Platforms
+#   Search
+#   Code Intelligence
+#   Browser / Chat UI
+#   Maintenance
 #   Done
 
-# Hoặc set trực tiếp qua CLI
+# Defaults cho project mới
+knowns settings --global
+
+# Hoặc set trực tiếp qua config API
 knowns config set embedding true       # Bật semantic search
 knowns config set lsp true             # Bật LSP toàn cục
 knowns config set lsp.go true          # Bật LSP cho Go
@@ -118,3 +129,5 @@ knowns config set gitTracking.memories false
 ```
 
 Thay đổi `gitTracking.*` sẽ tự động regenerate `.gitignore`.
+
+Interactive `knowns init` cần terminal rộng tối thiểu 90 cột. Nếu terminal quá nhỏ, Knowns hiển thị hướng dẫn resize hoặc dùng `knowns init --no-wizard`, rồi dừng mà không tự init bằng defaults.

--- a/docs/vi/reference/configuration.md
+++ b/docs/vi/reference/configuration.md
@@ -93,7 +93,9 @@ Supported: `claude-code`, `opencode`, `codex`, `kiro`, `antigravity`, `cursor`, 
 Có thể edit `.knowns/config.json` trực tiếp, nhưng flow thường là:
 
 - `knowns init` cho lần đầu (project structure + git tracking)
-- `knowns setup` cho AI platform integrations
+- `knowns init` cũng tạo selected project instruction shims (`KNOWNS.md`, mặc định `CLAUDE.md` + `AGENTS.md`)
+- `knowns setup` cho AI platform integrations như MCP/config files, skills, runtime hooks
+- `knowns setup agents` khi chỉ cần `KNOWNS.md` + `AGENTS.md`
 - `knowns settings` để mở settings center tương tác cho project hiện tại
 - `knowns settings --global` để lưu defaults dùng lại cho các lần `knowns init` sau
 - `knowns config get/set/list/reset` cho script hoặc agent

--- a/docs/vi/reference/sync.md
+++ b/docs/vi/reference/sync.md
@@ -10,7 +10,7 @@ Chạy `knowns sync` sau khi:
 - upgrade CLI
 - muốn generated files khớp lại với config
 
-Để cấu hình AI platforms (skills, instructions, MCP configs), dùng `knowns setup`.
+Để tạo project guidance files ban đầu, dùng `knowns init` hoặc `knowns setup agents`. Để cấu hình AI platforms đầy đủ (skills, MCP configs, runtime hooks), dùng `knowns setup <target>`.
 
 ## Các dạng dùng
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -23,6 +23,14 @@ var configCmd = &cobra.Command{
 	Short: "Manage project configuration",
 }
 
+var runSemanticSetupForSettings = runSemanticSetup
+
+type localONNXModelChoice struct {
+	Model     *embeddingModel
+	Label     string
+	Installed bool
+}
+
 // --- config get ---
 
 var configGetCmd = &cobra.Command{
@@ -347,15 +355,20 @@ func runConfigReset(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// --- config toggle ---
+// --- settings ---
 
-var configToggleCmd = &cobra.Command{
-	Use:   "toggle",
-	Short: "Interactively toggle features on/off",
-	RunE:  runConfigToggle,
+var settingsCmd = &cobra.Command{
+	Use:   "settings",
+	Short: "Open interactive project settings",
+	RunE:  runSettings,
 }
 
-func runConfigToggle(cmd *cobra.Command, args []string) error {
+func runSettings(cmd *cobra.Command, args []string) error {
+	global, _ := cmd.Flags().GetBool("global")
+	if global {
+		return runGlobalSettings()
+	}
+
 	store := getStore()
 
 	project, err := store.Config.Load()
@@ -363,34 +376,24 @@ func runConfigToggle(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	chatUI := project.Settings.EnableChatUI == nil || *project.Settings.EnableChatUI
-	lspEnabled := project.Settings.LSP != nil && project.Settings.LSP.Enabled != nil && *project.Settings.LSP.Enabled
-	embeddingEnabled := project.Settings.SemanticSearch != nil && project.Settings.SemanticSearch.Enabled
-
-	// Build status labels
-	statusLabel := func(enabled bool) string {
-		if enabled {
-			return "on"
-		}
-		return "off"
-	}
-
 	var choice string
-	options := []huh.Option[string]{
-		huh.NewOption(fmt.Sprintf("AI Chat  [%s]", statusLabel(chatUI)), "chat"),
-		huh.NewOption(fmt.Sprintf("LSP (Experimental)  [%s]", statusLabel(lspEnabled)), "lsp"),
-		huh.NewOption(fmt.Sprintf("Semantic Search  [%s]", statusLabel(embeddingEnabled)), "embedding"),
-		huh.NewOption("Done", "done"),
-	}
-
 	for {
 		choice = ""
 		form := huh.NewForm(
 			huh.NewGroup(
 				huh.NewSelect[string]().
-					Title("Feature Settings").
-					Description("Select a feature to configure").
-					Options(options...).
+					Title("Project Settings").
+					Description(fmt.Sprintf("Current project: %s", project.Name)).
+					Options(
+						huh.NewOption("Project", "project"),
+						huh.NewOption("Git Tracking", "git"),
+						huh.NewOption("AI Platforms", "platforms"),
+						huh.NewOption("Search", "search"),
+						huh.NewOption("Code Intelligence", "code"),
+						huh.NewOption("Browser / Chat UI", "chat"),
+						huh.NewOption("Maintenance", "maintenance"),
+						huh.NewOption("Done", "done"),
+					).
 					Value(&choice),
 			),
 		).WithTheme(huh.ThemeCatppuccin())
@@ -407,25 +410,519 @@ func runConfigToggle(cmd *cobra.Command, args []string) error {
 		case "done":
 			fmt.Println(RenderSuccess("Settings saved."))
 			return nil
-		case "chat":
-			if err := toggleChatUI(store, &chatUI); err != nil {
+		case "project":
+			if err := configureProjectIdentity(store, project); err != nil {
 				return err
 			}
-		case "lsp":
-			if err := toggleLSP(store, &lspEnabled); err != nil {
+		case "git":
+			if err := configureGitTracking(store, project); err != nil {
 				return err
 			}
-		case "embedding":
+		case "platforms":
+			if err := configurePlatforms(store, project); err != nil {
+				return err
+			}
+		case "search":
+			embeddingEnabled := project.Settings.SemanticSearch != nil && project.Settings.SemanticSearch.Enabled
 			if err := toggleEmbedding(store, project, &embeddingEnabled); err != nil {
 				return err
 			}
+		case "code":
+			if err := configureCodeIntelligence(store, project); err != nil {
+				return err
+			}
+		case "chat":
+			chatUI := project.Settings.EnableChatUI == nil || *project.Settings.EnableChatUI
+			if err := toggleChatUI(store, &chatUI); err != nil {
+				return err
+			}
+		case "maintenance":
+			if err := showSettingsMaintenance(project); err != nil {
+				return err
+			}
+		}
+		project, err = store.Config.Load()
+		if err != nil {
+			return fmt.Errorf("reload config: %w", err)
+		}
+	}
+}
+
+func runGlobalSettings() error {
+	embStore := storage.NewEmbeddingSettingsStore()
+	settings, err := embStore.Load()
+	if err != nil {
+		return err
+	}
+	if settings.ProjectDefaults == nil {
+		settings.ProjectDefaults = &storage.ProjectDefaults{
+			Settings: models.DefaultProjectSettings(),
+		}
+	}
+
+	var choice string
+	for {
+		choice = ""
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Global Settings").
+					Description("Defaults for new projects created by knowns init").
+					Options(
+						huh.NewOption("Project Defaults", "project"),
+						huh.NewOption("Default Git Tracking", "git"),
+						huh.NewOption("Default AI Platforms", "platforms"),
+						huh.NewOption("Default Search", "search"),
+						huh.NewOption("Default Code Intelligence", "code"),
+						huh.NewOption("Default Browser / Chat UI", "chat"),
+						huh.NewOption("Done", "done"),
+					).
+					Value(&choice),
+			),
+		).WithTheme(huh.ThemeCatppuccin())
+
+		if err := form.Run(); err != nil {
+			if err == huh.ErrUserAborted {
+				fmt.Println("Aborted.")
+				return nil
+			}
+			return err
 		}
 
-		// Refresh option labels
-		options[0] = huh.NewOption(fmt.Sprintf("AI Chat  [%s]", statusLabel(chatUI)), "chat")
-		options[1] = huh.NewOption(fmt.Sprintf("LSP (Experimental)  [%s]", statusLabel(lspEnabled)), "lsp")
-		options[2] = huh.NewOption(fmt.Sprintf("Semantic Search  [%s]", statusLabel(embeddingEnabled)), "embedding")
+		defaults := settings.ProjectDefaults
+		switch choice {
+		case "done":
+			if err := embStore.Save(settings); err != nil {
+				return err
+			}
+			fmt.Println(RenderSuccess("Global settings saved."))
+			fmt.Println(RenderHint("Run: knowns init to use these defaults in a new project."))
+			return nil
+		case "project":
+			name := defaults.ProjectName
+			form := huh.NewForm(huh.NewGroup(
+				huh.NewInput().
+					Title("Default project name").
+					Description("Leave blank to use the directory name.").
+					Value(&name),
+			)).WithTheme(huh.ThemeCatppuccin())
+			if err := form.Run(); err != nil {
+				if err == huh.ErrUserAborted {
+					return nil
+				}
+				return err
+			}
+			defaults.ProjectName = strings.TrimSpace(name)
+		case "git":
+			if err := configureGitTrackingSettings(&defaults.Settings); err != nil {
+				return err
+			}
+		case "platforms":
+			if err := configurePlatformSettings(&defaults.Settings); err != nil {
+				return err
+			}
+		case "search":
+			if err := configureSemanticDefaults(&defaults.Settings); err != nil {
+				return err
+			}
+		case "code":
+			if err := configureLSPSettings(&defaults.Settings); err != nil {
+				return err
+			}
+		case "chat":
+			enabled := defaults.Settings.EnableChatUI == nil || *defaults.Settings.EnableChatUI
+			form := huh.NewForm(huh.NewGroup(
+				huh.NewConfirm().
+					Title("Enable Chat UI by default").
+					Value(&enabled),
+			)).WithTheme(huh.ThemeCatppuccin())
+			if err := form.Run(); err != nil {
+				if err == huh.ErrUserAborted {
+					return nil
+				}
+				return err
+			}
+			defaults.Settings.EnableChatUI = &enabled
+		}
+		if err := embStore.Save(settings); err != nil {
+			return err
+		}
 	}
+}
+
+func configureProjectIdentity(store *storage.Store, project *models.Project) error {
+	name := project.Name
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewInput().
+			Title("Project name").
+			Value(&name).
+			Validate(func(s string) error {
+				if strings.TrimSpace(s) == "" {
+					return fmt.Errorf("project name is required")
+				}
+				return nil
+			}),
+	)).WithTheme(huh.ThemeCatppuccin())
+	if err := form.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
+	}
+	project.Name = strings.TrimSpace(name)
+	return store.Config.Save(project)
+}
+
+func configureGitTracking(store *storage.Store, project *models.Project) error {
+	if err := configureGitTrackingSettings(&project.Settings); err != nil {
+		return err
+	}
+	if err := store.Config.Save(project); err != nil {
+		return err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	return writeKnownsGitignore(cwd, project.Settings.GitTrackingMode, project.Settings.GitTracking)
+}
+
+func configureGitTrackingSettings(settings *models.ProjectSettings) error {
+	mode := settings.GitTrackingMode
+	if mode == "" {
+		mode = "git-tracked"
+	}
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Git tracking mode").
+			Options(
+				huh.NewOption("Git Tracked", "git-tracked"),
+				huh.NewOption("Git Ignored", "git-ignored"),
+				huh.NewOption("None", "none"),
+			).
+			Value(&mode),
+	)).WithTheme(huh.ThemeCatppuccin())
+	if err := form.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
+	}
+	settings.GitTrackingMode = mode
+	if mode == "none" {
+		settings.GitTracking = nil
+		return nil
+	}
+	tracking := models.GitTrackingDefaults()
+	if settings.GitTracking != nil {
+		tracking = *settings.GitTracking
+	}
+	selected := gitTrackingSelectedSections(&tracking)
+	sectionForm := huh.NewForm(huh.NewGroup(
+		huh.NewMultiSelect[string]().
+			Title("Knowns sections to track in git").
+			Options(
+				huh.NewOption("Tasks", "tasks").Selected(sectionSelected(selected, "tasks")),
+				huh.NewOption("Docs", "docs").Selected(sectionSelected(selected, "docs")),
+				huh.NewOption("Templates", "templates").Selected(sectionSelected(selected, "templates")),
+				huh.NewOption("Memories", "memories").Selected(sectionSelected(selected, "memories")),
+			).
+			Value(&selected),
+	)).WithTheme(huh.ThemeCatppuccin())
+	if err := sectionForm.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
+	}
+	tracking = gitTrackingFromSelectedSections(selected)
+	settings.GitTracking = &tracking
+	return nil
+}
+
+func configurePlatforms(store *storage.Store, project *models.Project) error {
+	if err := configurePlatformSettings(&project.Settings); err != nil {
+		return err
+	}
+	if err := store.Config.Save(project); err != nil {
+		return err
+	}
+	fmt.Println(RenderHint("Run: knowns sync to apply platform changes to generated files."))
+	return nil
+}
+
+func configurePlatformSettings(settings *models.ProjectSettings) error {
+	selected := settings.Platforms
+	if len(selected) == 0 {
+		selected = []string{"claude-code", "agents"}
+	}
+	options := make([]huh.Option[string], 0, len(wizardPlatformIDs))
+	for _, id := range wizardPlatformIDs {
+		options = append(options, huh.NewOption(platformLabel(id), id).Selected(sectionSelected(selected, id)))
+	}
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewMultiSelect[string]().
+			Title("AI platforms").
+			Description("Select generated instruction and integration targets.").
+			Options(options...).
+			Value(&selected),
+	)).WithTheme(huh.ThemeCatppuccin())
+	if err := form.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
+	}
+	settings.Platforms = selected
+	return nil
+}
+
+func configureCodeIntelligence(store *storage.Store, project *models.Project) error {
+	if err := configureLSPSettings(&project.Settings); err != nil {
+		return err
+	}
+	if err := store.Config.Save(project); err != nil {
+		return err
+	}
+	fmt.Println(RenderHint("Run: knowns lsp status for missing server install guidance."))
+	return nil
+}
+
+func configureSemanticDefaults(settings *models.ProjectSettings) error {
+	enabled := settings.SemanticSearch != nil && settings.SemanticSearch.Enabled
+	provider := "local"
+	model := "multilingual-e5-small"
+	if settings.SemanticSearch != nil {
+		if settings.SemanticSearch.Provider != "" {
+			provider = settings.SemanticSearch.Provider
+		}
+		if settings.SemanticSearch.Model != "" {
+			model = settings.SemanticSearch.Model
+		}
+	}
+
+	providerForm := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Enable semantic search by default").
+				Value(&enabled),
+		),
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Default provider").
+				Options(
+					huh.NewOption("Local ONNX (offline)", "local"),
+					huh.NewOption("Ollama (local API)", "ollama"),
+					huh.NewOption("API (OpenAI-compatible)", "api"),
+				).
+				Value(&provider),
+		).WithHideFunc(func() bool { return !enabled }),
+	).WithTheme(huh.ThemeCatppuccin())
+	if err := providerForm.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
+	}
+	if !enabled {
+		settings.SemanticSearch = &models.SemanticSearchSettings{Enabled: false, Model: model, Provider: provider}
+		return nil
+	}
+	if provider != "local" {
+		modelForm := huh.NewForm(huh.NewGroup(
+			huh.NewInput().
+				Title("Default model").
+				Value(&model),
+		)).WithTheme(huh.ThemeCatppuccin())
+		if err := modelForm.Run(); err != nil {
+			if err == huh.ErrUserAborted {
+				return nil
+			}
+			return err
+		}
+	}
+	ss := &models.SemanticSearchSettings{Enabled: true, Provider: provider, Model: model}
+	if provider == "local" {
+		if err := selectLocalONNXModel(&model); err != nil {
+			if err == huh.ErrUserAborted {
+				return nil
+			}
+			return err
+		}
+		selected := findSupportedModel(model)
+		if selected == nil {
+			return fmt.Errorf("unknown local ONNX model %q", model)
+		}
+		if !isModelInstalled(selected) {
+			download := false
+			confirmForm := huh.NewForm(huh.NewGroup(
+				huh.NewConfirm().
+					Title(fmt.Sprintf("Download %s now?", selected.ID)).
+					Description("Global defaults can use a missing model, but downloading now prepares this machine for future projects.").
+					Value(&download),
+			)).WithTheme(huh.ThemeCatppuccin())
+			if err := confirmForm.Run(); err != nil {
+				if err == huh.ErrUserAborted {
+					return nil
+				}
+				return err
+			}
+			if download {
+				if err := runSemanticSetupForSettings(selected.ID, false); err != nil {
+					return err
+				}
+			}
+		}
+		ss = semanticSettingsForLocalONNX(selected)
+	}
+	settings.SemanticSearch = ss
+	return nil
+}
+
+func configureLSPSettings(settings *models.ProjectSettings) error {
+	if settings.LSP == nil {
+		settings.LSP = &models.LSPSettings{Languages: map[string]models.LSPLanguageSettings{}}
+	}
+	enabled := settings.LSP.Enabled != nil && *settings.LSP.Enabled
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewConfirm().
+			Title("Enable code intelligence").
+			Description("Language servers power code symbols, references, and diagnostics.").
+			Value(&enabled),
+	)).WithTheme(huh.ThemeCatppuccin())
+	if err := form.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
+	}
+	settings.LSP.Enabled = &enabled
+	if settings.LSP.Languages == nil {
+		settings.LSP.Languages = map[string]models.LSPLanguageSettings{}
+	}
+	for _, id := range []string{"go", "typescript", "python", "rust", "c_cpp", "java", "csharp", "ruby", "php"} {
+		lang := settings.LSP.Languages[id]
+		if lang.Enabled == nil {
+			lang.Enabled = &enabled
+		}
+		settings.LSP.Languages[id] = lang
+	}
+	return nil
+}
+
+func showSettingsMaintenance(project *models.Project) error {
+	fmt.Println(RenderSectionHeader("Maintenance"))
+	fmt.Println(RenderHint("Run: knowns sync to apply generated files, git rules, models, and MCP configs."))
+	if project.Settings.SemanticSearch != nil && project.Settings.SemanticSearch.Enabled {
+		fmt.Println(RenderHint("Run: knowns search --reindex after changing search settings."))
+	}
+	fmt.Println(RenderHint("Run: knowns config list --plain for scriptable inspection."))
+	return nil
+}
+
+func localONNXModelChoices(currentModel string) []localONNXModelChoice {
+	choices := make([]localONNXModelChoice, 0, len(supportedModels))
+	for i := range supportedModels {
+		m := &supportedModels[i]
+		installed := isModelInstalled(m)
+		status := "not downloaded"
+		if installed {
+			status = "downloaded"
+		}
+		current := ""
+		if currentModel == m.ID {
+			current = ", current"
+		}
+		choices = append(choices, localONNXModelChoice{
+			Model:     m,
+			Installed: installed,
+			Label: fmt.Sprintf("%s - %s (%dd, %d tokens, %dMB, %s%s)",
+				m.ID, m.Name, m.Dimensions, m.MaxTokens, m.SizeMB, status, current),
+		})
+	}
+	return choices
+}
+
+func localONNXModelSelectOptions(currentModel string) []huh.Option[string] {
+	choices := localONNXModelChoices(currentModel)
+	options := make([]huh.Option[string], 0, len(choices))
+	for _, choice := range choices {
+		options = append(options, huh.NewOption(choice.Label, choice.Model.ID))
+	}
+	return options
+}
+
+func selectLocalONNXModel(model *string) error {
+	if model == nil {
+		return fmt.Errorf("model value is required")
+	}
+	if findSupportedModel(*model) == nil {
+		*model = "multilingual-e5-small"
+	}
+	modelForm := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Local ONNX model").
+				Description("Downloaded models are ready for offline semantic search. Missing models can be downloaded after selection.").
+				Options(localONNXModelSelectOptions(*model)...).
+				Value(model),
+		),
+	).WithTheme(huh.ThemeCatppuccin())
+
+	if err := modelForm.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return err
+		}
+		return err
+	}
+	return nil
+}
+
+func semanticSettingsForLocalONNX(model *embeddingModel) *models.SemanticSearchSettings {
+	return &models.SemanticSearchSettings{
+		Enabled:       true,
+		Provider:      "local",
+		Model:         model.ID,
+		HuggingFaceID: model.HuggingFace,
+		Dimensions:    model.Dimensions,
+		MaxTokens:     model.MaxTokens,
+	}
+}
+
+func saveLocalONNXSemanticSettings(store *storage.Store, project *models.Project, model *embeddingModel) error {
+	if store == nil {
+		return fmt.Errorf("store is required")
+	}
+	if project == nil {
+		return fmt.Errorf("project is required")
+	}
+	project.Settings.SemanticSearch = semanticSettingsForLocalONNX(model)
+	return store.Config.Save(project)
+}
+
+func applyLocalONNXSelection(store *storage.Store, project *models.Project, modelID string, confirmDownload func(*embeddingModel) (bool, error)) (bool, error) {
+	selected := findSupportedModel(modelID)
+	if selected == nil {
+		return false, fmt.Errorf("unknown local ONNX model %q", modelID)
+	}
+	if !isModelInstalled(selected) {
+		download, err := confirmDownload(selected)
+		if err != nil {
+			return false, err
+		}
+		if !download {
+			fmt.Println(RenderWarning(fmt.Sprintf("Kept previous Local ONNX model; %q was not downloaded.", selected.ID)))
+			fmt.Println(RenderHint("Run: " + RenderCmd(fmt.Sprintf("knowns model download %s", selected.ID)) + " and select it again."))
+			return false, nil
+		}
+		if err := runSemanticSetupForSettings(selected.ID, false); err != nil {
+			return false, err
+		}
+	}
+	if err := saveLocalONNXSemanticSettings(store, project, selected); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func toggleChatUI(store *storage.Store, chatUI *bool) error {
@@ -505,30 +1002,6 @@ func toggleChatUI(store *storage.Store, chatUI *bool) error {
 			_ = store.Config.Set("settings.opencodeServer.password", password)
 		}
 	}
-	return nil
-}
-
-func toggleLSP(store *storage.Store, lspEnabled *bool) error {
-	enabled := *lspEnabled
-
-	form := huh.NewForm(
-		huh.NewGroup(
-			huh.NewConfirm().
-				Title("Enable LSP (Experimental)").
-				Description("Language Server Protocol for code intelligence").
-				Value(&enabled),
-		),
-	).WithTheme(huh.ThemeCatppuccin())
-
-	if err := form.Run(); err != nil {
-		if err == huh.ErrUserAborted {
-			return nil
-		}
-		return err
-	}
-
-	*lspEnabled = enabled
-	_ = store.Config.Set("settings.lsp.enabled", enabled)
 	return nil
 }
 
@@ -654,27 +1127,34 @@ func toggleEmbedding(store *storage.Store, project *models.Project, embeddingEna
 
 	// Local ONNX
 	if provider == "local" {
-		modelForm := huh.NewForm(
-			huh.NewGroup(
-				huh.NewInput().
-					Title("Model").
-					Placeholder("e.g. gte-small").
-					Value(&model),
-			),
-		).WithTheme(huh.ThemeCatppuccin())
-
-		if err := modelForm.Run(); err != nil {
+		if err := selectLocalONNXModel(&model); err != nil {
 			if err == huh.ErrUserAborted {
 				return nil
 			}
 			return err
 		}
 
-		*embeddingEnabled = true
-		_ = store.Config.Set("settings.semanticSearch.enabled", true)
-		_ = store.Config.Set("settings.semanticSearch.provider", provider)
-		if model != "" {
-			_ = store.Config.Set("settings.semanticSearch.model", model)
+		saved, err := applyLocalONNXSelection(store, project, model, func(selected *embeddingModel) (bool, error) {
+			download := false
+			confirmForm := huh.NewForm(huh.NewGroup(
+				huh.NewConfirm().
+					Title(fmt.Sprintf("Download %s now?", selected.ID)).
+					Description(fmt.Sprintf("%s is not downloaded. Download it before saving this Local ONNX setting.", selected.Name)).
+					Value(&download),
+			)).WithTheme(huh.ThemeCatppuccin())
+			if err := confirmForm.Run(); err != nil {
+				if err == huh.ErrUserAborted {
+					return false, nil
+				}
+				return false, err
+			}
+			return download, nil
+		})
+		if err != nil {
+			return err
+		}
+		if saved {
+			*embeddingEnabled = true
 		}
 		return nil
 	}
@@ -916,15 +1396,16 @@ func listAPIModels(baseURL, apiKey string) ([]string, error) {
 	return names, nil
 }
 
-
 func init() {
+	settingsCmd.Flags().Bool("global", false, "Edit global defaults for future knowns init runs")
+
 	configResetCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 
 	configCmd.AddCommand(configGetCmd)
 	configCmd.AddCommand(configSetCmd)
 	configCmd.AddCommand(configListCmd)
 	configCmd.AddCommand(configResetCmd)
-	configCmd.AddCommand(configToggleCmd)
 
 	rootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(settingsCmd)
 }

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,181 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/howznguyen/knowns/internal/models"
+	"github.com/howznguyen/knowns/internal/storage"
+)
+
+func TestLocalONNXModelChoicesShowDownloadStatus(t *testing.T) {
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+
+	model := findSupportedModel("gte-small")
+	if model == nil {
+		t.Fatal("missing gte-small model")
+	}
+	installedPath := filepath.Join(home, ".knowns", "models", model.HuggingFace, "onnx", "model_quantized.onnx")
+	if err := os.MkdirAll(filepath.Dir(installedPath), 0755); err != nil {
+		t.Fatalf("mkdir model dir: %v", err)
+	}
+	if err := os.WriteFile(installedPath, []byte("onnx"), 0644); err != nil {
+		t.Fatalf("write model file: %v", err)
+	}
+
+	choices := localONNXModelChoices("gte-small")
+	var installedLabel, missingLabel string
+	for _, choice := range choices {
+		switch choice.Model.ID {
+		case "gte-small":
+			installedLabel = choice.Label
+		case "gte-base":
+			missingLabel = choice.Label
+		}
+	}
+	if !strings.Contains(installedLabel, "downloaded") || !strings.Contains(installedLabel, "current") {
+		t.Fatalf("expected installed current label, got %q", installedLabel)
+	}
+	if !strings.Contains(missingLabel, "not downloaded") {
+		t.Fatalf("expected missing label, got %q", missingLabel)
+	}
+}
+
+func TestSaveLocalONNXSemanticSettingsPersistsFullConfig(t *testing.T) {
+	store, project := newConfigTestProject(t)
+	model := findSupportedModel("gte-small")
+	if model == nil {
+		t.Fatal("missing gte-small model")
+	}
+
+	if err := saveLocalONNXSemanticSettings(store, project, model); err != nil {
+		t.Fatalf("save local ONNX settings: %v", err)
+	}
+
+	saved, err := store.Config.Load()
+	if err != nil {
+		t.Fatalf("load saved config: %v", err)
+	}
+	ss := saved.Settings.SemanticSearch
+	if ss == nil {
+		t.Fatal("expected semantic search settings")
+	}
+	if !ss.Enabled || ss.Provider != "local" || ss.Model != model.ID {
+		t.Fatalf("unexpected semantic config: %#v", ss)
+	}
+	if ss.HuggingFaceID != model.HuggingFace || ss.Dimensions != model.Dimensions || ss.MaxTokens != model.MaxTokens {
+		t.Fatalf("expected full model metadata, got %#v", ss)
+	}
+}
+
+func TestApplyLocalONNXSelectionDeclineLeavesConfigUnchanged(t *testing.T) {
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+
+	store, project := newConfigTestProject(t)
+	project.Settings.SemanticSearch = &models.SemanticSearchSettings{
+		Enabled:       true,
+		Provider:      "local",
+		Model:         "gte-small",
+		HuggingFaceID: "Xenova/gte-small",
+		Dimensions:    384,
+		MaxTokens:     512,
+	}
+	if err := store.Config.Save(project); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	saved, err := applyLocalONNXSelection(store, project, "gte-base", func(*embeddingModel) (bool, error) {
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("apply selection: %v", err)
+	}
+	if saved {
+		t.Fatal("expected declined selection to skip save")
+	}
+
+	loaded, err := store.Config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if got := loaded.Settings.SemanticSearch.Model; got != "gte-small" {
+		t.Fatalf("expected previous model to remain, got %q", got)
+	}
+}
+
+func TestApplyLocalONNXSelectionDownloadsMissingModelBeforeSave(t *testing.T) {
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+
+	store, project := newConfigTestProject(t)
+	oldSetup := runSemanticSetupForSettings
+	var downloaded string
+	runSemanticSetupForSettings = func(modelID string, force ...bool) error {
+		downloaded = modelID
+		return nil
+	}
+	t.Cleanup(func() { runSemanticSetupForSettings = oldSetup })
+
+	saved, err := applyLocalONNXSelection(store, project, "gte-base", func(*embeddingModel) (bool, error) {
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("apply selection: %v", err)
+	}
+	if !saved {
+		t.Fatal("expected approved selection to save")
+	}
+	if downloaded != "gte-base" {
+		t.Fatalf("expected download for gte-base, got %q", downloaded)
+	}
+
+	loaded, err := store.Config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if got := loaded.Settings.SemanticSearch.Model; got != "gte-base" {
+		t.Fatalf("expected selected model, got %q", got)
+	}
+	if loaded.Settings.SemanticSearch.Dimensions != 768 {
+		t.Fatalf("expected gte-base dimensions, got %d", loaded.Settings.SemanticSearch.Dimensions)
+	}
+}
+
+func TestProviderSettingsForAPIAndOllamaRemainMinimal(t *testing.T) {
+	for _, provider := range []string{"api", "ollama"} {
+		ss := &models.SemanticSearchSettings{Enabled: true, Provider: provider, Model: "embed-model"}
+		if ss.HuggingFaceID != "" || ss.Dimensions != 0 || ss.MaxTokens != 0 {
+			t.Fatalf("expected %s provider config to remain provider/model only, got %#v", provider, ss)
+		}
+	}
+}
+
+func newConfigTestProject(t *testing.T) (*storage.Store, *models.Project) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), ".knowns")
+	store := storage.NewStore(root)
+	if err := store.Init("config-test"); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	project, err := store.Config.Load()
+	if err != nil {
+		t.Fatalf("load project: %v", err)
+	}
+	return store, project
+}

--- a/internal/cli/download_setup.go
+++ b/internal/cli/download_setup.go
@@ -236,7 +236,7 @@ func (m *setupModel) startCurrentStep() tea.Cmd {
 			return setupStepDoneMsg{err: err}
 		}
 
-		resp, err := client.Get(url)
+		resp, err := downloadGetWithRetry(client, url)
 		if err != nil {
 			return setupStepDoneMsg{err: err}
 		}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -279,23 +279,29 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	var cfg initConfig
+	globalDefaults, err := loadGlobalProjectDefaults()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to load global settings: %v\n", err)
+	}
 
 	// Determine if interactive mode
 	interactive := !noWizard
 	if interactive && isTTYFn() && terminalWidthFn() < 90 {
-		fmt.Println(warnStyle.Render("Terminal width is too small for the interactive setup wizard."))
-		fmt.Println(dimStyle.Render("  Falling back to non-interactive defaults. Re-run with a wider terminal for the full wizard."))
+		fmt.Println(warnStyle.Render("Terminal is too small for the interactive setup wizard."))
 		fmt.Println()
-		interactive = false
+		fmt.Println(RenderField("Minimum width", "90 columns"))
+		fmt.Println(RenderField("Current width", fmt.Sprintf("%d columns", terminalWidthFn())))
+		fmt.Println()
+		fmt.Println(dimStyle.Render("  Resize the terminal and rerun: knowns init"))
+		fmt.Println(dimStyle.Render("  Or run explicitly without the wizard: knowns init --no-wizard"))
+		fmt.Println(dimStyle.Render("  Or pass explicit flags such as: knowns init --no-wizard --git-tracked"))
+		fmt.Println()
+		return nil
 	}
 
 	if interactive && len(args) == 0 {
 		// Load any existing config to pre-populate wizard defaults.
-		var existingName string
-		var existingGitTrackingMode string
-		var existingGitTracking *models.GitTracking
-		var existingSemanticEnabled *bool
-		var existingSemanticModel string
+		existingName, existingGitTrackingMode, existingGitTracking, existingSemanticEnabled, existingSemanticModel := defaultsForWizard(cwd, globalDefaults)
 		if existingCfg, err := storage.NewStore(root).Config.Load(); err == nil {
 			existingName = existingCfg.Name
 			existingGitTrackingMode = existingCfg.Settings.GitTrackingMode
@@ -322,10 +328,66 @@ func runInit(cmd *cobra.Command, args []string) error {
 	} else {
 		// Non-interactive or name provided
 		name := filepath.Base(cwd)
+		if globalDefaults != nil && globalDefaults.ProjectName != "" {
+			name = globalDefaults.ProjectName
+		}
 		if len(args) > 0 {
 			name = args[0]
 		}
 		gitMode := "git-tracked"
+		gitTracking := models.GitTrackingDefaults()
+		enableSemantic := isTTY()
+		semanticModel := "multilingual-e5-small"
+		embeddingSource := "local"
+		platforms := []string{"claude-code", "agents"}
+		enableChatUI := true
+		if globalDefaults != nil {
+			if globalDefaults.Settings.GitTrackingMode != "" {
+				gitMode = globalDefaults.Settings.GitTrackingMode
+			}
+			if globalDefaults.Settings.GitTracking != nil {
+				gitTracking = *globalDefaults.Settings.GitTracking
+			}
+			if globalDefaults.Settings.SemanticSearch != nil {
+				enableSemantic = globalDefaults.Settings.SemanticSearch.Enabled
+				semanticModel = globalDefaults.Settings.SemanticSearch.Model
+				if globalDefaults.Settings.SemanticSearch.Provider != "" {
+					embeddingSource = globalDefaults.Settings.SemanticSearch.Provider
+				}
+			}
+			if len(globalDefaults.Settings.Platforms) > 0 {
+				platforms = globalDefaults.Settings.Platforms
+			}
+			if globalDefaults.Settings.EnableChatUI != nil {
+				enableChatUI = *globalDefaults.Settings.EnableChatUI
+			}
+		}
+		if force {
+			if existingCfg, err := storage.NewStore(root).Config.Load(); err == nil {
+				if existingCfg.Name != "" && len(args) == 0 {
+					name = existingCfg.Name
+				}
+				if existingCfg.Settings.GitTrackingMode != "" {
+					gitMode = existingCfg.Settings.GitTrackingMode
+				}
+				if existingCfg.Settings.GitTracking != nil {
+					gitTracking = *existingCfg.Settings.GitTracking
+				}
+				if existingCfg.Settings.SemanticSearch != nil {
+					enableSemantic = existingCfg.Settings.SemanticSearch.Enabled
+					semanticModel = existingCfg.Settings.SemanticSearch.Model
+					if existingCfg.Settings.SemanticSearch.Provider != "" {
+						embeddingSource = existingCfg.Settings.SemanticSearch.Provider
+					}
+				}
+				if len(existingCfg.Settings.Platforms) > 0 {
+					platforms = existingCfg.Settings.Platforms
+				}
+				if existingCfg.Settings.EnableChatUI != nil {
+					enableChatUI = *existingCfg.Settings.EnableChatUI
+				}
+			}
+		}
 		if gitTracked {
 			gitMode = "git-tracked"
 		} else if gitIgnored {
@@ -334,11 +396,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 		cfg = initConfig{
 			Name:            name,
 			GitTrackingMode: gitMode,
-			GitTracking:     models.GitTrackingDefaults(),
-			EnableSemantic:  isTTY(),
-			SemanticModel:   "multilingual-e5-small",
-			Platforms:       []string{"claude-code", "agents"},
-			EnableChatUI:    true,
+			GitTracking:     gitTracking,
+			EnableSemantic:  enableSemantic,
+			SemanticModel:   semanticModel,
+			EmbeddingSource: embeddingSource,
+			Platforms:       platforms,
+			EnableChatUI:    enableChatUI,
 		}
 	}
 
@@ -503,6 +566,37 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println()
 	return maybeOpenBrowser(cwd, openFlag, noOpen)
+}
+
+func loadGlobalProjectDefaults() (*storage.ProjectDefaults, error) {
+	settings, err := storage.NewEmbeddingSettingsStore().Load()
+	if err != nil {
+		return nil, err
+	}
+	return settings.ProjectDefaults, nil
+}
+
+func defaultsForWizard(cwd string, defaults *storage.ProjectDefaults) (string, string, *models.GitTracking, *bool, string) {
+	name := filepath.Base(cwd)
+	var gitMode string
+	var gitTracking *models.GitTracking
+	var semanticEnabled *bool
+	var semanticModel string
+
+	if defaults == nil {
+		return name, gitMode, gitTracking, semanticEnabled, semanticModel
+	}
+	if defaults.ProjectName != "" {
+		name = defaults.ProjectName
+	}
+	gitMode = defaults.Settings.GitTrackingMode
+	gitTracking = defaults.Settings.GitTracking
+	if defaults.Settings.SemanticSearch != nil {
+		enabled := defaults.Settings.SemanticSearch.Enabled
+		semanticEnabled = &enabled
+		semanticModel = defaults.Settings.SemanticSearch.Model
+	}
+	return name, gitMode, gitTracking, semanticEnabled, semanticModel
 }
 
 func runWizard(cwd string, gitTracked, gitIgnored bool, gitAvailable bool, existingName string, existingGitTrackingMode string, existingGitTracking *models.GitTracking, existingSemanticEnabled *bool, existingSemanticModel string) (*initConfig, error) {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -193,6 +193,81 @@ func hasPlatform(platforms []string, id string) bool {
 	return false
 }
 
+func hasExplicitPlatform(platforms []string, id string) bool {
+	for _, p := range platforms {
+		if p == id {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldCreateInstructionFile(platforms []string, f instructionFile) bool {
+	if len(platforms) == 0 {
+		return true
+	}
+	if f.PlatformID == "agents" && hasExplicitPlatform(platforms, "codex") {
+		return true
+	}
+	return hasExplicitPlatform(platforms, f.PlatformID)
+}
+
+func defaultInstructionPlatforms() []string {
+	return []string{"claude-code", "agents"}
+}
+
+func instructionPlatformOptions(selected []string) []huh.Option[string] {
+	selectedSet := make(map[string]bool, len(selected))
+	for _, id := range selected {
+		if id == "codex" {
+			id = "agents"
+		}
+		selectedSet[id] = true
+	}
+	options := []struct {
+		label string
+		id    string
+	}{
+		{label: "CLAUDE.md  (Claude Code)", id: "claude-code"},
+		{label: "AGENTS.md  (Codex / generic agents)", id: "agents"},
+		{label: "OPENCODE.md  (OpenCode)", id: "opencode"},
+		{label: "GEMINI.md  (Gemini CLI)", id: "gemini"},
+		{label: ".github/copilot-instructions.md  (GitHub Copilot)", id: "copilot"},
+	}
+	result := make([]huh.Option[string], len(options))
+	for i, opt := range options {
+		result[i] = huh.NewOption(opt.label, opt.id).Selected(selectedSet[opt.id])
+	}
+	return result
+}
+
+func normalizeInstructionPlatforms(platforms []string) []string {
+	if len(platforms) == 0 {
+		return defaultInstructionPlatforms()
+	}
+	seen := make(map[string]bool, len(platforms))
+	normalized := make([]string, 0, len(platforms))
+	for _, id := range platforms {
+		if id == "codex" {
+			id = "agents"
+		}
+		switch id {
+		case "claude-code", "agents", "opencode", "gemini", "copilot":
+		default:
+			continue
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		normalized = append(normalized, id)
+	}
+	if len(normalized) == 0 {
+		return defaultInstructionPlatforms()
+	}
+	return normalized
+}
+
 // initConfig holds all wizard answers.
 type initConfig struct {
 	Name            string
@@ -301,7 +376,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	if interactive && len(args) == 0 {
 		// Load any existing config to pre-populate wizard defaults.
-		existingName, existingGitTrackingMode, existingGitTracking, existingSemanticEnabled, existingSemanticModel := defaultsForWizard(cwd, globalDefaults)
+		existingName, existingGitTrackingMode, existingGitTracking, existingSemanticEnabled, existingSemanticModel, existingPlatforms := defaultsForWizard(cwd, globalDefaults)
 		if existingCfg, err := storage.NewStore(root).Config.Load(); err == nil {
 			existingName = existingCfg.Name
 			existingGitTrackingMode = existingCfg.Settings.GitTrackingMode
@@ -313,10 +388,13 @@ func runInit(cmd *cobra.Command, args []string) error {
 				existingSemanticEnabled = &enabled
 				existingSemanticModel = existingCfg.Settings.SemanticSearch.Model
 			}
+			if len(existingCfg.Settings.Platforms) > 0 {
+				existingPlatforms = existingCfg.Settings.Platforms
+			}
 		}
 
 		// Run full wizard with huh
-		wizardCfg, err := runWizard(cwd, gitTracked, gitIgnored, gitAvailable, existingName, existingGitTrackingMode, existingGitTracking, existingSemanticEnabled, existingSemanticModel)
+		wizardCfg, err := runWizard(cwd, gitTracked, gitIgnored, gitAvailable, existingName, existingGitTrackingMode, existingGitTracking, existingSemanticEnabled, existingSemanticModel, existingPlatforms)
 		if err != nil {
 			if err == huh.ErrUserAborted {
 				fmt.Println(warnStyle.Render("Setup cancelled."))
@@ -339,7 +417,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		enableSemantic := isTTY()
 		semanticModel := "multilingual-e5-small"
 		embeddingSource := "local"
-		platforms := []string{"claude-code", "agents"}
+		platforms := defaultInstructionPlatforms()
 		enableChatUI := true
 		if globalDefaults != nil {
 			if globalDefaults.Settings.GitTrackingMode != "" {
@@ -473,6 +551,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 				return writeKnownsGitignore(cwd, cfg.GitTrackingMode, &cfg.GitTracking)
 			},
 		},
+		{
+			label: "Creating project instruction files",
+			run: func() error {
+				return createInstructionFilesForPlatforms(cwd, force, cfg.Platforms)
+			},
+		},
 	}
 
 	if !hasGitRepo && gitAvailable {
@@ -576,15 +660,16 @@ func loadGlobalProjectDefaults() (*storage.ProjectDefaults, error) {
 	return settings.ProjectDefaults, nil
 }
 
-func defaultsForWizard(cwd string, defaults *storage.ProjectDefaults) (string, string, *models.GitTracking, *bool, string) {
+func defaultsForWizard(cwd string, defaults *storage.ProjectDefaults) (string, string, *models.GitTracking, *bool, string, []string) {
 	name := filepath.Base(cwd)
 	var gitMode string
 	var gitTracking *models.GitTracking
 	var semanticEnabled *bool
 	var semanticModel string
+	platforms := defaultInstructionPlatforms()
 
 	if defaults == nil {
-		return name, gitMode, gitTracking, semanticEnabled, semanticModel
+		return name, gitMode, gitTracking, semanticEnabled, semanticModel, platforms
 	}
 	if defaults.ProjectName != "" {
 		name = defaults.ProjectName
@@ -596,10 +681,13 @@ func defaultsForWizard(cwd string, defaults *storage.ProjectDefaults) (string, s
 		semanticEnabled = &enabled
 		semanticModel = defaults.Settings.SemanticSearch.Model
 	}
-	return name, gitMode, gitTracking, semanticEnabled, semanticModel
+	if len(defaults.Settings.Platforms) > 0 {
+		platforms = defaults.Settings.Platforms
+	}
+	return name, gitMode, gitTracking, semanticEnabled, semanticModel, platforms
 }
 
-func runWizard(cwd string, gitTracked, gitIgnored bool, gitAvailable bool, existingName string, existingGitTrackingMode string, existingGitTracking *models.GitTracking, existingSemanticEnabled *bool, existingSemanticModel string) (*initConfig, error) {
+func runWizard(cwd string, gitTracked, gitIgnored bool, gitAvailable bool, existingName string, existingGitTrackingMode string, existingGitTracking *models.GitTracking, existingSemanticEnabled *bool, existingSemanticModel string, existingPlatforms []string) (*initConfig, error) {
 	defaultName := filepath.Base(cwd)
 	if existingName != "" {
 		defaultName = existingName
@@ -666,6 +754,20 @@ func runWizard(cwd string, gitTracked, gitIgnored bool, gitAvailable bool, exist
 	if gitGroup != nil {
 		groups = append(groups, gitGroup)
 	}
+	cfg.Platforms = normalizeInstructionPlatforms(existingPlatforms)
+	groups = append(groups, huh.NewGroup(
+		huh.NewMultiSelect[string]().
+			Title("Project instruction files").
+			Description("KNOWNS.md is always created as the canonical project guidance. Choose compatibility shims for agents that read project files.").
+			Options(instructionPlatformOptions(cfg.Platforms)...).
+			Validate(func(s []string) error {
+				if len(s) == 0 {
+					return fmt.Errorf("select at least one instruction file")
+				}
+				return nil
+			}).
+			Value(&cfg.Platforms),
+	))
 
 	form := huh.NewForm(groups...).
 		WithTheme(huh.ThemeCatppuccin()).
@@ -1223,7 +1325,7 @@ func createInstructionFilesForPlatforms(projectRoot string, force bool, platform
 	}
 
 	for _, f := range defaultInstructionFiles {
-		if !hasPlatform(platforms, f.PlatformID) {
+		if !shouldCreateInstructionFile(platforms, f) {
 			continue
 		}
 		if err := writeInstructionFile(projectRoot, f.Path, f.Platform, force); err != nil {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -183,6 +183,17 @@ func TestRunInitNoWizardUsesGlobalDefaults(t *testing.T) {
 	if !ok || len(platforms) != 2 || platforms[0] != "codex" || platforms[1] != "agents" {
 		t.Fatalf("expected global platforms, got %#v", settings["platforms"])
 	}
+	assertContains(t, readTextFile(t, filepath.Join(projectRoot, "KNOWNS.md")), "# KNOWNS")
+	assertContains(t, readTextFile(t, filepath.Join(projectRoot, "AGENTS.md")), "Compatibility entrypoint")
+	if _, err := os.Stat(filepath.Join(projectRoot, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected CLAUDE.md not to be created when global defaults select codex+agents, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectRoot, ".codex", "config.toml")); !os.IsNotExist(err) {
+		t.Fatalf("expected init not to create project Codex config, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectRoot, ".mcp.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected init not to create project MCP config, got err=%v", err)
+	}
 }
 
 func TestSettingsCommandSurface(t *testing.T) {
@@ -603,6 +614,20 @@ func TestCreateInstructionFilesQuietIncludesOpenCode(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(projectRoot, "OPENCODE.md")); err != nil {
 		t.Fatalf("expected OPENCODE.md to be created: %v", err)
+	}
+}
+
+func TestCreateInstructionFilesForCodexCreatesAgentsShimOnly(t *testing.T) {
+	projectRoot := t.TempDir()
+
+	if err := createInstructionFilesForPlatforms(projectRoot, false, []string{"codex"}); err != nil {
+		t.Fatalf("createInstructionFilesForPlatforms returned error: %v", err)
+	}
+
+	assertContains(t, readTextFile(t, filepath.Join(projectRoot, "KNOWNS.md")), "# KNOWNS")
+	assertContains(t, readTextFile(t, filepath.Join(projectRoot, "AGENTS.md")), "Compatibility entrypoint")
+	if _, err := os.Stat(filepath.Join(projectRoot, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected CLAUDE.md not to be created for codex-only instructions, got err=%v", err)
 	}
 }
 

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -52,7 +53,7 @@ func TestCreateOpenCodeConfigQuietCreatesConfig(t *testing.T) {
 	}
 }
 
-func TestRunInitFallsBackWhenTerminalTooNarrow(t *testing.T) {
+func TestRunInitStopsWhenTerminalTooNarrow(t *testing.T) {
 	projectRoot := t.TempDir()
 	oldWD, err := os.Getwd()
 	if err != nil {
@@ -105,12 +106,100 @@ func TestRunInitFallsBackWhenTerminalTooNarrow(t *testing.T) {
 	_ = w.Close()
 	<-done
 
-	if !strings.Contains(stdout.String(), "Terminal width is too small for the interactive setup wizard") {
+	if !strings.Contains(stdout.String(), "Terminal is too small for the interactive setup wizard") {
 		t.Fatalf("expected narrow-terminal warning, got:\n%s", stdout.String())
 	}
-	if _, err := os.Stat(filepath.Join(projectRoot, ".knowns", "config.json")); err != nil {
-		t.Fatalf("expected init to continue with defaults, config missing: %v", err)
+	if !strings.Contains(stdout.String(), "knowns init --no-wizard") {
+		t.Fatalf("expected no-wizard guidance, got:\n%s", stdout.String())
 	}
+	if _, err := os.Stat(filepath.Join(projectRoot, ".knowns", "config.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected init to stop without config creation, got err: %v", err)
+	}
+}
+
+func TestRunInitNoWizardUsesGlobalDefaults(t *testing.T) {
+	home := t.TempDir()
+	projectRoot := t.TempDir()
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWD) }()
+	if err := os.Chdir(projectRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+
+	settingsPath := filepath.Join(home, ".knowns", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	writeJSONFile(t, settingsPath, map[string]any{
+		"projectDefaults": map[string]any{
+			"projectName": "global-default-project",
+			"settings": map[string]any{
+				"gitTrackingMode": "git-ignored",
+				"platforms":       []string{"codex", "agents"},
+				"enableChatUI":    false,
+			},
+		},
+	})
+
+	execLookPath = func(string) (string, error) { return "", os.ErrNotExist }
+	t.Cleanup(func() { execLookPath = defaultExecLookPath })
+	setInitBoolFlag(t, "no-wizard", true)
+	setInitBoolFlag(t, "no-open", true)
+	setInitBoolFlag(t, "git-tracked", false)
+	setInitBoolFlag(t, "git-ignored", false)
+	setInitBoolFlag(t, "force", false)
+
+	if err := runInit(initCmd, nil); err != nil {
+		t.Fatalf("runInit returned error: %v", err)
+	}
+
+	config := readJSONFile(t, filepath.Join(projectRoot, ".knowns", "config.json"))
+	if got := config["name"]; got != "global-default-project" {
+		t.Fatalf("expected global project name, got %#v", got)
+	}
+	settings := getMap(t, config, "settings")
+	if got := settings["gitTrackingMode"]; got != "git-ignored" {
+		t.Fatalf("expected global gitTrackingMode, got %#v", got)
+	}
+	if got := settings["enableChatUI"]; got != false {
+		t.Fatalf("expected global enableChatUI false, got %#v", got)
+	}
+	platforms, ok := settings["platforms"].([]any)
+	if !ok || len(platforms) != 2 || platforms[0] != "codex" || platforms[1] != "agents" {
+		t.Fatalf("expected global platforms, got %#v", settings["platforms"])
+	}
+}
+
+func TestSettingsCommandSurface(t *testing.T) {
+	if settingsCmd.Flags().Lookup("global") == nil {
+		t.Fatalf("expected settings --global flag to be registered")
+	}
+	for _, child := range configCmd.Commands() {
+		if child.Name() == "toggle" {
+			t.Fatalf("knowns config toggle must not be registered")
+		}
+	}
+}
+
+func setInitBoolFlag(t *testing.T, name string, value bool) {
+	t.Helper()
+	flag := initCmd.Flags().Lookup(name)
+	if flag == nil {
+		t.Fatalf("missing init flag %q", name)
+	}
+	old := flag.Value.String()
+	if err := initCmd.Flags().Set(name, strconv.FormatBool(value)); err != nil {
+		t.Fatalf("set flag %s: %v", name, err)
+	}
+	t.Cleanup(func() { _ = initCmd.Flags().Set(name, old) })
 }
 
 func TestCreateMCPJsonFileQuietUsesNpxKnowns(t *testing.T) {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -129,10 +129,17 @@ func TestRunInitNoWizardUsesGlobalDefaults(t *testing.T) {
 		t.Fatalf("chdir: %v", err)
 	}
 	oldHome := os.Getenv("HOME")
+	oldUserProfile := os.Getenv("USERPROFILE")
 	if err := os.Setenv("HOME", home); err != nil {
 		t.Fatalf("set HOME: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+	if err := os.Setenv("USERPROFILE", home); err != nil {
+		t.Fatalf("set USERPROFILE: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", oldHome)
+		_ = os.Setenv("USERPROFILE", oldUserProfile)
+	})
 
 	settingsPath := filepath.Join(home, ".knowns", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -258,7 +258,7 @@ func (m *downloadModel) startDownload() tea.Cmd {
 	dst := m.dst
 	return func() tea.Msg {
 		client := &http.Client{Timeout: 30 * time.Minute}
-		resp, err := client.Get(url)
+		resp, err := downloadGetWithRetry(client, url)
 		if err != nil {
 			return progressErrMsg{err}
 		}
@@ -302,9 +302,63 @@ func (m *downloadModel) startDownload() tea.Cmd {
 	}
 }
 
+func downloadGetWithRetry(client *http.Client, url string) (*http.Response, error) {
+	const maxAttempts = 4
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		resp, err := client.Get(url)
+		if err != nil {
+			lastErr = err
+		} else if !downloadRetryableStatus(resp.StatusCode) {
+			return resp, nil
+		} else {
+			lastErr = fmt.Errorf("HTTP %d", resp.StatusCode)
+			if attempt == maxAttempts {
+				return resp, nil
+			}
+			delay := downloadRetryDelay(attempt, resp)
+			resp.Body.Close()
+			time.Sleep(delay)
+			continue
+		}
+
+		if attempt == maxAttempts {
+			break
+		}
+		time.Sleep(downloadRetryDelay(attempt, nil))
+	}
+
+	return nil, lastErr
+}
+
+func downloadRetryableStatus(statusCode int) bool {
+	return statusCode == http.StatusRequestTimeout ||
+		statusCode == http.StatusTooManyRequests ||
+		statusCode >= http.StatusInternalServerError
+}
+
+func downloadRetryDelay(attempt int, resp *http.Response) time.Duration {
+	if resp != nil {
+		if retryAfter := strings.TrimSpace(resp.Header.Get("Retry-After")); retryAfter != "" {
+			if seconds, err := time.ParseDuration(retryAfter + "s"); err == nil && seconds > 0 {
+				return min(seconds, 30*time.Second)
+			}
+			if when, err := http.ParseTime(retryAfter); err == nil {
+				if delay := time.Until(when); delay > 0 {
+					return min(delay, 30*time.Second)
+				}
+			}
+		}
+	}
+
+	delay := time.Duration(attempt*attempt) * time.Second
+	return min(delay, 15*time.Second)
+}
+
 func downloadSimple(url, dst string) (int64, error) {
 	client := &http.Client{Timeout: 30 * time.Minute}
-	resp, err := client.Get(url)
+	resp, err := downloadGetWithRetry(client, url)
 	if err != nil {
 		return 0, err
 	}
@@ -318,7 +372,11 @@ func downloadSimple(url, dst string) (int64, error) {
 	}
 	defer out.Close()
 	n, err := io.Copy(out, resp.Body)
-	return n, err
+	if err != nil {
+		_ = os.Remove(dst)
+		return 0, err
+	}
+	return n, nil
 }
 
 // progressWriter wraps an io.Writer and tracks bytes written.

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/charmbracelet/huh"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
 	"github.com/howznguyen/knowns/internal/codegen"
 	"github.com/howznguyen/knowns/internal/runtimeinstall"
 	"github.com/spf13/cobra"
@@ -24,6 +24,7 @@ Targets:
   opencode  Generate OPENCODE.md, KNOWNS.md, opencode.json, skills, and runtime hooks
   copilot   Generate .github/copilot-instructions.md and KNOWNS.md
   kiro      Generate .kiro steering/settings, KNOWNS.md, skills, and runtime hooks
+  agents    Generate AGENTS.md and KNOWNS.md
   all       Generate all supported AI integration files
 
 Use --global to install at user-level paths (no project required).
@@ -84,12 +85,14 @@ func runSetupCmd(cmd *cobra.Command, args []string) error {
 			platforms = []string{"cursor"}
 		case "gemini":
 			platforms = []string{"gemini"}
+		case "agents":
+			platforms = []string{"agents"}
 		case "antigravity":
 			platforms = []string{"antigravity"}
 		case "all":
 			platforms = allPlatformIDs
 		default:
-			return fmt.Errorf("unknown setup target %q (expected: claude, opencode, copilot, kiro, codex, cursor, gemini, antigravity, all)", target)
+			return fmt.Errorf("unknown setup target %q (expected: claude, opencode, copilot, kiro, codex, cursor, gemini, antigravity, agents, all)", target)
 		}
 	}
 
@@ -125,7 +128,7 @@ func runSetupSelector() ([]string, error) {
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Title("AI platforms to integrate").
-				Description("Choose which platforms to generate config and instruction files for.\n"+
+				Description("Choose which platforms to generate config and instruction files for.\n" +
 					"At least one platform must be selected.").
 				Options(platformOptions...).
 				Validate(func(s []string) error {

--- a/internal/cli/setup_global.go
+++ b/internal/cli/setup_global.go
@@ -43,12 +43,14 @@ func runGlobalSetup(cmd *cobra.Command, args []string, force bool) error {
 			platforms = []string{"cursor"}
 		case "gemini":
 			platforms = []string{"gemini"}
+		case "agents":
+			platforms = []string{"agents"}
 		case "antigravity":
 			platforms = []string{"antigravity"}
 		case "all":
 			platforms = allPlatformIDs
 		default:
-			return fmt.Errorf("unknown setup target %q (expected: claude, opencode, copilot, kiro, codex, cursor, gemini, antigravity, all)", target)
+			return fmt.Errorf("unknown setup target %q (expected: claude, opencode, copilot, kiro, codex, cursor, gemini, antigravity, agents, all)", target)
 		}
 	}
 
@@ -67,7 +69,7 @@ func buildGlobalSetupSteps(force bool, platforms []string) []initStep {
 	var steps []initStep
 
 	// 1. Global skills
-	if hasPlatform(platforms, "claude-code") || hasPlatform(platforms, "kiro") || hasPlatform(platforms, "codex") || hasPlatform(platforms, "opencode") || hasPlatform(platforms, "antigravity") || hasPlatform(platforms, "cursor") || hasPlatform(platforms, "gemini") {
+	if hasPlatform(platforms, "claude-code") || hasPlatform(platforms, "kiro") || hasPlatform(platforms, "codex") || hasPlatform(platforms, "opencode") || hasPlatform(platforms, "antigravity") || hasPlatform(platforms, "cursor") || hasPlatform(platforms, "gemini") || hasPlatform(platforms, "agents") {
 		steps = append(steps, initStep{
 			label: "Syncing global skills",
 			run: func() error {
@@ -343,6 +345,7 @@ func setupGlobalCodexMCP(home string) error {
 
 	return os.WriteFile(configPath, []byte(content), 0644)
 }
+
 // --- Global skills ---
 
 func syncGlobalSkills(home string, platforms []string) error {
@@ -354,7 +357,7 @@ func syncGlobalSkills(home string, platforms []string) error {
 		targets["kiro"] = filepath.Join(home, ".kiro", "skills")
 	}
 	// All other platforms share ~/.agents/skills/ (agentskills.io standard)
-	for _, p := range []string{"codex", "opencode", "antigravity", "gemini", "cursor"} {
+	for _, p := range []string{"codex", "opencode", "antigravity", "gemini", "cursor", "agents"} {
 		if hasPlatform(platforms, p) {
 			targets["agents"] = filepath.Join(home, ".agents", "skills")
 			break

--- a/internal/references/references.go
+++ b/internal/references/references.go
@@ -4,11 +4,13 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/howznguyen/knowns/internal/models"
 )
 
-var referenceRE = regexp.MustCompile(`@(task-[A-Za-z0-9.-]+(?:\{[a-z-]+\})?|memory-[A-Za-z0-9-]+(?:\{[a-z-]+\})?|doc/[^\s\)]+)`)
+var taskReferenceRE = regexp.MustCompile(`^@task-[A-Za-z0-9.-]+(?:\{[a-z-]+\})?`)
+var memoryReferenceRE = regexp.MustCompile(`^@memory-[A-Za-z0-9-]+(?:\{[a-z-]+\})?`)
 var docRangeSuffixRE = regexp.MustCompile(`:(\d+)-(\d+)$`)
 var docLineSuffixRE = regexp.MustCompile(`:(\d+)$`)
 
@@ -40,19 +42,41 @@ func AllowedRelation(relation string) bool {
 }
 
 func Extract(content string) []models.SemanticReference {
-	matches := referenceRE.FindAllString(content, -1)
-	refs := make([]models.SemanticReference, 0, len(matches))
-	for _, match := range matches {
+	refs := []models.SemanticReference{}
+	inCodeBlock := false
+
+	for i := 0; i < len(content); {
+		if isLineStart(content, i) && strings.HasPrefix(content[i:], "```") {
+			inCodeBlock = !inCodeBlock
+			i += 3
+			continue
+		}
+		if inCodeBlock {
+			i++
+			continue
+		}
+		if content[i] != '@' {
+			i++
+			continue
+		}
+
+		match := extractReferenceAt(content[i:])
+		if match == "" {
+			i++
+			continue
+		}
+
 		ref, ok := Parse(match)
 		if ok {
 			refs = append(refs, ref)
 		}
+		i += len(match)
 	}
 	return refs
 }
 
 func Parse(raw string) (models.SemanticReference, bool) {
-	raw = strings.TrimSpace(strings.TrimRight(raw, ".,;"))
+	raw = strings.TrimSpace(trimTrailingPunctuation(raw))
 	if raw == "" || !strings.HasPrefix(raw, "@") {
 		return models.SemanticReference{}, false
 	}
@@ -116,9 +140,154 @@ func parseDocTarget(value string) (string, *models.DocReferenceFragment) {
 		value = strings.TrimSuffix(value, m[0])
 	}
 
-	value = strings.TrimRight(value, ".,;")
+	value = trimTrailingPunctuation(value)
 	if fragment.Raw == "" {
 		fragment = nil
 	}
 	return value, fragment
+}
+
+func extractReferenceAt(content string) string {
+	switch {
+	case strings.HasPrefix(content, "@doc/"):
+		return extractDocReferenceAt(content)
+	case strings.HasPrefix(content, "@task-"):
+		return taskReferenceRE.FindString(content)
+	case strings.HasPrefix(content, "@memory-"):
+		return memoryReferenceRE.FindString(content)
+	default:
+		return ""
+	}
+}
+
+func extractDocReferenceAt(content string) string {
+	i := len("@doc/")
+	if i >= len(content) || !isDocPathChar(rune(content[i])) {
+		return ""
+	}
+
+	for i < len(content) {
+		r := rune(content[i])
+		switch {
+		case isDocPathChar(r):
+			i++
+		case r == '#':
+			next := consumeDocHeading(content, i)
+			if next == i {
+				return content[:i]
+			}
+			i = next
+		case r == ':':
+			next := consumeDocLineSuffix(content, i)
+			if next == i {
+				return content[:i]
+			}
+			i = next
+		case r == '{':
+			next := consumeRelationSuffix(content, i)
+			if next == i {
+				return content[:i]
+			}
+			i = next
+			return content[:i]
+		default:
+			return content[:i]
+		}
+	}
+
+	return content[:i]
+}
+
+func consumeDocHeading(content string, start int) int {
+	i := start + 1
+	for i < len(content) {
+		r := rune(content[i])
+		if !isDocHeadingChar(r) {
+			break
+		}
+		i++
+	}
+	if i == start+1 {
+		return start
+	}
+	return i
+}
+
+func consumeDocLineSuffix(content string, start int) int {
+	i := start + 1
+	rangeSeparatorSeen := false
+	digitsBeforeSeparator := 0
+	digitsAfterSeparator := 0
+
+	for i < len(content) {
+		r := rune(content[i])
+		switch {
+		case r >= '0' && r <= '9':
+			if rangeSeparatorSeen {
+				digitsAfterSeparator++
+			} else {
+				digitsBeforeSeparator++
+			}
+			i++
+		case r == '-' && !rangeSeparatorSeen && digitsBeforeSeparator > 0:
+			rangeSeparatorSeen = true
+			i++
+		default:
+			goto done
+		}
+	}
+
+done:
+	if digitsBeforeSeparator == 0 || (rangeSeparatorSeen && digitsAfterSeparator == 0) {
+		return start
+	}
+	return i
+}
+
+func consumeRelationSuffix(content string, start int) int {
+	i := start + 1
+	for i < len(content) {
+		r := rune(content[i])
+		if (r >= 'a' && r <= 'z') || r == '-' {
+			i++
+			continue
+		}
+		break
+	}
+	if i == start+1 || i >= len(content) || content[i] != '}' {
+		return start
+	}
+	return i + 1
+}
+
+func isDocPathChar(r rune) bool {
+	return (r >= 'A' && r <= 'Z') ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= '0' && r <= '9') ||
+		r == '/' ||
+		r == '_' ||
+		r == '-' ||
+		r == '.'
+}
+
+func isDocHeadingChar(r rune) bool {
+	return (r >= 'A' && r <= 'Z') ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= '0' && r <= '9') ||
+		r == '_' ||
+		r == '-' ||
+		r == '.'
+}
+
+func isLineStart(content string, i int) bool {
+	if i == 0 {
+		return true
+	}
+	return content[i-1] == '\n'
+}
+
+func trimTrailingPunctuation(value string) string {
+	return strings.TrimRightFunc(value, func(r rune) bool {
+		return unicode.IsSpace(r) || strings.ContainsRune(".,;:!?`'\"", r)
+	})
 }

--- a/internal/storage/embedding_settings_store.go
+++ b/internal/storage/embedding_settings_store.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/howznguyen/knowns/internal/models"
 )
 
 // RetryConfig configures exponential backoff for API rate limiting.
@@ -36,9 +38,16 @@ type EmbeddingModel struct {
 
 // EmbeddingSettings holds the global embedding provider and model registry.
 type EmbeddingSettings struct {
-	Providers            map[string]EmbeddingProvider `json:"embeddingProviders,omitempty"`
-	Models               map[string]EmbeddingModel    `json:"embeddingModels,omitempty"`
-	DefaultEmbeddingModel string                      `json:"defaultEmbeddingModel,omitempty"`
+	Providers             map[string]EmbeddingProvider `json:"embeddingProviders,omitempty"`
+	Models                map[string]EmbeddingModel    `json:"embeddingModels,omitempty"`
+	DefaultEmbeddingModel string                       `json:"defaultEmbeddingModel,omitempty"`
+	ProjectDefaults       *ProjectDefaults             `json:"projectDefaults,omitempty"`
+}
+
+// ProjectDefaults are user-level defaults applied by future `knowns init` runs.
+type ProjectDefaults struct {
+	ProjectName string                 `json:"projectName,omitempty"`
+	Settings    models.ProjectSettings `json:"settings,omitempty"`
 }
 
 // EmbeddingSettingsStore reads and writes ~/.knowns/settings.json.

--- a/tests/e2e_cli_test.go
+++ b/tests/e2e_cli_test.go
@@ -421,14 +421,22 @@ func TestCLI_SemanticSearch(t *testing.T) {
 	})
 
 	// Step 2: Model download (180s timeout for network download)
+	modelDownloaded := false
 	t.Run("model download", func(t *testing.T) {
 		res := runCliWithTimeout(t, dir, 180*time.Second, "model", "download", "all-MiniLM-L6-v2")
-		requireSuccess(t, res)
 		output := res.Stdout + res.Stderr
+		if res.ExitCode != 0 && strings.Contains(output, "HTTP 429") {
+			t.Skipf("skipping semantic search test: model download was rate limited: %s", truncate(output, 300))
+		}
+		requireSuccess(t, res)
+		modelDownloaded = true
 		if !strings.Contains(output, "downloaded") && !strings.Contains(output, "already installed") {
 			t.Logf("download output: %s", truncate(output, 500))
 		}
 	})
+	if !modelDownloaded {
+		t.Skip("skipping semantic search test: embedding model is unavailable")
+	}
 
 	// Step 3: Model set
 	t.Run("model set", func(t *testing.T) {
@@ -519,4 +527,3 @@ func TestCLI_Board(t *testing.T) {
 		requireSuccess(t, res)
 	})
 }
-

--- a/ui/src/pages/ConfigPage.tsx
+++ b/ui/src/pages/ConfigPage.tsx
@@ -1205,7 +1205,7 @@ export default function ConfigPage() {
 													{disabled && (
 														<div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
 															<PowerOff className="h-3.5 w-3.5" />
-															Enable via settings/config toggle to start this service.
+															Enable via settings or config set to start this service.
 														</div>
 													)}
 												</div>


### PR DESCRIPTION
## Description

feat(settings): add first-run setup pipeline

- Add interactive settings defaults so first-time setup can reuse global choices for init, semantic search, platforms, and code intelligence

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Other (please describe):