### PR TITLE
release: promote v0.29.0 to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,11 @@ jobs:
 
       - name: Run platform and keyword fallback tests
         run: |
-          go test ./internal/search ./internal/cli ./internal/server/routes ./internal/doctor
+          # Existing local-provider unit tests use mocked embedders and assume
+          # a supported runtime. Model that explicit Intel opt-in here; the
+          # commands below run without the override and verify the disabled path.
+          KNOWNS_ORT_LIB="${RUNNER_TEMP}/libonnxruntime-test.dylib" \
+            go test ./internal/search ./internal/cli ./internal/server/routes ./internal/doctor
           go test ./internal/search -run '^TestKeywordModeUsesBM25WithoutSemanticAndPreservesResultShape$'
           bun test npm/knowns/install.test.js
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,79 @@ jobs:
           path: ${{ runner.temp }}/retrieval-evaluation-keyword.json
           if-no-files-found: error
 
+  macos-intel:
+    runs-on: macos-15-intel
+    needs: [test]
+    timeout-minutes: 20
+    name: macOS Intel CLI Smoke
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Build UI
+        run: cd ui && bun install --frozen-lockfile && bun run build
+
+      - name: Run platform and keyword fallback tests
+        run: |
+          go test ./internal/search ./internal/cli ./internal/server/routes ./internal/doctor
+          go test ./internal/search -run '^TestKeywordModeUsesBM25WithoutSemanticAndPreservesResultShape$'
+          bun test npm/knowns/install.test.js
+
+      - name: Build native Intel binary without ONNX Runtime
+        env:
+          CGO_ENABLED: '1'
+        run: go build -ldflags "-s -w -X github.com/howznguyen/knowns/internal/util.Version=${GITHUB_SHA}" -o bin/knowns ./cmd/knowns
+
+      - name: Verify installer and disabled Local ONNX path
+        shell: bash
+        run: |
+          file bin/knowns | grep -q "Mach-O 64-bit"
+          file bin/knowns | grep -q "x86_64"
+          test ! -e bin/libonnxruntime.dylib
+          ./bin/knowns --version
+
+          export KNOWNS_INSTALLER_TEST=1
+          source install/install.sh
+          detect_platform
+          test "$PLATFORM" = "darwin-x64"
+
+          output=$(./bin/knowns model download gte-small 2>&1) && {
+            echo "Local ONNX model download unexpectedly succeeded"
+            exit 1
+          }
+          echo "$output" | grep -q "Local ONNX is not bundled for macOS Intel"
+
+          smoke_dir=$(mktemp -d)
+          (
+            cd "$smoke_dir"
+            git init -q
+            export KNOWN_LSP_AUTO_INSTALL=0
+            export NO_UPDATE_CHECK=1
+            "$GITHUB_WORKSPACE/bin/knowns" init "Intel Smoke" --no-wizard --no-open
+            config_output=$("$GITHUB_WORKSPACE/bin/knowns" config set semanticSearch true 2>&1) && {
+              echo "Local ONNX config unexpectedly succeeded"
+              exit 1
+            }
+            echo "$config_output" | grep -q "Local ONNX is not bundled for macOS Intel"
+            sync_output=$("$GITHUB_WORKSPACE/bin/knowns" sync --model 2>&1)
+            echo "$sync_output"
+            echo "$sync_output" | grep -q "keyword/BM25 search remains active"
+
+            bun -e 'const fs = require("fs"); const p = ".knowns/config.json"; const c = JSON.parse(fs.readFileSync(p, "utf8")); c.settings.semanticSearch = { enabled: true, provider: "local", model: "gte-small", huggingFaceId: "Xenova/gte-small", dimensions: 384, maxTokens: 512 }; fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");'
+            export KNOWN_RUNTIME_INLINE=1
+            status_output=$("$GITHUB_WORKSPACE/bin/knowns" search --status-check 2>&1)
+            echo "$status_output" | grep -q "ONNX runtime: unavailable on macOS Intel"
+            setup_output=$("$GITHUB_WORKSPACE/bin/knowns" search --setup 2>&1)
+            echo "$setup_output" | grep -q "Local ONNX setup is unavailable on macOS Intel"
+            "$GITHUB_WORKSPACE/bin/knowns" task create "Intel keyword fallback" --description "BM25 remains available without ONNX"
+            search_output=$("$GITHUB_WORKSPACE/bin/knowns" search "Intel keyword fallback" --plain 2>&1)
+            echo "$search_output"
+            echo "$search_output" | grep -q "Matched by: keyword"
+          )
+
   retrieval-semantic-evaluation:
     runs-on: ubuntu-latest
     needs: [test]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,6 +135,14 @@ jobs:
             ext: ""
             cgo_enabled: "1"
             ort_lib: libonnxruntime.dylib
+            bundle_onnx: "true"
+          - runner: macos-15-intel
+            goos: darwin
+            goarch: amd64
+            npm_pkg: knowns-darwin-x64
+            ext: ""
+            cgo_enabled: "1"
+            bundle_onnx: "false"
           - runner: ubuntu-latest
             goos: linux
             goarch: amd64
@@ -142,6 +150,7 @@ jobs:
             ext: ""
             cgo_enabled: "1"
             ort_lib: libonnxruntime.so
+            bundle_onnx: "true"
           - runner: ubuntu-24.04-arm
             goos: linux
             goarch: arm64
@@ -149,6 +158,7 @@ jobs:
             ext: ""
             cgo_enabled: "1"
             ort_lib: libonnxruntime.so
+            bundle_onnx: "true"
           - runner: windows-latest
             goos: windows
             goarch: amd64
@@ -156,6 +166,7 @@ jobs:
             ext: ".exe"
             cgo_enabled: "1"
             ort_lib: onnxruntime.dll
+            bundle_onnx: "true"
             llvm_mingw_archive: llvm-mingw-20260407-ucrt-x86_64.zip
             llvm_mingw_prefix: x86_64-w64-mingw32
     runs-on: ${{ matrix.runner }}
@@ -204,7 +215,7 @@ jobs:
           path: ui/dist/
 
       - name: Run npm installer tests
-        if: matrix.goos == 'windows'
+        if: matrix.goos == 'windows' || (matrix.goos == 'darwin' && matrix.goarch == 'amd64')
         run: bun test npm/knowns/install.test.js
 
       - name: Trace downloaded UI artifact
@@ -234,6 +245,7 @@ jobs:
           go build -ldflags "$LDFLAGS" -o "artifacts/${{ matrix.npm_pkg }}/knowns${{ matrix.ext }}" ./cmd/knowns
 
       - name: Bundle ONNX Runtime native library
+        if: matrix.bundle_onnx == 'true'
         env:
           ORT_VERSION: "1.25.0"
         run: |
@@ -284,6 +296,22 @@ jobs:
           echo "=== Artifact contents ==="
           ls -la "${ARTIFACT_DIR}/"
 
+      - name: Verify macOS Intel package without bundled ONNX
+        if: matrix.goos == 'darwin' && matrix.goarch == 'amd64'
+        run: |
+          ARTIFACT_DIR="artifacts/${{ matrix.npm_pkg }}"
+          test -x "${ARTIFACT_DIR}/knowns"
+          if find "${ARTIFACT_DIR}" -maxdepth 1 -name '*onnxruntime*' | grep -q .; then
+            echo "FATAL: macOS Intel package must not bundle ONNX Runtime"
+            exit 1
+          fi
+          "${ARTIFACT_DIR}/knowns" --version
+          output=$("${ARTIFACT_DIR}/knowns" model download gte-small 2>&1) && {
+            echo "FATAL: Local ONNX model download unexpectedly succeeded"
+            exit 1
+          }
+          echo "$output" | grep -q "Local ONNX is not bundled for macOS Intel"
+
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
@@ -328,7 +356,7 @@ jobs:
         run: |
           cp README.md npm/knowns/README.md
 
-          PLATFORM_PKGS="knowns-darwin-arm64 knowns-linux-arm64 knowns-linux-x64 knowns-win-x64"
+          PLATFORM_PKGS="knowns-darwin-arm64 knowns-darwin-x64 knowns-linux-arm64 knowns-linux-x64 knowns-win-x64"
 
           for pkg in $PLATFORM_PKGS; do
             (
@@ -375,6 +403,7 @@ jobs:
               pkg.bin = { knowns: 'bin/knowns.js', kn: 'bin/knowns.js' };
               pkg.optionalDependencies = {
                 '@knowns/darwin-arm64': version,
+                '@knowns/darwin-x64': version,
                 '@knowns/linux-arm64': version,
                 '@knowns/linux-x64': version,
                 '@knowns/win-x64': version,
@@ -406,6 +435,12 @@ jobs:
             echo "✓ $pkg/libonnxruntime.dylib"
           done
 
+          if find npm/knowns-darwin-x64 -maxdepth 1 -name '*onnxruntime*' | grep -q .; then
+            echo "FATAL: npm/knowns-darwin-x64 must not contain ONNX Runtime"
+            exit 1
+          fi
+          echo "✓ knowns-darwin-x64 intentionally excludes ONNX Runtime"
+
           # Linux: libonnxruntime.so
           for pkg in knowns-linux-arm64 knowns-linux-x64; do
             if ! ls npm/$pkg/libonnxruntime*.so* >/dev/null 2>&1; then
@@ -417,7 +452,7 @@ jobs:
           done
 
           # Main binary in all packages
-          for pkg in knowns-darwin-arm64 knowns-linux-arm64 knowns-linux-x64; do
+          for pkg in knowns-darwin-arm64 knowns-darwin-x64 knowns-linux-arm64 knowns-linux-x64; do
             if [ ! -f "npm/$pkg/knowns" ]; then
               echo "FATAL: npm/$pkg/knowns is missing!"
               exit 1
@@ -434,7 +469,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          PLATFORM_PKGS="knowns-darwin-arm64 knowns-linux-arm64 knowns-linux-x64 knowns-win-x64"
+          PLATFORM_PKGS="knowns-darwin-arm64 knowns-darwin-x64 knowns-linux-arm64 knowns-linux-x64 knowns-win-x64"
           for pkg in $PLATFORM_PKGS; do
             (
               cd "npm/$pkg"
@@ -500,6 +535,7 @@ jobs:
         run: |
           for pkgdir in \
             npm/knowns-darwin-arm64 \
+            npm/knowns-darwin-x64 \
             npm/knowns-linux-arm64 \
             npm/knowns-linux-x64 \
             npm/knowns-win-x64; do
@@ -521,6 +557,15 @@ jobs:
             tar -tzf "$archive" | grep -Fx "./knowns" >/dev/null || { echo "$archive missing knowns"; exit 1; }
             tar -tzf "$archive" | grep -E "^\./libonnxruntime.*\.dylib$" >/dev/null || { echo "$archive missing libonnxruntime dylib"; exit 1; }
           done
+
+          tar -tzf knowns-darwin-x64.tar.gz | grep -Fx "./knowns" >/dev/null || {
+            echo "knowns-darwin-x64.tar.gz missing knowns"
+            exit 1
+          }
+          if tar -tzf knowns-darwin-x64.tar.gz | grep -i "onnxruntime" >/dev/null; then
+            echo "knowns-darwin-x64.tar.gz must not contain ONNX Runtime"
+            exit 1
+          fi
 
           for archive in \
             knowns-linux-arm64.tar.gz \
@@ -554,6 +599,15 @@ jobs:
           verify_elf_arch knowns-linux-x64.tar.gz   ./knowns            "3e00" "x86_64"
           verify_elf_arch knowns-linux-arm64.tar.gz  ./knowns            "b700" "aarch64"
 
+          macho_dir=$(mktemp -d)
+          tar -xzf knowns-darwin-x64.tar.gz -C "$macho_dir"
+          (file "$macho_dir/knowns" | grep -q "Mach-O 64-bit" &&
+            file "$macho_dir/knowns" | grep -q "x86_64") || {
+            echo "FATAL: knowns-darwin-x64.tar.gz contains the wrong binary architecture"
+            exit 1
+          }
+          rm -rf "$macho_dir"
+
       - name: Ensure GitHub release exists
         if: github.event_name == 'release'
         env:
@@ -585,6 +639,7 @@ jobs:
           fi
 
           SHA_DARWIN_ARM64=$(awk '{print $1}' knowns-darwin-arm64.tar.gz.sha256)
+          SHA_DARWIN_X64=$(awk '{print $1}' knowns-darwin-x64.tar.gz.sha256)
           SHA_LINUX_X64=$(awk '{print $1}' knowns-linux-x64.tar.gz.sha256)
 
           git clone https://x-access-token:${GH_TOKEN}@github.com/knowns-dev/homebrew-tap.git
@@ -602,6 +657,10 @@ jobs:
                 url "https://github.com/knowns-dev/knowns/releases/download/v${VERSION}/knowns-darwin-arm64.tar.gz"
                 sha256 "${SHA_DARWIN_ARM64}"
               end
+              on_intel do
+                url "https://github.com/knowns-dev/knowns/releases/download/v${VERSION}/knowns-darwin-x64.tar.gz"
+                sha256 "${SHA_DARWIN_X64}"
+              end
             end
 
             on_linux do
@@ -613,7 +672,8 @@ jobs:
 
             def install
               # ONNX Runtime native lib goes into libexec so knowns can find it
-              libexec.install Dir["libonnxruntime*"]
+              onnx_libraries = Dir["libonnxruntime*"]
+              libexec.install onnx_libraries unless onnx_libraries.empty?
               bin.install "knowns"
               bin.install_symlink "knowns" => "kn"
             end

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -8,6 +8,20 @@ Install the `knowns` CLI first. Installation only makes the command available; y
 - Git if you want repository-aware init/setup behavior
 - optional local model downloads if you plan to use semantic search
 
+## Platform support
+
+| Platform | CLI artifact | Bundled local ONNX |
+| --- | --- | --- |
+| macOS Apple Silicon | `darwin-arm64` | Yes |
+| macOS Intel (x86_64) | `darwin-x64` | No |
+| Linux x64 | `linux-x64` | Yes |
+| Linux ARM64 | `linux-arm64` | Yes |
+| Windows x64 | `win32-x64` | Yes |
+
+On macOS Intel, the full CLI and keyword/BM25 search remain available. Local ONNX controls are disabled because ONNX Runtime no longer provides a compatible prebuilt macOS x86_64 library. For semantic search, use Ollama or an OpenAI-compatible API provider.
+
+Advanced users can explicitly set `KNOWN_ORT_LIB` to a compatible x86_64 `libonnxruntime.dylib`; Knowns will then enable the local ONNX provider.
+
 ## Homebrew
 
 ```bash

--- a/docs/vi/getting-started/installation.md
+++ b/docs/vi/getting-started/installation.md
@@ -8,6 +8,20 @@ Cài `knowns` CLI trước. Việc cài đặt chỉ làm cho command khả dụ
 - Git (nếu muốn `knowns init` nhận diện repo)
 - Tùy chọn: local model cho semantic search
 
+## Nền tảng được hỗ trợ
+
+| Nền tảng | Gói CLI | Local ONNX đi kèm |
+| --- | --- | --- |
+| macOS Apple Silicon | `darwin-arm64` | Có |
+| macOS Intel (x86_64) | `darwin-x64` | Không |
+| Linux x64 | `linux-x64` | Có |
+| Linux ARM64 | `linux-arm64` | Có |
+| Windows x64 | `win32-x64` | Có |
+
+Trên macOS Intel, toàn bộ CLI và tìm kiếm từ khóa/BM25 vẫn hoạt động. Các thiết lập Local ONNX được tắt vì ONNX Runtime không còn cung cấp thư viện macOS x86_64 dựng sẵn tương thích. Để dùng semantic search, hãy chọn Ollama hoặc API tương thích OpenAI.
+
+Người dùng nâng cao có thể chủ động đặt `KNOWN_ORT_LIB` trỏ đến `libonnxruntime.dylib` x86_64 tương thích; khi đó Knowns sẽ bật lại provider Local ONNX.
+
 ## Homebrew
 
 ```bash

--- a/install/install.sh
+++ b/install/install.sh
@@ -53,11 +53,6 @@ detect_platform() {
         *)             error "Unsupported architecture: $ARCH" ;;
     esac
 
-    # macOS Intel (x64) is no longer supported — ONNX Runtime 1.25.0 dropped it.
-    if [ "$OS" = "darwin" ] && [ "$ARCH" = "x64" ]; then
-        error "macOS Intel (x86_64) is no longer supported. Please use macOS on Apple Silicon (arm64)."
-    fi
-
     PLATFORM="${OS}-${ARCH}"
 }
 
@@ -252,4 +247,6 @@ main() {
     printf "  ${DIM}  curl -fsSL https://github.com/${REPO}/releases/download/${VERSION}/uninstall.sh | sh${RESET}\n\n"
 }
 
-main
+if [ "${KNOWNS_INSTALLER_TEST:-0}" != "1" ]; then
+    main
+fi

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -31,6 +31,27 @@ type localONNXModelChoice struct {
 	Installed bool
 }
 
+func semanticProviderOptions() []huh.Option[string] {
+	options := make([]huh.Option[string], 0, 3)
+	if search.CurrentLocalONNXCapability().Supported {
+		options = append(options, huh.NewOption("Local ONNX (offline)", "local"))
+	}
+	return append(options,
+		huh.NewOption("Ollama (local API)", "ollama"),
+		huh.NewOption("API (OpenAI-compatible)", "api"),
+	)
+}
+
+func normalizedSemanticProvider(provider string) string {
+	if provider == "" {
+		provider = "local"
+	}
+	if provider == "local" && !search.CurrentLocalONNXCapability().Supported {
+		return "ollama"
+	}
+	return provider
+}
+
 // --- config get ---
 
 var configGetCmd = &cobra.Command{
@@ -114,6 +135,14 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		actualKey = "settings." + key
 	}
 
+	project, err := store.Config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if err := validateConfigSetLocalONNX(project, actualKey, val, search.CurrentLocalONNXCapability()); err != nil {
+		return err
+	}
+
 	if err := store.Config.Set(actualKey, val); err != nil {
 		return fmt.Errorf("config set %q: %w", key, err)
 	}
@@ -137,6 +166,34 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println(RenderSuccess(fmt.Sprintf("Set %s = %v", key, rawVal)))
+	return nil
+}
+
+func validateConfigSetLocalONNX(project *models.Project, key string, value any, capability search.LocalONNXCapability) error {
+	if capability.Supported || project == nil {
+		return nil
+	}
+	enabled := false
+	provider := "local"
+	if settings := project.Settings.SemanticSearch; settings != nil {
+		enabled = settings.Enabled
+		if settings.Provider != "" {
+			provider = settings.Provider
+		}
+	}
+	switch key {
+	case "settings.semanticSearch.enabled":
+		if next, ok := value.(bool); ok {
+			enabled = next
+		}
+	case "settings.semanticSearch.provider":
+		if next, ok := value.(string); ok {
+			provider = next
+		}
+	}
+	if enabled && provider == "local" {
+		return fmt.Errorf("%s", capability.Reason)
+	}
 	return nil
 }
 
@@ -713,6 +770,7 @@ func configureSemanticDefaults(settings *models.ProjectSettings) error {
 			model = settings.SemanticSearch.Model
 		}
 	}
+	provider = normalizedSemanticProvider(provider)
 
 	providerForm := huh.NewForm(
 		huh.NewGroup(
@@ -723,11 +781,7 @@ func configureSemanticDefaults(settings *models.ProjectSettings) error {
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Default provider").
-				Options(
-					huh.NewOption("Local ONNX (offline)", "local"),
-					huh.NewOption("Ollama (local API)", "ollama"),
-					huh.NewOption("API (OpenAI-compatible)", "api"),
-				).
+				Options(semanticProviderOptions()...).
 				Value(&provider),
 		).WithHideFunc(func() bool { return !enabled }),
 	).WithTheme(huh.ThemeCatppuccin())
@@ -866,6 +920,9 @@ func localONNXModelSelectOptions(currentModel string) []huh.Option[string] {
 }
 
 func selectLocalONNXModel(model *string) error {
+	if err := search.RequireLocalONNX(); err != nil {
+		return err
+	}
 	if model == nil {
 		return fmt.Errorf("model value is required")
 	}
@@ -903,6 +960,9 @@ func semanticSettingsForLocalONNX(model *embeddingModel) *models.SemanticSearchS
 }
 
 func saveLocalONNXSemanticSettings(store *storage.Store, project *models.Project, model *embeddingModel) error {
+	if err := search.RequireLocalONNX(); err != nil {
+		return err
+	}
 	if store == nil {
 		return fmt.Errorf("store is required")
 	}
@@ -914,6 +974,9 @@ func saveLocalONNXSemanticSettings(store *storage.Store, project *models.Project
 }
 
 func applyLocalONNXSelection(store *storage.Store, project *models.Project, modelID string, confirmDownload func(*embeddingModel) (bool, error)) (bool, error) {
+	if err := search.RequireLocalONNX(); err != nil {
+		return false, err
+	}
 	selected := findSupportedModel(modelID)
 	if selected == nil {
 		return false, fmt.Errorf("unknown local ONNX model %q", modelID)
@@ -1029,6 +1092,7 @@ func toggleEmbedding(store *storage.Store, project *models.Project, embeddingEna
 			provider = project.Settings.SemanticSearch.Provider
 		}
 	}
+	provider = normalizedSemanticProvider(provider)
 
 	form := huh.NewForm(
 		huh.NewGroup(
@@ -1040,11 +1104,7 @@ func toggleEmbedding(store *storage.Store, project *models.Project, embeddingEna
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Provider").
-				Options(
-					huh.NewOption("Local ONNX (offline)", "local"),
-					huh.NewOption("Ollama (local API)", "ollama"),
-					huh.NewOption("API (OpenAI, etc.)", "api"),
-				).
+				Options(semanticProviderOptions()...).
 				Value(&provider),
 		).WithHideFunc(func() bool { return !enabled }),
 	).WithTheme(huh.ThemeCatppuccin())

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/howznguyen/knowns/internal/models"
+	"github.com/howznguyen/knowns/internal/search"
 	"github.com/howznguyen/knowns/internal/storage"
 )
 
@@ -154,6 +155,31 @@ func TestApplyLocalONNXSelectionDownloadsMissingModelBeforeSave(t *testing.T) {
 	}
 	if loaded.Settings.SemanticSearch.Dimensions != 768 {
 		t.Fatalf("expected gte-base dimensions, got %d", loaded.Settings.SemanticSearch.Dimensions)
+	}
+}
+
+func TestValidateConfigSetLocalONNXOnMacOSIntel(t *testing.T) {
+	unsupported := search.LocalONNXCapabilityForPlatform("darwin", "amd64", "")
+	project := &models.Project{}
+
+	if err := validateConfigSetLocalONNX(project, "settings.semanticSearch.enabled", true, unsupported); err == nil || !strings.Contains(err.Error(), "Ollama") {
+		t.Fatalf("enabling default local provider error = %v, want actionable guidance", err)
+	}
+
+	project.Settings.SemanticSearch = &models.SemanticSearchSettings{
+		Enabled:  true,
+		Provider: "ollama",
+	}
+	if err := validateConfigSetLocalONNX(project, "settings.semanticSearch.provider", "local", unsupported); err == nil {
+		t.Fatal("switching an enabled project to local ONNX should fail")
+	}
+	if err := validateConfigSetLocalONNX(project, "settings.semanticSearch.provider", "api", unsupported); err != nil {
+		t.Fatalf("API provider should remain writable: %v", err)
+	}
+
+	project.Settings.SemanticSearch.Enabled = false
+	if err := validateConfigSetLocalONNX(project, "settings.semanticSearch.provider", "local", unsupported); err != nil {
+		t.Fatalf("disabled legacy local configuration should remain writable: %v", err)
 	}
 }
 

--- a/internal/cli/download_setup.go
+++ b/internal/cli/download_setup.go
@@ -299,6 +299,9 @@ func (m *setupModel) cleanup() {
 // and embedding model files. Returns (steps, alreadyInstalled, error).
 // Used by the init command to integrate downloads into the progressive step UI.
 func buildSemanticDownloadSteps(modelID string) ([]initStep, bool, error) {
+	if err := search.RequireLocalONNX(); err != nil {
+		return nil, false, err
+	}
 	var selected *embeddingModel
 	for i := range supportedModels {
 		if supportedModels[i].ID == modelID {
@@ -322,6 +325,9 @@ func buildSemanticDownloadSteps(modelID string) ([]initStep, bool, error) {
 // using a unified bubbletea multi-step progress UI.
 // Pass force=true to re-download even if already installed.
 func runSemanticSetup(modelID string, force ...bool) error {
+	if err := search.RequireLocalONNX(); err != nil {
+		return err
+	}
 	forceDownload := len(force) > 0 && force[0]
 
 	// Find the model
@@ -410,6 +416,22 @@ func runSemanticSetup(modelID string, force ...bool) error {
 func ensureONNXRuntime() bool {
 	avail, _ := search.IsONNXAvailable()
 	return avail
+}
+
+func semanticProviderForSettings(settings *models.SemanticSearchSettings) string {
+	if settings != nil && settings.Provider != "" {
+		return settings.Provider
+	}
+	return "local"
+}
+
+func localONNXUnsupportedForCapability(settings *models.SemanticSearchSettings, capability search.LocalONNXCapability) bool {
+	return semanticProviderForSettings(settings) == "local" && !capability.Supported
+}
+
+func currentLocalONNXUnsupported(settings *models.SemanticSearchSettings) (search.LocalONNXCapability, bool) {
+	capability := search.CurrentLocalONNXCapability()
+	return capability, localONNXUnsupportedForCapability(settings, capability)
 }
 
 func ensureSemanticStoreReady(store *storage.Store, defaultModelID string) (bool, error) {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -277,10 +277,32 @@ type initConfig struct {
 	GitTracking     models.GitTracking
 	EnableSemantic  bool
 	SemanticModel   string
-	EmbeddingSource string // "local" or "api"
+	EmbeddingSource string // "local", "ollama", or "api"
 	Platforms       []string
 	EnableChatUI    bool
 	TaskLifecycle   *models.TaskLifecycleSettings
+}
+
+func applyLocalONNXInitCapability(cfg *initConfig) {
+	if !applyLocalONNXInitCapabilityFor(cfg, search.CurrentLocalONNXCapability()) {
+		return
+	}
+	fmt.Fprintln(os.Stderr, warnStyle.Render("Local ONNX is unavailable on macOS Intel; continuing with keyword/BM25 search."))
+	fmt.Fprintln(os.Stderr, dimStyle.Render("  Configure Ollama or an OpenAI-compatible API later with: knowns settings"))
+}
+
+func applyLocalONNXInitCapabilityFor(cfg *initConfig, capability search.LocalONNXCapability) bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.EmbeddingSource == "" {
+		cfg.EmbeddingSource = "local"
+	}
+	if !cfg.EnableSemantic || cfg.EmbeddingSource != "local" || capability.Supported {
+		return false
+	}
+	cfg.EnableSemantic = false
+	return true
 }
 
 // Aliases for centralized styles (see styles.go)
@@ -487,6 +509,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		}
 	}
 	cfg.TaskLifecycle = taskLifecycleSeed
+	applyLocalONNXInitCapability(&cfg)
 
 	// Build init steps
 	steps := []initStep{
@@ -512,11 +535,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 					project.Settings.GitTracking = &cfg.GitTracking
 				}
 				if cfg.EnableSemantic && cfg.SemanticModel != "" {
-					if cfg.EmbeddingSource == "api" {
+					if cfg.EmbeddingSource == "api" || cfg.EmbeddingSource == "ollama" {
 						// API provider: reference model from global settings.
 						project.Settings.SemanticSearch = &models.SemanticSearchSettings{
 							Enabled:  true,
-							Provider: "api",
+							Provider: cfg.EmbeddingSource,
 							Model:    cfg.SemanticModel,
 						}
 					} else {
@@ -525,6 +548,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 						if m != nil {
 							project.Settings.SemanticSearch = &models.SemanticSearchSettings{
 								Enabled:       true,
+								Provider:      "local",
 								Model:         m.ID,
 								HuggingFaceID: m.HuggingFaceID,
 								Dimensions:    m.Dimensions,
@@ -534,6 +558,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 							// Custom model registered at runtime.
 							project.Settings.SemanticSearch = &models.SemanticSearchSettings{
 								Enabled:       true,
+								Provider:      "local",
 								Model:         cfg.SemanticModel,
 								HuggingFaceID: mc.HuggingFaceID,
 								Dimensions:    mc.Dimensions,
@@ -578,7 +603,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	// Conditional semantic download steps (only for local ONNX with built-in models)
 	isBuiltinModel := findSupportedModel(cfg.SemanticModel) != nil
-	if cfg.EnableSemantic && cfg.EmbeddingSource != "api" && isBuiltinModel {
+	if cfg.EnableSemantic && cfg.EmbeddingSource == "local" && isBuiltinModel {
 		dlSteps, alreadyInstalled, err := buildSemanticDownloadSteps(cfg.SemanticModel)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: semantic search setup failed: %v\n", err)
@@ -593,7 +618,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if cfg.EnableSemantic && cfg.EmbeddingSource != "api" && isBuiltinModel {
+	if cfg.EnableSemantic && cfg.EmbeddingSource == "local" && isBuiltinModel {
 		steps = append(steps, initStep{
 			label: "Preparing project and global semantic stores",
 			run: func() error {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -11,9 +11,65 @@ import (
 
 	"github.com/howznguyen/knowns/internal/models"
 	"github.com/howznguyen/knowns/internal/runtimeinstall"
+	"github.com/howznguyen/knowns/internal/search"
 	"github.com/howznguyen/knowns/internal/storage"
 	"gopkg.in/yaml.v3"
 )
+
+func TestApplyLocalONNXInitCapabilityForMacOSIntel(t *testing.T) {
+	unsupported := search.LocalONNXCapabilityForPlatform("darwin", "amd64", "")
+
+	local := initConfig{EnableSemantic: true, EmbeddingSource: "local"}
+	if changed := applyLocalONNXInitCapabilityFor(&local, unsupported); !changed {
+		t.Fatal("local semantic init should be changed on macOS Intel")
+	}
+	if local.EnableSemantic {
+		t.Fatal("local semantic init should fall back to keyword/BM25 search")
+	}
+
+	ollama := initConfig{EnableSemantic: true, EmbeddingSource: "ollama"}
+	if changed := applyLocalONNXInitCapabilityFor(&ollama, unsupported); changed {
+		t.Fatal("Ollama semantic init should remain enabled")
+	}
+	if !ollama.EnableSemantic {
+		t.Fatal("Ollama semantic init was unexpectedly disabled")
+	}
+
+	customRuntime := search.LocalONNXCapabilityForPlatform("darwin", "amd64", "/opt/onnx/libonnxruntime.dylib")
+	custom := initConfig{EnableSemantic: true, EmbeddingSource: "local"}
+	if changed := applyLocalONNXInitCapabilityFor(&custom, customRuntime); changed {
+		t.Fatal("explicit compatible ONNX runtime should keep local semantic init enabled")
+	}
+	if !custom.EnableSemantic {
+		t.Fatal("custom local ONNX semantic init was unexpectedly disabled")
+	}
+}
+
+func TestLocalONNXUnsupportedForCapability(t *testing.T) {
+	unsupported := search.LocalONNXCapabilityForPlatform("darwin", "amd64", "")
+	supported := search.LocalONNXCapabilityForPlatform("darwin", "amd64", "/opt/onnx/libonnxruntime.dylib")
+
+	tests := []struct {
+		name       string
+		settings   *models.SemanticSearchSettings
+		capability search.LocalONNXCapability
+		want       bool
+	}{
+		{name: "default provider uses local ONNX", capability: unsupported, want: true},
+		{name: "explicit local provider", settings: &models.SemanticSearchSettings{Provider: "local"}, capability: unsupported, want: true},
+		{name: "Ollama remains available", settings: &models.SemanticSearchSettings{Provider: "ollama"}, capability: unsupported},
+		{name: "API remains available", settings: &models.SemanticSearchSettings{Provider: "api"}, capability: unsupported},
+		{name: "custom local runtime re-enables ONNX", settings: &models.SemanticSearchSettings{Provider: "local"}, capability: supported},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := localONNXUnsupportedForCapability(test.settings, test.capability); got != test.want {
+				t.Fatalf("localONNXUnsupportedForCapability() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
 
 func TestCreateOpenCodeConfigQuietCreatesConfig(t *testing.T) {
 	execLookPath = func(string) (string, error) { return "/usr/local/bin/knowns", nil }

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -611,6 +611,9 @@ var modelDownloadCmd = &cobra.Command{
 }
 
 func runModelDownload(cmd *cobra.Command, args []string) error {
+	if err := search.RequireLocalONNX(); err != nil {
+		return err
+	}
 	modelID := args[0]
 	forceFlag, _ := cmd.Flags().GetBool("force")
 
@@ -840,6 +843,9 @@ var modelSetCmd = &cobra.Command{
 }
 
 func runModelSet(cmd *cobra.Command, args []string) error {
+	if err := search.RequireLocalONNX(); err != nil {
+		return err
+	}
 	modelID := args[0]
 
 	var selected *embeddingModel
@@ -918,6 +924,9 @@ func runModelAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Local ONNX model path (existing behavior — add to HuggingFace registry).
+	if err := search.RequireLocalONNX(); err != nil {
+		return err
+	}
 	hfID, _ := cmd.Flags().GetString("hf-id")
 	if hfID == "" {
 		hfID = "Xenova/" + modelName

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -138,6 +138,9 @@ func maybeAutoSetup() {
 	if cfg.Settings.SemanticSearch == nil || !cfg.Settings.SemanticSearch.Enabled {
 		return
 	}
+	if _, unsupported := currentLocalONNXUnsupported(cfg.Settings.SemanticSearch); unsupported {
+		return
+	}
 
 	modelID := cfg.Settings.SemanticSearch.Model
 	if modelID == "" {

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -546,13 +546,25 @@ func runStatusCheck() error {
 	cfg, _ := store.Config.Load()
 
 	onnxAvail, onnxPath := search.IsONNXAvailable()
+	var semanticSettings *models.SemanticSearchSettings
+	if cfg != nil {
+		semanticSettings = cfg.Settings.SemanticSearch
+	}
+	provider := semanticProviderForSettings(semanticSettings)
+	usesLocalONNX := provider == "local"
+	capability := search.CurrentLocalONNXCapability()
 
 	fmt.Println()
 	fmt.Println(StyleBold.Render("Semantic Search Status"))
 	fmt.Println(RenderSeparator(40))
 
 	// ONNX runtime.
-	if onnxAvail {
+	if !usesLocalONNX {
+		fmt.Println(searchDimStyle.Render(fmt.Sprintf("  ONNX runtime: not used (provider: %s)", provider)))
+	} else if !capability.Supported {
+		fmt.Println(searchWarnStyle.Render("  ONNX runtime: unavailable on macOS Intel"))
+		fmt.Println(searchDimStyle.Render("    " + capability.Reason))
+	} else if onnxAvail {
 		fmt.Println(searchSuccessStyle.Render("  ONNX runtime: installed"))
 		fmt.Println(searchDimStyle.Render(fmt.Sprintf("    Path: %s", onnxPath)))
 	} else {
@@ -585,10 +597,11 @@ func runStatusCheck() error {
 	}
 
 	// Overall status.
+	providerReady := !usesLocalONNX || onnxAvail
 	fmt.Println()
-	if onnxAvail && cfg != nil && cfg.Settings.SemanticSearch != nil && cfg.Settings.SemanticSearch.Enabled && count > 0 {
+	if providerReady && semanticSettings != nil && semanticSettings.Enabled && count > 0 {
 		fmt.Println(searchSuccessStyle.Render("  Status: ready (hybrid search active)"))
-	} else if onnxAvail && cfg != nil && cfg.Settings.SemanticSearch != nil && cfg.Settings.SemanticSearch.Enabled {
+	} else if providerReady && semanticSettings != nil && semanticSettings.Enabled {
 		fmt.Println(searchWarnStyle.Render("  Status: needs search reindex (run: knowns search --reindex)"))
 	} else {
 		fmt.Println(searchDimStyle.Render("  Status: keyword-only mode"))
@@ -607,6 +620,39 @@ func runSetup() error {
 		return err
 	}
 
+	ss := cfg.Settings.SemanticSearch
+	provider := semanticProviderForSettings(ss)
+	if provider == "api" || provider == "ollama" {
+		if ss.Model == "" {
+			fmt.Println(searchWarnStyle.Render("No embedding model configured."))
+			fmt.Println()
+			fmt.Println(RenderHint("Choose a remote embedding model with: " + RenderCmd("knowns settings")))
+			fmt.Println()
+			return nil
+		}
+		if !ss.Enabled {
+			ss.Enabled = true
+			_ = store.Config.Set("settings.semanticSearch.enabled", true)
+			fmt.Println(searchSuccessStyle.Render("Semantic search enabled."))
+		} else {
+			fmt.Println(StyleDim.Render("Semantic search is already enabled."))
+		}
+		fmt.Println()
+		fmt.Println(RenderNextSteps(
+			RenderCmd("knowns search --reindex"),
+			RenderCmd("knowns search \"your query\""),
+		))
+		return nil
+	}
+
+	if capability, unsupported := currentLocalONNXUnsupported(ss); unsupported {
+		fmt.Println(searchWarnStyle.Render("Local ONNX setup is unavailable on macOS Intel."))
+		fmt.Println()
+		fmt.Println(RenderHint(capability.Reason))
+		fmt.Println()
+		return nil
+	}
+
 	// Check ONNX runtime.
 	onnxAvail, _ := search.IsONNXAvailable()
 	if !onnxAvail {
@@ -618,7 +664,7 @@ func runSetup() error {
 	}
 
 	// Check if a model is set.
-	if cfg.Settings.SemanticSearch == nil || cfg.Settings.SemanticSearch.Model == "" {
+	if ss == nil || ss.Model == "" {
 		fmt.Println(searchWarnStyle.Render("No embedding model configured."))
 		fmt.Println()
 		fmt.Println(RenderHint("Set a model first:"))
@@ -627,7 +673,6 @@ func runSetup() error {
 		return nil
 	}
 
-	ss := cfg.Settings.SemanticSearch
 	if !ss.Enabled {
 		ss.Enabled = true
 		_ = store.Config.Set("settings.semanticSearch.enabled", true)
@@ -874,6 +919,17 @@ func runReindex() error {
 
 	if total == 0 {
 		fmt.Println(RenderWarning("No tasks, docs, or decisions to index."))
+		return nil
+	}
+
+	cfg, _ := store.Config.Load()
+	var semanticSettings *models.SemanticSearchSettings
+	if cfg != nil {
+		semanticSettings = cfg.Settings.SemanticSearch
+	}
+	if capability, unsupported := currentLocalONNXUnsupported(semanticSettings); unsupported {
+		fmt.Println(searchWarnStyle.Render("  Local ONNX semantic reindex skipped; keyword/BM25 search remains active."))
+		fmt.Println(searchDimStyle.Render("  " + capability.Reason))
 		return nil
 	}
 

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -261,6 +261,11 @@ func runSyncModel(store *storage.Store, force bool) error {
 	if cfg.Settings.SemanticSearch != nil && (cfg.Settings.SemanticSearch.Provider == "api" || cfg.Settings.SemanticSearch.Provider == "ollama") {
 		return runSyncModelAPI(cfg)
 	}
+	if capability, unsupported := currentLocalONNXUnsupported(cfg.Settings.SemanticSearch); unsupported {
+		fmt.Printf("%s Local ONNX setup skipped; keyword/BM25 search remains active.\n", StyleWarning.Render("⚠"))
+		fmt.Println(StyleDim.Render("  " + capability.Reason))
+		return nil
+	}
 
 	defaultModelID := "multilingual-e5-small"
 	if cfg.Settings.SemanticSearch != nil && cfg.Settings.SemanticSearch.Model != "" {

--- a/internal/doctor/local.go
+++ b/internal/doctor/local.go
@@ -30,6 +30,7 @@ type localDependencies struct {
 	exists          func(string) bool
 	lookPath        func(string) (string, error)
 	onnxAvailable   func() (bool, string)
+	onnxCapability  func() search.LocalONNXCapability
 	localONNXModel  func(*models.SemanticSearchSettings) localONNXModelStatus
 	readFile        func(string) ([]byte, error)
 }
@@ -59,6 +60,7 @@ func defaultLocalDependencies() localDependencies {
 		},
 		lookPath:       exec.LookPath,
 		onnxAvailable:  search.IsONNXAvailable,
+		onnxCapability: search.CurrentLocalONNXCapability,
 		localONNXModel: inspectLocalONNXModel,
 		readFile:       os.ReadFile,
 	}
@@ -116,6 +118,9 @@ func newLocalState(store *storage.Store, deps localDependencies) *localState {
 	}
 	if deps.onnxAvailable == nil {
 		deps.onnxAvailable = defaults.onnxAvailable
+	}
+	if deps.onnxCapability == nil {
+		deps.onnxCapability = defaults.onnxCapability
 	}
 	if deps.localONNXModel == nil {
 		deps.localONNXModel = defaults.localONNXModel

--- a/internal/doctor/local_test.go
+++ b/internal/doctor/local_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/howznguyen/knowns/internal/models"
 	"github.com/howznguyen/knowns/internal/readiness"
 	"github.com/howznguyen/knowns/internal/runtimeinstall"
+	"github.com/howznguyen/knowns/internal/search"
 	"github.com/howznguyen/knowns/internal/services"
 	"github.com/howznguyen/knowns/internal/storage"
 )
@@ -243,6 +244,47 @@ func TestSearchChecksReportLocalONNXDependencyStates(t *testing.T) {
 				t.Fatalf("model check = %#v", result)
 			}
 		})
+	}
+}
+
+func TestSearchChecksExplainUnsupportedMacOSIntelONNX(t *testing.T) {
+	store := newDoctorStore(t)
+	configureSemanticSearch(t, store, &models.SemanticSearchSettings{
+		Enabled:  true,
+		Model:    "gte-small",
+		Provider: "local",
+	})
+	state := newLocalState(store, localDependencies{
+		onnxCapability: func() search.LocalONNXCapability {
+			return search.LocalONNXCapabilityForPlatform("darwin", "amd64", "")
+		},
+	})
+
+	configResult, err := searchConfigChecker(state).Check(context.Background())
+	if err != nil {
+		t.Fatalf("config Check() error = %v", err)
+	}
+	if configResult.Status != StatusWarn ||
+		configResult.Evidence["errorCode"] != "onnx_platform_unsupported" ||
+		configResult.Remediation == nil ||
+		configResult.Remediation.Command != "knowns settings" {
+		t.Fatalf("config check = %#v", configResult)
+	}
+
+	for _, checker := range []Checker{
+		searchModelChecker(state),
+		searchONNXRuntimeChecker(state),
+		searchProjectIndexChecker(state),
+		searchGlobalIndexChecker(state),
+		searchSemanticRuntimeChecker(state),
+	} {
+		result, err := checker.Check(context.Background())
+		if err != nil {
+			t.Fatalf("%s Check() error = %v", checker.ID, err)
+		}
+		if result.Status != StatusSkip || result.SkipReason != "platform_unsupported" {
+			t.Fatalf("%s check = %#v", checker.ID, result)
+		}
 	}
 }
 

--- a/internal/doctor/search_checks.go
+++ b/internal/doctor/search_checks.go
@@ -46,6 +46,14 @@ func semanticSettings(state *localState) (*models.SemanticSearchSettings, error)
 	return project.Settings.SemanticSearch, nil
 }
 
+func unsupportedLocalONNX(state *localState, settings *models.SemanticSearchSettings) (search.LocalONNXCapability, bool) {
+	if settings == nil || providerName(settings.Provider) != "local" {
+		return search.LocalONNXCapability{}, false
+	}
+	capability := state.deps.onnxCapability()
+	return capability, !capability.Supported
+}
+
 func searchConfigChecker(state *localState) Checker {
 	return Checker{
 		ID:    "search.semantic",
@@ -64,6 +72,21 @@ func searchConfigChecker(state *localState) Checker {
 			provider := settings.Provider
 			if provider == "" {
 				provider = "local"
+			}
+			if capability, unsupported := unsupportedLocalONNX(state, settings); unsupported {
+				return CheckResult{
+					Status:  StatusWarn,
+					Summary: "Local ONNX is unavailable on macOS Intel",
+					Evidence: Evidence{
+						"provider":  provider,
+						"available": false,
+						"errorCode": "onnx_platform_unsupported",
+					},
+					Remediation: &Remediation{
+						Description: capability.Reason,
+						Command:     "knowns settings",
+					},
+				}, nil
 			}
 			if settings.Model == "" {
 				return CheckResult{
@@ -104,6 +127,9 @@ func searchModelChecker(state *localState) Checker {
 			}
 			if settings == nil || !settings.Enabled {
 				return subsystemDisabled("Semantic model check is disabled", "config_disabled"), nil
+			}
+			if _, unsupported := unsupportedLocalONNX(state, settings); unsupported {
+				return subsystemDisabled("Local ONNX model check is not applicable on macOS Intel", "platform_unsupported"), nil
 			}
 			if settings.Model == "" {
 				return CheckResult{
@@ -257,6 +283,9 @@ func searchONNXRuntimeChecker(state *localState) Checker {
 			if providerName(settings.Provider) != "local" {
 				return subsystemDisabled("ONNX Runtime is not used by the configured provider", "not_applicable"), nil
 			}
+			if _, unsupported := unsupportedLocalONNX(state, settings); unsupported {
+				return subsystemDisabled("ONNX Runtime is not bundled for macOS Intel", "platform_unsupported"), nil
+			}
 			available, _ := state.deps.onnxAvailable()
 			if !available {
 				return CheckResult{
@@ -403,6 +432,9 @@ func searchProjectIndexChecker(state *localState) Checker {
 			if settings == nil || !settings.Enabled {
 				return subsystemDisabled("Project semantic index is disabled", "config_disabled"), nil
 			}
+			if _, unsupported := unsupportedLocalONNX(state, settings); unsupported {
+				return subsystemDisabled("Project semantic index is disabled because Local ONNX is unavailable", "platform_unsupported"), nil
+			}
 			payload, err := state.readinessSnapshot()
 			if err != nil {
 				return CheckResult{}, err
@@ -466,6 +498,9 @@ func searchGlobalIndexChecker(state *localState) Checker {
 			}
 			if settings == nil || !settings.Enabled {
 				return subsystemDisabled("Global semantic index is disabled", "config_disabled"), nil
+			}
+			if _, unsupported := unsupportedLocalONNX(state, settings); unsupported {
+				return subsystemDisabled("Global semantic index is disabled because Local ONNX is unavailable", "platform_unsupported"), nil
 			}
 			payload, err := state.readinessSnapshot()
 			if err != nil {
@@ -537,6 +572,9 @@ func searchSemanticRuntimeChecker(state *localState) Checker {
 			}
 			if settings == nil || !settings.Enabled {
 				return subsystemDisabled("Semantic runtime is disabled", "config_disabled"), nil
+			}
+			if _, unsupported := unsupportedLocalONNX(state, settings); unsupported {
+				return subsystemDisabled("Semantic runtime is disabled because Local ONNX is unavailable", "platform_unsupported"), nil
 			}
 			payload, err := state.readinessSnapshot()
 			if err != nil {

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -314,8 +314,9 @@ type SemanticSearchSettings struct {
 	Enabled bool   `json:"enabled,omitempty"`
 	Model   string `json:"model"`
 
-	// Provider selects the embedding backend: "local" (default, ONNX) or "api"
-	// (OpenAI-compatible endpoint configured in ~/.knowns/settings.json).
+	// Provider selects the embedding backend: "local" (default, ONNX),
+	// "ollama", or "api" (OpenAI-compatible endpoint configured in
+	// ~/.knowns/settings.json).
 	Provider string `json:"provider,omitempty"`
 
 	// HuggingFaceID is the full HuggingFace model identifier

--- a/internal/readiness/readiness.go
+++ b/internal/readiness/readiness.go
@@ -281,9 +281,8 @@ func buildSearch(store *storage.Store) *SearchStatus {
 		ss.SemanticEnabled = sem.Enabled
 		ss.ModelConfigured = sem.Model != ""
 
-		// Check if ONNX runtime is available.
 		onnxAvail, _ := search.IsONNXAvailable()
-		ss.ModelInstalled = onnxAvail && sem.Model != ""
+		ss.ModelInstalled = semanticModelInstalled(sem, onnxAvail)
 	}
 
 	// Project index readiness.
@@ -313,6 +312,18 @@ func buildSearch(store *storage.Store) *SearchStatus {
 	}
 
 	return ss
+}
+
+func semanticModelInstalled(settings *models.SemanticSearchSettings, onnxAvailable bool) bool {
+	if settings == nil || settings.Model == "" {
+		return false
+	}
+	if settings.Provider == "api" || settings.Provider == "ollama" {
+		// Remote providers manage model availability outside the bundled
+		// ONNX runtime. Runtime health is reported separately.
+		return true
+	}
+	return onnxAvailable
 }
 
 func buildSemanticRuntimeReadiness() *SemanticRuntimeReadiness {

--- a/internal/readiness/readiness_test.go
+++ b/internal/readiness/readiness_test.go
@@ -72,6 +72,23 @@ func TestSemanticRuntimeReadinessReportsDisabledState(t *testing.T) {
 	}
 }
 
+func TestSemanticModelInstalledDoesNotRequireONNXForRemoteProviders(t *testing.T) {
+	for _, provider := range []string{"api", "ollama"} {
+		settings := &models.SemanticSearchSettings{Provider: provider, Model: "remote-model"}
+		if !semanticModelInstalled(settings, false) {
+			t.Fatalf("provider %q should not require a local ONNX runtime", provider)
+		}
+	}
+
+	local := &models.SemanticSearchSettings{Provider: "local", Model: "gte-small"}
+	if semanticModelInstalled(local, false) {
+		t.Fatal("local provider should require an available ONNX runtime")
+	}
+	if !semanticModelInstalled(local, true) {
+		t.Fatal("local provider with ONNX runtime should be ready")
+	}
+}
+
 func TestBuildReadinessIncludesDecisionCountsAndCapabilities(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	store := storage.NewStore(filepath.Join(t.TempDir(), ".knowns"))

--- a/internal/search/init.go
+++ b/internal/search/init.go
@@ -52,6 +52,9 @@ func InitSemantic(store *storage.Store) (EmbedderProvider, VectorStore, error) {
 	if ss.Provider == "api" || ss.Provider == "ollama" {
 		return initSemanticAPI(store, ss)
 	}
+	if err := RequireLocalONNX(); err != nil {
+		return nil, nil, err
+	}
 	return initSemanticLocal(store, ss)
 }
 

--- a/internal/search/onnx_capability.go
+++ b/internal/search/onnx_capability.go
@@ -1,0 +1,60 @@
+package search
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+const macOSIntelONNXReason = "Local ONNX is not bundled for macOS Intel (x86_64). Use Ollama or an OpenAI-compatible API provider, or set KNOWNS_ORT_LIB to a compatible x86_64 libonnxruntime.dylib."
+
+// LocalONNXCapability describes whether this installation can select the
+// in-process ONNX embedding provider. macOS Intel releases intentionally ship
+// without ONNX Runtime because upstream no longer publishes a compatible
+// prebuilt dylib.
+type LocalONNXCapability struct {
+	Supported        bool   `json:"supported"`
+	RuntimeAvailable bool   `json:"runtimeAvailable"`
+	CustomLibrary    bool   `json:"customLibrary"`
+	Reason           string `json:"reason,omitempty"`
+}
+
+// LocalONNXCapabilityForPlatform resolves support without depending on the
+// current process architecture, which keeps release and platform tests
+// deterministic.
+func LocalONNXCapabilityForPlatform(goos, goarch, libraryPath string) LocalONNXCapability {
+	runtimeAvailable := strings.TrimSpace(libraryPath) != ""
+	if goos == "darwin" && goarch == "amd64" {
+		if runtimeAvailable {
+			return LocalONNXCapability{
+				Supported:        true,
+				RuntimeAvailable: true,
+				CustomLibrary:    true,
+			}
+		}
+		return LocalONNXCapability{
+			Supported: false,
+			Reason:    macOSIntelONNXReason,
+		}
+	}
+	return LocalONNXCapability{
+		Supported:        true,
+		RuntimeAvailable: runtimeAvailable,
+	}
+}
+
+// CurrentLocalONNXCapability reports support for the running binary. An
+// explicitly supplied compatible library re-enables local ONNX on macOS Intel.
+func CurrentLocalONNXCapability() LocalONNXCapability {
+	return LocalONNXCapabilityForPlatform(runtime.GOOS, runtime.GOARCH, ResolveORTLibraryPath())
+}
+
+// RequireLocalONNX returns actionable guidance when local ONNX cannot be used
+// by this installation.
+func RequireLocalONNX() error {
+	capability := CurrentLocalONNXCapability()
+	if capability.Supported {
+		return nil
+	}
+	return fmt.Errorf("%s", capability.Reason)
+}

--- a/internal/search/onnx_capability_test.go
+++ b/internal/search/onnx_capability_test.go
@@ -1,0 +1,65 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLocalONNXCapabilityForPlatform(t *testing.T) {
+	tests := []struct {
+		name       string
+		goos       string
+		goarch     string
+		library    string
+		supported  bool
+		available  bool
+		custom     bool
+		reasonText string
+	}{
+		{
+			name:      "macOS Apple Silicon remains supported",
+			goos:      "darwin",
+			goarch:    "arm64",
+			supported: true,
+		},
+		{
+			name:       "macOS Intel defaults to remote semantic providers",
+			goos:       "darwin",
+			goarch:     "amd64",
+			reasonText: "Ollama",
+		},
+		{
+			name:      "macOS Intel accepts an explicit compatible runtime",
+			goos:      "darwin",
+			goarch:    "amd64",
+			library:   "/opt/onnx/libonnxruntime.dylib",
+			supported: true,
+			available: true,
+			custom:    true,
+		},
+		{
+			name:      "Linux remains supported",
+			goos:      "linux",
+			goarch:    "amd64",
+			supported: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capability := LocalONNXCapabilityForPlatform(test.goos, test.goarch, test.library)
+			if capability.Supported != test.supported {
+				t.Fatalf("Supported = %v, want %v", capability.Supported, test.supported)
+			}
+			if capability.RuntimeAvailable != test.available {
+				t.Fatalf("RuntimeAvailable = %v, want %v", capability.RuntimeAvailable, test.available)
+			}
+			if capability.CustomLibrary != test.custom {
+				t.Fatalf("CustomLibrary = %v, want %v", capability.CustomLibrary, test.custom)
+			}
+			if test.reasonText != "" && !strings.Contains(capability.Reason, test.reasonText) {
+				t.Fatalf("Reason = %q, want text %q", capability.Reason, test.reasonText)
+			}
+		})
+	}
+}

--- a/internal/search/semantic_runtime.go
+++ b/internal/search/semantic_runtime.go
@@ -387,6 +387,9 @@ func loadSemanticRuntimeConfig(store *storage.Store) (semanticRuntimeConfig, err
 	if provider == "api" || provider == "ollama" {
 		return semanticRuntimeAPIConfig(ss, provider)
 	}
+	if err := RequireLocalONNX(); err != nil {
+		return semanticRuntimeConfig{}, err
+	}
 	return semanticRuntimeLocalConfig(ss, provider)
 }
 

--- a/internal/server/routes/config.go
+++ b/internal/server/routes/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/howznguyen/knowns/internal/agents/opencode"
 	"github.com/howznguyen/knowns/internal/models"
+	"github.com/howznguyen/knowns/internal/search"
 	"github.com/howznguyen/knowns/internal/storage"
 )
 
@@ -54,6 +55,7 @@ func (cr *ConfigRoutes) configResponse(project *models.Project) map[string]inter
 		"id":            project.ID,
 		"createdAt":     project.CreatedAt,
 		"taskLifecycle": project.Settings.EffectiveTaskLifecycle(),
+		"localONNX":     search.CurrentLocalONNXCapability(),
 		"capabilities": map[string]bool{
 			"taskHardDelete": cr.capabilities.HardDelete,
 		},
@@ -147,6 +149,12 @@ func (cr *ConfigRoutes) save(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 		return
 	}
+	if semanticSearchUpdateRequested(payload) {
+		if err := validateSemanticSearchCapability(project.Settings.SemanticSearch, search.CurrentLocalONNXCapability()); err != nil {
+			respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+			return
+		}
+	}
 	if err := project.Settings.Validate(); err != nil {
 		respondError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 		return
@@ -163,6 +171,36 @@ func (cr *ConfigRoutes) save(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	respondJSON(w, http.StatusOK, cr.configResponse(project))
+}
+
+func validateSemanticSearchCapability(settings *models.SemanticSearchSettings, capability search.LocalONNXCapability) error {
+	if settings == nil || !settings.Enabled {
+		return nil
+	}
+	provider := settings.Provider
+	if provider == "" {
+		provider = "local"
+	}
+	if provider == "local" && !capability.Supported {
+		return fmt.Errorf("%s", capability.Reason)
+	}
+	return nil
+}
+
+func semanticSearchUpdateRequested(payload map[string]json.RawMessage) bool {
+	if _, ok := payload["semanticSearch"]; ok {
+		return true
+	}
+	raw, ok := payload["settings"]
+	if !ok {
+		return false
+	}
+	var nested map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &nested); err != nil {
+		return false
+	}
+	_, ok = nested["semanticSearch"]
+	return ok
 }
 
 func applyProjectConfigUpdate(project *models.Project, payload map[string]json.RawMessage) error {

--- a/internal/server/routes/config_semantic_test.go
+++ b/internal/server/routes/config_semantic_test.go
@@ -1,0 +1,107 @@
+package routes
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/howznguyen/knowns/internal/models"
+	"github.com/howznguyen/knowns/internal/search"
+)
+
+func TestValidateSemanticSearchCapability(t *testing.T) {
+	unsupported := search.LocalONNXCapabilityForPlatform("darwin", "amd64", "")
+
+	tests := []struct {
+		name     string
+		settings *models.SemanticSearchSettings
+		wantErr  bool
+	}{
+		{
+			name: "disabled local configuration remains readable",
+			settings: &models.SemanticSearchSettings{
+				Enabled:  false,
+				Provider: "local",
+			},
+		},
+		{
+			name: "Ollama remains available",
+			settings: &models.SemanticSearchSettings{
+				Enabled:  true,
+				Provider: "ollama",
+				Model:    "nomic-embed-text",
+			},
+		},
+		{
+			name: "API remains available",
+			settings: &models.SemanticSearchSettings{
+				Enabled:  true,
+				Provider: "api",
+				Model:    "text-embedding-3-small",
+			},
+		},
+		{
+			name: "local ONNX is rejected",
+			settings: &models.SemanticSearchSettings{
+				Enabled:  true,
+				Provider: "local",
+				Model:    "gte-small",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty provider retains local semantics",
+			settings: &models.SemanticSearchSettings{
+				Enabled: true,
+				Model:   "gte-small",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateSemanticSearchCapability(test.settings, unsupported)
+			if test.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "Ollama") {
+					t.Fatalf("error = %v, want actionable local ONNX error", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestSemanticSearchUpdateRequested(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]json.RawMessage
+		want    bool
+	}{
+		{
+			name:    "direct semantic patch",
+			payload: map[string]json.RawMessage{"semanticSearch": json.RawMessage(`{"provider":"ollama"}`)},
+			want:    true,
+		},
+		{
+			name:    "nested legacy settings",
+			payload: map[string]json.RawMessage{"settings": json.RawMessage(`{"semanticSearch":{"provider":"api"}}`)},
+			want:    true,
+		},
+		{
+			name:    "unrelated patch remains writable",
+			payload: map[string]json.RawMessage{"name": json.RawMessage(`"Intel project"`)},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := semanticSearchUpdateRequested(test.payload); got != test.want {
+				t.Fatalf("semanticSearchUpdateRequested() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/server/routes/embedding_models.go
+++ b/internal/server/routes/embedding_models.go
@@ -149,8 +149,12 @@ func (emr *EmbeddingModelRoutes) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	localModels := []embeddingModelInfo{}
+	if search.CurrentLocalONNXCapability().Supported {
+		localModels = listLocalEmbeddingModels()
+	}
 	respondJSON(w, http.StatusOK, embeddingModelsResponse{
-		Local:      listLocalEmbeddingModels(),
+		Local:      localModels,
 		API:        listOllamaEmbeddingModels(),
 		Configured: configured,
 	})

--- a/npm/knowns-darwin-x64/package.json
+++ b/npm/knowns-darwin-x64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@knowns/darwin-x64",
+  "version": "0.0.0",
+  "description": "Knowns CLI binary for macOS Intel (x86_64); local ONNX Runtime is not bundled",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "knowns",
+  "files": [
+    "knowns"
+  ],
+  "license": "MIT",
+  "homepage": "https://knowns.sh",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/knowns-dev/knowns.git"
+  }
+}

--- a/npm/knowns/install.test.js
+++ b/npm/knowns/install.test.js
@@ -20,6 +20,24 @@ test("maps Windows x64 to the published package name", () => {
   });
 });
 
+test("maps macOS Intel to the darwin-x64 package and release asset", () => {
+  expect(getPlatformPackage("darwin", "x64")).toEqual({
+    name: "@knowns/darwin-x64",
+    asset: "knowns-darwin-x64",
+    ext: "",
+    packageOs: "darwin",
+    packageCpu: "x64",
+  });
+});
+
+test("macOS Intel package contains only the CLI binary", () => {
+  const pkg = readPackageJson("../knowns-darwin-x64/package.json");
+
+  expect(pkg.os).toEqual(["darwin"]);
+  expect(pkg.cpu).toEqual(["x64"]);
+  expect(pkg.files).toEqual(["knowns"]);
+});
+
 test("Windows platform packages use npm's win32 os identifier", () => {
   const x64Pkg = readPackageJson("../knowns-win-x64/package.json");
   const arm64Pkg = readPackageJson("../knowns-win-arm64/package.json");

--- a/ui/e2e/config.spec.ts
+++ b/ui/e2e/config.spec.ts
@@ -48,6 +48,49 @@ test.describe("Configuration Page", () => {
 		});
 	});
 
+	test("disables Local ONNX settings when the platform does not bundle it", async ({ page }) => {
+		await page.route("**/api/config", async (route) => {
+			if (route.request().method() !== "GET") {
+				await route.continue();
+				return;
+			}
+			const response = await route.fetch();
+			const body = await response.json();
+			body.config = {
+				...(body.config || {}),
+				semanticSearch: {
+					enabled: true,
+					provider: "local",
+					model: "gte-small",
+					huggingFaceId: "Xenova/gte-small",
+				},
+				localONNX: {
+					supported: false,
+					runtimeAvailable: false,
+					customLibrary: false,
+					reason: "Local ONNX is not bundled for macOS Intel (x86_64). Use Ollama or an API provider.",
+				},
+			};
+			await route.fulfill({ response, json: body });
+		});
+
+		await page.goto(`${server.baseURL}/config`);
+		await page.getByRole("button", { name: "Search", exact: true }).click();
+
+		await expect(page.getByTestId("local-onnx-unavailable")).toContainText("macOS Intel");
+		const provider = page.getByRole("combobox");
+		await expect(provider).toHaveValue("ollama");
+		await expect(provider.locator('option[value="local"]')).toBeDisabled();
+		await expect(page.getByText("HuggingFace ID", { exact: true })).toHaveCount(0);
+
+		const saveRequest = page.waitForRequest(
+			(request) => request.url().endsWith("/api/config") && request.method() === "PATCH",
+		);
+		await page.getByRole("spinbutton").first().fill("768");
+		const request = await saveRequest;
+		expect(request.postDataJSON().semanticSearch.provider).toBe("ollama");
+	});
+
 	test("keeps category navigation and active content usable on mobile", async ({ page }) => {
 		await page.setViewportSize({ width: 390, height: 844 });
 		await page.goto(`${server.baseURL}/config`);

--- a/ui/src/contexts/ConfigContext.tsx
+++ b/ui/src/contexts/ConfigContext.tsx
@@ -52,6 +52,12 @@ export interface Config {
 		dimensions?: number;
 		maxTokens?: number;
 	};
+	localONNX?: {
+		supported: boolean;
+		runtimeAvailable: boolean;
+		customLibrary: boolean;
+		reason?: string;
+	};
 	lsp?: {
 		enabled?: boolean;
 		languages?: Record<string, {
@@ -106,6 +112,7 @@ const DEFAULT_CONFIG: Config = {
 function editablePatch(updates: ConfigPatch): ConfigPatch {
 	const {
 		capabilities: _readOnlyCapabilities,
+		localONNX: _readOnlyLocalONNX,
 		id: _readOnlyID,
 		createdAt: _readOnlyCreatedAt,
 		opencodeInstalled: _readOnlyOpenCodeInstalled,

--- a/ui/src/pages/ConfigPage.tsx
+++ b/ui/src/pages/ConfigPage.tsx
@@ -174,12 +174,21 @@ function useAutoSave(updateConfig: (c: ConfigPatch) => Promise<void>) {
 function editableConfig(config: Config): Config {
 	const {
 		capabilities: _readOnlyCapabilities,
+		localONNX: _readOnlyLocalONNX,
 		id: _readOnlyID,
 		createdAt: _readOnlyCreatedAt,
 		opencodeInstalled: _readOnlyOpenCodeInstalled,
 		...editable
 	} = config;
 	return editable;
+}
+
+function effectiveSemanticProvider(config: Config): string {
+	const configured = config.semanticSearch?.provider;
+	if (config.localONNX?.supported === false && (!configured || configured === "local")) {
+		return "ollama";
+	}
+	return configured || "local";
 }
 
 // ── Section header component ──────────────────────────────────────
@@ -215,6 +224,7 @@ function FieldRow({ label, hint, children }: { label: string; hint?: string; chi
 export default function ConfigPage() {
 	const { config: globalConfig, loading, updateConfig, chatUIEnabled } = useConfig();
 	const [config, setConfig] = useState<Config>({});
+	const semanticProvider = effectiveSemanticProvider(config);
 	const [activeCategory, setActiveCategory] = useState<Category>("general");
 	const [initialized, setInitialized] = useState(false);
 	const [saving, setSaving] = useState(false);
@@ -537,10 +547,10 @@ export default function ConfigPage() {
 	}, [loadEmbeddingModels]);
 
 	useEffect(() => {
-		if (!initialized || config.semanticSearch?.provider !== "api") return;
+		if (!initialized || semanticProvider !== "api") return;
 		setApiBase((current) => current || "http://localhost:11434/v1");
 		setTestModelName((current) => current || config.semanticSearch?.model || "");
-	}, [initialized, config.semanticSearch?.provider, config.semanticSearch?.model]);
+	}, [initialized, semanticProvider, config.semanticSearch?.model]);
 
 	// Select embedding model and update config
 	const selectEmbeddingModel = useCallback((model: EmbeddingModelInfo) => {
@@ -549,6 +559,7 @@ export default function ConfigPage() {
 		const patch: Partial<Config> = {
 			semanticSearch: {
 				...(config.semanticSearch || {}),
+				provider: semanticProvider,
 				model: modelName,
 				dimensions: model.dimensions || config.semanticSearch?.dimensions || 384,
 				...(isApi ? {
@@ -560,7 +571,7 @@ export default function ConfigPage() {
 		};
 		setConfig(prev => ({ ...prev, ...patch }));
 		autoSave(patch);
-	}, [config.semanticSearch, autoSave]);
+	}, [config.semanticSearch, semanticProvider, autoSave]);
 
 	// Test embedding API endpoint
 	const handleTestEmbedding = async () => {
@@ -578,6 +589,7 @@ export default function ConfigPage() {
 				update({
 					semanticSearch: {
 						...(config.semanticSearch || {}),
+						provider: "api",
 						model: testModelName.trim(),
 						dimensions: data.dimensions,
 					},
@@ -848,7 +860,7 @@ export default function ConfigPage() {
 	};
 
 	const renderEmbeddingModels = () => {
-		const provider = config.semanticSearch?.provider || "local";
+		const provider = semanticProvider;
 		const models = provider === "local"
 			? embeddingModels?.local || []
 			: provider === "ollama"
@@ -913,20 +925,33 @@ export default function ConfigPage() {
 			<FieldRow label="Enabled">
 				<Switch
 					checked={config.semanticSearch?.enabled ?? false}
-					onCheckedChange={(checked) => update({ semanticSearch: { ...(config.semanticSearch || {}), enabled: checked } })}
+					onCheckedChange={(checked) => {
+						const current = config.semanticSearch || {};
+						update({ semanticSearch: { ...current, enabled: checked, provider: semanticProvider } });
+					}}
 				/>
 			</FieldRow>
 
+			{config.localONNX?.supported === false && (
+				<div
+					className="mb-3 flex gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200"
+					data-testid="local-onnx-unavailable"
+				>
+					<AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+					<span>{config.localONNX.reason || "Local ONNX is unavailable on this platform. Use Ollama or an API provider."}</span>
+				</div>
+			)}
+
 			<FieldRow label="Provider" hint="local = ONNX built-in, ollama = local Ollama server, api = custom endpoint">
 				<select
-					value={config.semanticSearch?.provider || "local"}
+					value={semanticProvider}
 					onChange={(e) => {
 						update({ semanticSearch: { ...(config.semanticSearch || {}), provider: e.target.value } });
 						void loadEmbeddingModels();
 					}}
 					className="w-full px-3 py-2 rounded-md border bg-input text-sm focus:outline-none focus:ring-2 focus:ring-ring"
 				>
-					<option value="local">Local (ONNX)</option>
+					<option value="local" disabled={config.localONNX?.supported === false}>Local (ONNX)</option>
 					<option value="ollama">Ollama</option>
 					<option value="api">API (OpenAI-compatible)</option>
 				</select>
@@ -934,7 +959,7 @@ export default function ConfigPage() {
 
 			{renderEmbeddingModels()}
 
-			{config.semanticSearch?.provider === "api" && (
+			{semanticProvider === "api" && (
 				<>
 					<Separator className="my-4" />
 					<SectionHeader icon={Search} title="API Endpoint" description="Configure a custom OpenAI-compatible embedding endpoint" />
@@ -964,11 +989,11 @@ export default function ConfigPage() {
 				</>
 			)}
 
-			{(!config.semanticSearch?.provider || config.semanticSearch.provider === "local") && (
+			{semanticProvider === "local" && (
 				<FieldRow label="HuggingFace ID" hint="Full HuggingFace model identifier (read-only when model is selected)">
 					<Input
 						value={config.semanticSearch?.huggingFaceId || ""}
-						onChange={(e) => update({ semanticSearch: { ...(config.semanticSearch || {}), huggingFaceId: e.target.value } })}
+						onChange={(e) => update({ semanticSearch: { ...(config.semanticSearch || {}), provider: "local", huggingFaceId: e.target.value } })}
 						placeholder="Select a model above"
 						readOnly={!!config.semanticSearch?.huggingFaceId}
 					/>
@@ -979,7 +1004,7 @@ export default function ConfigPage() {
 				<Input
 					type="number"
 					value={config.semanticSearch?.dimensions ?? 384}
-					onChange={(e) => update({ semanticSearch: { ...(config.semanticSearch || {}), dimensions: parseInt(e.target.value, 10) || 384 } })}
+					onChange={(e) => update({ semanticSearch: { ...(config.semanticSearch || {}), provider: semanticProvider, dimensions: parseInt(e.target.value, 10) || 384 } })}
 				/>
 			</FieldRow>
 
@@ -987,7 +1012,7 @@ export default function ConfigPage() {
 				<Input
 					type="number"
 					value={config.semanticSearch?.maxTokens ?? 512}
-					onChange={(e) => update({ semanticSearch: { ...(config.semanticSearch || {}), maxTokens: parseInt(e.target.value, 10) || 512 } })}
+					onChange={(e) => update({ semanticSearch: { ...(config.semanticSearch || {}), provider: semanticProvider, maxTokens: parseInt(e.target.value, 10) || 512 } })}
 				/>
 			</FieldRow>
 		</div>


### PR DESCRIPTION
## Summary

- promote the changes merged into `develop` since `v0.28.0` to `main`
- include macOS Intel (`darwin-x64`) CLI release support from #135
- prepare the existing `v0.29.0` draft for publication

## Release verification

- PR #135 CI completed successfully across all 9 jobs
- native `macos-15-intel` smoke passed
- `knowns@0.29.0` and tag `v0.29.0` do not exist yet

After this PR merges, the `v0.29.0` draft release can be published to trigger the full release workflow.