### PR TITLE
fix(windows): throttle runtime probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,17 @@
 
 <p align="center">
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-%3E%3D1.24.2-00ADD8?style=flat-square&logo=go" alt="Go"></a>
-  <a href="https://www.npmjs.com/package/knowns"><img src="https://img.shields.io/npm/v/knowns.svg?style=flat-square" alt="npm"></a>
+  <a href="https://github.com/knowns-dev/knowns/releases"><img src="https://img.shields.io/github/v/release/knowns-dev/knowns?style=flat-square" alt="Release"></a>
+  <a href="https://github.com/knowns-dev/knowns/stargazers"><img src="https://img.shields.io/github/stars/knowns-dev/knowns?style=flat-square" alt="GitHub stars"></a>
   <a href="https://github.com/knowns-dev/knowns/actions/workflows/ci.yml"><img src="https://github.com/knowns-dev/knowns/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="#installation"><img src="https://img.shields.io/badge/platform-win%20%7C%20mac%20%7C%20linux-lightgrey?style=flat-square" alt="Platform"></a>
-  <a href="https://discord.knowns.dev"><img src="https://img.shields.io/badge/Discord-Join%20community-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://discord.knowns.dev"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Join Discord"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/knowns-dev/knowns?style=flat-square" alt="License"></a>
+</p>
+
+<p align="center">
+  <img src="https://custom-icon-badges.demolab.com/badge/Working%20on-Codex-111111?style=flat-square&logo=openai&logoColor=white" alt="Working on Codex">
+  <img src="https://img.shields.io/badge/Working%20on-Claude-D97757?style=flat-square&logo=claude&logoColor=fff" alt="Working on Claude">
 </p>
 
 <p align="center">
@@ -27,7 +33,7 @@
 
 Every time you start a new AI coding session, you re-explain your architecture, paste docs, repeat conventions, and clarify past decisions. Your AI assistant is powerful - but it forgets everything between sessions.
 
-**Knowns fixes that.** It gives AI assistants like Claude, Cursor, Copilot, and others structured, persistent access to your project's tasks, documentation, specs, acceptance criteria, and architectural decisions. Instead of prompting from scratch, your AI reads what it needs and picks up where you left off.
+**Knowns fixes that.** It gives AI assistants like Claude Code, Codex, Cursor, Copilot, OpenCode, and others structured, persistent access to your project's tasks, documentation, specs, acceptance criteria, and architectural decisions. Instead of prompting from scratch, your AI reads what it needs and picks up where you left off.
 
 If you believe AI should truly understand software projects, consider giving **Knowns** a star.
 
@@ -50,6 +56,7 @@ If you believe AI should truly understand software projects, consider giving **K
 - [Quick Start](#quick-start)
 - [Core Capabilities](#core-capabilities)
 - [What You Can Build](#what-you-can-build-with-knowns)
+- [AI Integrations](#ai-integrations)
 - [Agent Skills Workflow](#agent-skills-workflow)
 - [Installation](#installation)
 - [Documentation](#documentation)
@@ -119,7 +126,7 @@ Everything lives in a `.knowns/` directory in your repo. Plain files. Committabl
 - **Solo developers** who pair with AI daily and want it to remember project context across sessions
 - **Teams** building with AI assistants and tired of everyone re-explaining the same architecture
 - **Open-source maintainers** who want contributors (human or AI) to onboard faster
-- **Anyone** who uses Claude, Cursor, Copilot, Windsurf, or other AI coding tools and wants them to actually understand the project
+- **Anyone** who uses Claude Code, Codex, Cursor, Copilot, OpenCode, Windsurf, or other AI coding tools and wants them to actually understand the project
 
 ---
 
@@ -241,7 +248,7 @@ knowns search "how does authentication work" --plain
 
 ### MCP Integration
 
-Full [Model Context Protocol](https://modelcontextprotocol.io/) server. Claude, Cursor, and other MCP-compatible assistants get native access to tasks, docs, memory, search, and validation - no copy-pasting required.
+Full [Model Context Protocol](https://modelcontextprotocol.io/) server. Claude Code, Codex, Cursor, OpenCode, and other MCP-compatible assistants get native access to tasks, docs, memory, search, and validation - no copy-pasting required.
 
 ### Code Intelligence
 
@@ -303,6 +310,26 @@ knowns browser --open
 | **AI Workspaces** | Multi-phase agent orchestration with worktree isolation |
 | **Code Intelligence** | LSP-based symbols, definitions, references, diagnostics, and safe edits |
 | **Web UI** | Kanban board, doc browser, knowledge graph, mermaid diagrams |
+
+---
+
+## AI Integrations
+
+Knowns does not replace your AI assistant. It gives the assistants you already use one shared project context layer: tasks, docs, specs, memory, decisions, search, validation, and code intelligence through MCP and synced skills.
+
+For normal personal setup, use `knowns setup <target> --global`. Use project-level setup only when you intentionally want config files committed or scoped to one repository.
+
+| Assistant | Setup | What it gets |
+|---|---|---|
+| Claude Code | `knowns setup claude --global` | MCP, `/kn-*` skills, runtime memory hooks |
+| Codex | `knowns setup codex --global` | MCP, `$kn-*` skills, runtime memory hooks |
+| OpenCode | `knowns setup opencode --global` | MCP, `.agents/skills`, plugin/runtime integration |
+| Kiro | `knowns setup kiro --global` | MCP, skills, runtime hooks |
+| Cursor | `knowns setup cursor --global` | MCP access to Knowns context |
+| Gemini / Antigravity | `knowns setup gemini --global` / `knowns setup antigravity --global` | Global MCP config |
+| Copilot / generic agents | `knowns setup copilot` / `knowns setup agents` | Instruction shims and agent-readable guidance |
+
+See [Platforms](./docs/en/integrations/platforms.md) for the full mapping.
 
 ---
 
@@ -447,15 +474,34 @@ make install      # Install to GOPATH/bin
 
 ### Uninstall
 
+Use the method that matches how you installed Knowns:
+
 ```bash
-# macOS/Linux
+# Homebrew
+brew uninstall knowns
+
+# npm
+npm uninstall -g knowns
+
+# Shell installer (macOS/Linux)
 curl -fsSL https://knowns.sh/script/uninstall | sh
 
-# Windows
+# Go install
+rm -f "$(go env GOPATH)/bin/knowns"
+```
+
+```powershell
+# PowerShell installer (Windows)
 irm https://knowns.sh/script/uninstall.ps1 | iex
 ```
 
-The uninstall scripts only remove installed CLI binaries and PATH entries added by the installer. They leave project `.knowns/` folders untouched.
+If you installed runtime memory adapters, remove them before uninstalling the CLI:
+
+```bash
+knowns runtime uninstall codex
+```
+
+Uninstall removes CLI binaries and PATH entries added by the installer. It leaves project `.knowns/` folders, tasks, docs, memories, and AI integration files untouched. Delete `.knowns/` only if you intentionally want to discard project context.
 
 ---
 
@@ -514,6 +560,7 @@ knowns sync
 
 | Guide | Description |
 |---|---|
+| [Installation](./docs/en/getting-started/installation.md) | Install, verify, run without a global install, and uninstall |
 | [User Guide](./docs/en/guides/user-guide.md) | Getting started and daily usage |
 | [Command Reference](./docs/en/reference/commands.md) | Core CLI commands with examples |
 | [Workflow Guide](./docs/en/guides/workflow.md) | Recommended human + AI workflow |

--- a/README.vi.md
+++ b/README.vi.md
@@ -6,11 +6,17 @@
 
 <p align="center">
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-%3E%3D1.24.2-00ADD8?style=flat-square&logo=go" alt="Go"></a>
-  <a href="https://www.npmjs.com/package/knowns"><img src="https://img.shields.io/npm/v/knowns.svg?style=flat-square" alt="npm"></a>
+  <a href="https://github.com/knowns-dev/knowns/releases"><img src="https://img.shields.io/github/v/release/knowns-dev/knowns?style=flat-square" alt="Release"></a>
+  <a href="https://github.com/knowns-dev/knowns/stargazers"><img src="https://img.shields.io/github/stars/knowns-dev/knowns?style=flat-square" alt="GitHub stars"></a>
   <a href="https://github.com/knowns-dev/knowns/actions/workflows/ci.yml"><img src="https://github.com/knowns-dev/knowns/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="#cài-đặt"><img src="https://img.shields.io/badge/platform-win%20%7C%20mac%20%7C%20linux-lightgrey?style=flat-square" alt="Platform"></a>
-  <a href="https://discord.knowns.dev"><img src="https://img.shields.io/badge/Discord-Community-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://discord.knowns.dev"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Join Discord"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/knowns-dev/knowns?style=flat-square" alt="License"></a>
+</p>
+
+<p align="center">
+  <img src="https://custom-icon-badges.demolab.com/badge/Working%20on-Codex-111111?style=flat-square&logo=openai&logoColor=white" alt="Working on Codex">
+  <img src="https://img.shields.io/badge/Working%20on-Claude-D97757?style=flat-square&logo=claude&logoColor=fff" alt="Working on Claude">
 </p>
 
 <p align="center">
@@ -27,7 +33,7 @@
 
 Mỗi lần mở session mới với AI, bạn lại phải giải thích lại architecture, paste doc, nhắc lại convention, làm rõ decision cũ. AI rất mạnh — nhưng nó không nhớ gì giữa các session.
 
-**Knowns fix đúng chỗ đó.** Cho AI assistants như Claude, Cursor, Copilot truy cập bền vững vào task, doc, spec, acceptance criteria, và architectural decisions của project. Thay vì prompt từ đầu, AI đọc đúng phần nó cần và tiếp tục từ chỗ bạn dừng.
+**Knowns fix đúng chỗ đó.** Cho AI assistants như Claude Code, Codex, Cursor, Copilot, OpenCode và các công cụ khác truy cập bền vững vào task, doc, spec, acceptance criteria, và architectural decisions của project. Thay vì prompt từ đầu, AI đọc đúng phần nó cần và tiếp tục từ chỗ bạn dừng.
 
 Nếu bạn nghĩ AI nên thực sự hiểu software project, cho **Knowns** một star nhé.
 
@@ -50,6 +56,7 @@ Nếu bạn nghĩ AI nên thực sự hiểu software project, cho **Knowns** m�
 - [Quick start](#quick-start)
 - [Khả năng chính](#khả-năng-chính)
 - [Xây được gì với Knowns?](#xây-được-gì-với-knowns)
+- [AI integrations](#ai-integrations)
 - [Agent skills workflow](#agent-skills-workflow)
 - [Cài đặt](#cài-đặt)
 - [Tài liệu](#tài-liệu)
@@ -119,7 +126,7 @@ Tất cả nằm trong `.knowns/` của repo. Plain files. Commit vào Git đư�
 - **Solo developers** pair với AI hằng ngày, muốn AI nhớ project context across sessions
 - **Teams** dùng AI assistants, chán cảnh ai cũng phải giải thích lại architecture
 - **Open-source maintainers** muốn contributors (người hoặc AI) onboard nhanh hơn
-- **Bất kỳ ai** dùng Claude, Cursor, Copilot, Windsurf hay AI coding tools khác và muốn chúng thực sự hiểu project
+- **Bất kỳ ai** dùng Claude Code, Codex, Cursor, Copilot, OpenCode, Windsurf hay AI coding tools khác và muốn chúng thực sự hiểu project
 
 ---
 
@@ -241,7 +248,7 @@ knowns search "how does authentication work" --plain
 
 ### MCP integration
 
-Full [Model Context Protocol](https://modelcontextprotocol.io/) server. Claude, Cursor và các MCP-compatible assistants truy cập trực tiếp task, doc, memory, search, validation — không cần copy-paste.
+Full [Model Context Protocol](https://modelcontextprotocol.io/) server. Claude Code, Codex, Cursor, OpenCode và các MCP-compatible assistants truy cập trực tiếp task, doc, memory, search, validation — không cần copy-paste.
 
 ### Code intelligence
 
@@ -303,6 +310,26 @@ knowns browser --open
 | **AI Workspaces** | Multi-phase agent orchestration với worktree isolation |
 | **Code Intelligence** | LSP-backed: symbols, definitions, references, rename, replace, insert, delete |
 | **Web UI** | Kanban board, doc browser, knowledge graph, mermaid diagrams |
+
+---
+
+## AI integrations
+
+Knowns không thay thế AI assistant bạn đang dùng. Nó cho các assistant đó một shared project context layer: task, doc, spec, memory, decision, search, validation và code intelligence qua MCP và synced skills.
+
+Với personal setup thông thường, dùng `knowns setup <target> --global`. Chỉ dùng project-level setup khi bạn chủ ý muốn config files nằm trong một repository cụ thể.
+
+| Assistant | Setup | Nhận được gì |
+|---|---|---|
+| Claude Code | `knowns setup claude --global` | MCP, `/kn-*` skills, runtime memory hooks |
+| Codex | `knowns setup codex --global` | MCP, `$kn-*` skills, runtime memory hooks |
+| OpenCode | `knowns setup opencode --global` | MCP, `.agents/skills`, plugin/runtime integration |
+| Kiro | `knowns setup kiro --global` | MCP, skills, runtime hooks |
+| Cursor | `knowns setup cursor --global` | MCP access tới Knowns context |
+| Gemini / Antigravity | `knowns setup gemini --global` / `knowns setup antigravity --global` | Global MCP config |
+| Copilot / generic agents | `knowns setup copilot` / `knowns setup agents` | Instruction shims và agent-readable guidance |
+
+Xem [Platforms](./docs/vi/integrations/platforms.md) để biết mapping đầy đủ.
 
 ---
 
@@ -445,15 +472,34 @@ make install      # Cài vào GOPATH/bin
 
 ### Gỡ cài đặt
 
+Dùng cách tương ứng với cách bạn đã cài Knowns:
+
 ```bash
-# macOS/Linux
+# Homebrew
+brew uninstall knowns
+
+# npm
+npm uninstall -g knowns
+
+# Shell installer (macOS/Linux)
 curl -fsSL https://knowns.sh/script/uninstall | sh
 
-# Windows
+# Go install
+rm -f "$(go env GOPATH)/bin/knowns"
+```
+
+```powershell
+# PowerShell installer (Windows)
 irm https://knowns.sh/script/uninstall.ps1 | iex
 ```
 
-Uninstall scripts chỉ xóa CLI binary và PATH entries do installer thêm. Không đụng tới `.knowns/` trong các project.
+Nếu đã cài runtime memory adapter, gỡ adapter trước khi gỡ CLI:
+
+```bash
+knowns runtime uninstall codex
+```
+
+Uninstall chỉ xóa CLI binary và PATH entries do installer thêm. Không đụng tới `.knowns/`, task, doc, memory, hoặc AI integration files trong project. Chỉ xóa `.knowns/` khi bạn thật sự muốn bỏ toàn bộ project context.
 
 ---
 
@@ -512,6 +558,7 @@ knowns sync
 
 | Guide | Mô tả |
 |---|---|
+| [Cài đặt](./docs/vi/getting-started/installation.md) | Cài đặt, kiểm tra, chạy không cần global install, và gỡ cài đặt |
 | [Hướng dẫn sử dụng](./docs/vi/guides/user-guide.md) | Bắt đầu và sử dụng hằng ngày |
 | [Lệnh](./docs/vi/reference/commands.md) | CLI commands chính và ví dụ |
 | [Workflow](./docs/vi/guides/workflow.md) | Cách làm việc đề xuất |

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ If you are new to Knowns, start with installation, then run the quick start, the
 ## Start here
 
 - Install the CLI: [English](./en/getting-started/installation.md) / [Tieng Viet](./vi/getting-started/installation.md)
+- Uninstall the CLI: [English](./en/getting-started/uninstall.md) / [Tieng Viet](./vi/getting-started/uninstall.md)
 - Create a working project: [English](./en/getting-started/quick-start.md) / [Tieng Viet](./vi/getting-started/quick-start.md)
 - Understand why Knowns exists: [English](./en/guides/why-knowns.md) / [Tieng Viet](./vi/guides/why-knowns.md)
 - Learn the project workflow: [English](./en/guides/workflow.md) / [Tieng Viet](./vi/guides/workflow.md)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -28,10 +28,11 @@ Use these docs if you want to:
 6. [Task Management](./guides/task-management.md)
 7. [AI Agent Guide](./guides/ai-agent-guide.md)
 8. [AI Workflow](./guides/ai-workflow.md)
+9. [Uninstall](./getting-started/uninstall.md)
 
 ## Which page should I read first?
 
-- New user: start with [Installation](./getting-started/installation.md), then [Quick start](./getting-started/quick-start.md).
+- New user: start with [Installation](./getting-started/installation.md), then [Quick start](./getting-started/quick-start.md). If you need to remove the CLI later, use [Uninstall](./getting-started/uninstall.md).
 - Existing project owner: read [First project](./getting-started/first-project.md), then [Workflow](./guides/workflow.md).
 - AI assistant user: read [AI Workflow](./guides/ai-workflow.md), [MCP integration](./guides/mcp-integration.md), and [Skills](./integrations/skills.md).
 - CLI reference lookup: go directly to [Commands](./reference/commands.md).
@@ -56,6 +57,7 @@ Use these docs if you want to:
 - [Installation](./getting-started/installation.md)
 - [Quick start](./getting-started/quick-start.md)
 - [First project](./getting-started/first-project.md)
+- [Uninstall](./getting-started/uninstall.md)
 
 ### Guides
 

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -74,6 +74,11 @@ If you do not want a global install, you can still run Knowns through npm:
 npx knowns init
 ```
 
+## Uninstall
+
+See [Uninstall](./uninstall.md) for Homebrew, npm, shell installer, PowerShell, Go install, runtime adapter cleanup, and what project files are intentionally left behind.
+
 ## Next step
 
 - [Quick start](./quick-start.md)
+- [Uninstall](./uninstall.md)

--- a/docs/en/getting-started/uninstall.md
+++ b/docs/en/getting-started/uninstall.md
@@ -1,0 +1,79 @@
+# Uninstall
+
+Use the uninstall method that matches how you installed Knowns. Uninstalling the CLI does not delete project context by default.
+
+## Homebrew
+
+```bash
+brew uninstall knowns
+```
+
+## npm
+
+```bash
+npm uninstall -g knowns
+```
+
+## Shell installer on macOS/Linux
+
+```bash
+curl -fsSL https://knowns.sh/script/uninstall | sh
+```
+
+If you installed into a custom directory, pass the same directory to the uninstaller:
+
+```bash
+curl -fsSL https://knowns.sh/script/uninstall | KNOWNS_INSTALL_DIR="$HOME/.local/bin" sh
+```
+
+## PowerShell installer on Windows
+
+```powershell
+irm https://knowns.sh/script/uninstall.ps1 | iex
+```
+
+If you installed into a custom directory, set the same directory first:
+
+```powershell
+$env:KNOWNS_INSTALL_DIR = "$env:USERPROFILE\.knowns\bin"
+irm https://knowns.sh/script/uninstall.ps1 | iex
+```
+
+## Go install
+
+```bash
+rm -f "$(go env GOPATH)/bin/knowns"
+```
+
+If you installed a `kn` alias manually, remove that too.
+
+## Remove runtime memory adapters
+
+If you enabled runtime memory hooks for an assistant, remove the adapter before uninstalling the CLI:
+
+```bash
+knowns runtime uninstall codex
+knowns runtime uninstall claude
+knowns runtime uninstall opencode
+knowns runtime uninstall kiro
+```
+
+Run only the commands for runtimes you actually configured.
+
+## What is left behind
+
+The uninstall scripts remove installed CLI binaries and PATH entries added by the installer. They intentionally leave these files alone:
+
+- project `.knowns/` folders
+- tasks, docs, specs, memory, decisions, and templates
+- generated AI integration files such as `AGENTS.md`, `CLAUDE.md`, `.agents/skills`, `.claude/skills`, `.mcp.json`, `.codex/config.toml`, or `opencode.json`
+
+Delete those files manually only if you intentionally want to discard project context or remove AI integration artifacts from a repository.
+
+## Verify removal
+
+```bash
+knowns --version
+```
+
+If the command is not found, the CLI has been removed from your active PATH. Open a new terminal if your shell still sees an old PATH entry.

--- a/docs/vi/README.md
+++ b/docs/vi/README.md
@@ -30,10 +30,11 @@ Nội dung tiếng Việt bám theo `docs/en/` nhưng viết lại cho dễ đ�
 6. [Quản lý task](./guides/task-management.md)
 7. [Làm việc với AI](./guides/ai-agent-guide.md)
 8. [AI workflow](./guides/ai-workflow.md)
+9. [Gỡ cài đặt](./getting-started/uninstall.md)
 
 ## Nên đọc trang nào trước?
 
-- Người mới: đọc [Cài đặt](./getting-started/installation.md), rồi [Quick start](./getting-started/quick-start.md).
+- Người mới: đọc [Cài đặt](./getting-started/installation.md), rồi [Quick start](./getting-started/quick-start.md). Nếu cần gỡ CLI sau này, xem [Gỡ cài đặt](./getting-started/uninstall.md).
 - Project owner: đọc [Dự án đầu tiên](./getting-started/first-project.md), rồi [Workflow](./guides/workflow.md).
 - Người dùng AI assistant: đọc [AI workflow](./guides/ai-workflow.md), [MCP](./guides/mcp-integration.md), và [Skills](./integrations/skills.md).
 - Muốn tra cứu CLI: vào thẳng [Lệnh](./reference/commands.md).
@@ -53,6 +54,7 @@ Nội dung tiếng Việt bám theo `docs/en/` nhưng viết lại cho dễ đ�
 - [Cài đặt](./getting-started/installation.md)
 - [Quick start](./getting-started/quick-start.md)
 - [Dự án đầu tiên](./getting-started/first-project.md)
+- [Gỡ cài đặt](./getting-started/uninstall.md)
 
 ### Hướng dẫn
 

--- a/docs/vi/getting-started/installation.md
+++ b/docs/vi/getting-started/installation.md
@@ -74,6 +74,11 @@ Chạy qua npx:
 npx knowns init
 ```
 
+## Gỡ cài đặt
+
+Xem [Gỡ cài đặt](./uninstall.md) cho Homebrew, npm, shell installer, PowerShell, Go install, cleanup runtime adapter, và các project files được giữ lại có chủ ý.
+
 ## Tiếp theo
 
 - [Quick start](./quick-start.md)
+- [Gỡ cài đặt](./uninstall.md)

--- a/docs/vi/getting-started/uninstall.md
+++ b/docs/vi/getting-started/uninstall.md
@@ -1,0 +1,79 @@
+# Gỡ cài đặt
+
+Dùng cách gỡ tương ứng với cách bạn đã cài Knowns. Gỡ CLI mặc định không xóa project context.
+
+## Homebrew
+
+```bash
+brew uninstall knowns
+```
+
+## npm
+
+```bash
+npm uninstall -g knowns
+```
+
+## Shell installer trên macOS/Linux
+
+```bash
+curl -fsSL https://knowns.sh/script/uninstall | sh
+```
+
+Nếu trước đó bạn cài vào thư mục custom, truyền lại cùng thư mục cho uninstaller:
+
+```bash
+curl -fsSL https://knowns.sh/script/uninstall | KNOWNS_INSTALL_DIR="$HOME/.local/bin" sh
+```
+
+## PowerShell installer trên Windows
+
+```powershell
+irm https://knowns.sh/script/uninstall.ps1 | iex
+```
+
+Nếu trước đó bạn cài vào thư mục custom, set lại cùng thư mục trước:
+
+```powershell
+$env:KNOWNS_INSTALL_DIR = "$env:USERPROFILE\.knowns\bin"
+irm https://knowns.sh/script/uninstall.ps1 | iex
+```
+
+## Go install
+
+```bash
+rm -f "$(go env GOPATH)/bin/knowns"
+```
+
+Nếu bạn tự tạo alias `kn`, hãy xóa alias đó luôn.
+
+## Gỡ runtime memory adapters
+
+Nếu đã bật runtime memory hooks cho assistant, gỡ adapter trước khi gỡ CLI:
+
+```bash
+knowns runtime uninstall codex
+knowns runtime uninstall claude
+knowns runtime uninstall opencode
+knowns runtime uninstall kiro
+```
+
+Chỉ chạy các lệnh tương ứng với runtime bạn đã cấu hình.
+
+## Những gì được giữ lại
+
+Uninstall scripts chỉ xóa CLI binary và PATH entries do installer thêm. Các file sau được giữ nguyên có chủ ý:
+
+- project `.knowns/` folders
+- task, doc, spec, memory, decision, và template
+- AI integration files đã generate như `AGENTS.md`, `CLAUDE.md`, `.agents/skills`, `.claude/skills`, `.mcp.json`, `.codex/config.toml`, hoặc `opencode.json`
+
+Chỉ xóa thủ công các file đó khi bạn thật sự muốn bỏ project context hoặc remove AI integration artifacts khỏi repository.
+
+## Kiểm tra đã gỡ xong
+
+```bash
+knowns --version
+```
+
+Nếu command not found, CLI đã được gỡ khỏi PATH hiện tại. Mở terminal mới nếu shell vẫn còn thấy PATH cũ.

--- a/internal/lsp/adapters/helpers.go
+++ b/internal/lsp/adapters/helpers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/howznguyen/knowns/internal/lsp"
+	knownsprocess "github.com/howznguyen/knowns/internal/process"
 )
 
 func checkBinary(ctx context.Context, name string, args ...string) error {
@@ -21,7 +22,7 @@ func checkBinary(ctx context.Context, name string, args ...string) error {
 	if len(args) == 0 {
 		return nil
 	}
-	cmd := exec.CommandContext(ctx, path, args...)
+	cmd := knownsprocess.CommandContext(ctx, path, args...)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%s %s failed: %w: %s", name, strings.Join(args, " "), err, strings.TrimSpace(string(output)))
 	}
@@ -67,7 +68,7 @@ func commandOutput(ctx context.Context, name string, args ...string) (string, er
 	if err != nil {
 		return "", fmt.Errorf("%s not found in PATH: %w", name, err)
 	}
-	cmd := exec.CommandContext(ctx, path, args...)
+	cmd := knownsprocess.CommandContext(ctx, path, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%s %s failed: %w: %s", name, strings.Join(args, " "), err, strings.TrimSpace(string(output)))

--- a/internal/lsp/adapters/python.go
+++ b/internal/lsp/adapters/python.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/howznguyen/knowns/internal/lsp"
+	knownsprocess "github.com/howznguyen/knowns/internal/process"
 )
 
 type PythonAdapter struct{ lsp.BaseAdapter }
@@ -45,7 +46,7 @@ func (a *PythonAdapter) Install(ctx context.Context, targetDir string) (string, 
 	if pm == "uv" {
 		args = []string{"tool", "install", "python-lsp-server"}
 	}
-	cmd := exec.CommandContext(ctx, pm, args...)
+	cmd := knownsprocess.CommandContext(ctx, pm, args...)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("%s install failed: %w: %s", pm, err, output)
 	}

--- a/internal/lsp/adapters/ruby.go
+++ b/internal/lsp/adapters/ruby.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/howznguyen/knowns/internal/lsp"
+	knownsprocess "github.com/howznguyen/knowns/internal/process"
 )
 
 type RubyLspAdapter struct{ lsp.BaseAdapter }
@@ -34,7 +35,7 @@ func (a *RubyLspAdapter) InstallGuide() lsp.InstallGuide {
 func (a *RubyLspAdapter) CanInstall() bool                     { return true }
 func (a *RubyLspAdapter) RuntimeDeps() []lsp.RuntimeDependency { return nil }
 func (a *RubyLspAdapter) Install(ctx context.Context, targetDir string) (string, error) {
-	cmd := exec.CommandContext(ctx, "gem", "install", "ruby-lsp")
+	cmd := knownsprocess.CommandContext(ctx, "gem", "install", "ruby-lsp")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("gem install failed: %w: %s", err, output)
 	}

--- a/internal/lsp/adapters/rust.go
+++ b/internal/lsp/adapters/rust.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/howznguyen/knowns/internal/lsp"
+	knownsprocess "github.com/howznguyen/knowns/internal/process"
 )
 
 type RustAnalyzerAdapter struct{ lsp.BaseAdapter }
@@ -31,7 +32,7 @@ func (a *RustAnalyzerAdapter) InstallGuide() lsp.InstallGuide {
 func (a *RustAnalyzerAdapter) CanInstall() bool                     { return true }
 func (a *RustAnalyzerAdapter) RuntimeDeps() []lsp.RuntimeDependency { return nil }
 func (a *RustAnalyzerAdapter) Install(ctx context.Context, targetDir string) (string, error) {
-	cmd := exec.CommandContext(ctx, "rustup", "component", "add", "rust-analyzer")
+	cmd := knownsprocess.CommandContext(ctx, "rustup", "component", "add", "rust-analyzer")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("rustup install failed: %w: %s", err, output)
 	}

--- a/internal/lsp/detect.go
+++ b/internal/lsp/detect.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	knownsprocess "github.com/howznguyen/knowns/internal/process"
 )
 
 var autoDetectionIgnoredDirs = map[string]struct{}{
@@ -151,6 +153,6 @@ func (d *Detector) resolve(ctx context.Context, root string, lang Language, over
 }
 
 func runVersionCheck(ctx context.Context, path string, args ...string) error {
-	cmd := exec.CommandContext(ctx, path, args...)
+	cmd := knownsprocess.CommandContext(ctx, path, args...)
 	return cmd.Run()
 }

--- a/internal/lsp/installer.go
+++ b/internal/lsp/installer.go
@@ -14,12 +14,13 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	knownsprocess "github.com/howznguyen/knowns/internal/process"
 )
 
 // CurrentPlatformID returns the current platform identifier (e.g. "darwin-arm64").
@@ -967,7 +968,7 @@ type dependencyLastError struct {
 }
 
 func defaultRunCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+	return knownsprocess.CommandContext(ctx, name, args...).CombinedOutput()
 }
 
 func (i *Installer) writeSelection(adapter LanguageAdapter, dep RuntimeDependency, selectedPath string) error {

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -50,11 +50,17 @@ type Manager struct {
 	status   map[string]ServerStatus
 
 	traceEnabled map[string]bool
+
+	runtimeStatusCache           []LanguageRuntimeStatus
+	runtimeStatusCacheAt         time.Time
+	runtimeStatusCacheGeneration uint64
+	runtimeStatusCacheLoading    bool
+	runtimeStatusCacheCond       *sync.Cond
 }
 
 func NewManager(root string, cfg Config) *Manager {
 	registry := NewEmptyRegistry()
-	return &Manager{
+	m := &Manager{
 		root:     root,
 		registry: registry,
 		detector: NewDetector(registry),
@@ -65,6 +71,8 @@ func NewManager(root string, cfg Config) *Manager {
 
 		traceEnabled: make(map[string]bool),
 	}
+	m.runtimeStatusCacheCond = sync.NewCond(&m.mu)
+	return m
 }
 
 // RegisterAdapter registers a language adapter with the manager.
@@ -78,7 +86,11 @@ func (m *Manager) RegisterAdapter(adapter LanguageAdapter) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.registerAdapterLocked(adapter)
+	if err := m.registerAdapterLocked(adapter); err != nil {
+		return err
+	}
+	m.invalidateRuntimeStatusCacheLocked()
+	return nil
 }
 
 func (m *Manager) RegisterPluginAdapters(opts PluginAdapterLoadOptions) []PluginAdapterLoadError {
@@ -101,6 +113,7 @@ func (m *Manager) SetDetector(detector *Detector) {
 	defer m.mu.Unlock()
 	if detector != nil {
 		m.detector = detector
+		m.invalidateRuntimeStatusCacheLocked()
 	}
 }
 
@@ -116,6 +129,7 @@ func (m *Manager) SetConfig(cfg Config) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.config = cloneManagerConfig(cfg)
+	m.invalidateRuntimeStatusCacheLocked()
 }
 
 func cloneManagerConfig(cfg Config) Config {
@@ -192,15 +206,18 @@ func (m *Manager) ServerForPath(ctx context.Context, path string) (*Server, bool
 		slog.Warn("lsp: server not alive, restarting", "language", lang.ID)
 		m.mu.Lock()
 		m.status[lang.ID] = StatusStarting
+		m.invalidateRuntimeStatusCacheLocked()
 		m.mu.Unlock()
 		if err := srv.Start(ctx); err != nil {
 			m.mu.Lock()
 			m.status[lang.ID] = StatusCrashed
+			m.invalidateRuntimeStatusCacheLocked()
 			m.mu.Unlock()
 			return nil, false, m.runtimeErrorForCommand(srv.Command, err)
 		}
 		m.mu.Lock()
 		m.status[lang.ID] = StatusRunning
+		m.invalidateRuntimeStatusCacheLocked()
 		m.mu.Unlock()
 		return srv, true, nil
 	}
@@ -229,12 +246,14 @@ func (m *Manager) ServerForPath(ctx context.Context, path string) (*Server, bool
 		m.configureServerDocumentSyncLocked(lang.ID, srv)
 		m.configureServerPathCapabilityLocked(lang.ID, srv)
 		m.configureTraceLocked(lang.ID, srv)
+		m.invalidateRuntimeStatusCacheLocked()
 		m.mu.Unlock()
 		if err := srv.Start(ctx); err != nil {
 			return nil, false, m.runtimeErrorForCommand(cmd, err)
 		}
 		m.mu.Lock()
 		m.status[lang.ID] = StatusRunning
+		m.invalidateRuntimeStatusCacheLocked()
 		m.mu.Unlock()
 		return srv, true, nil
 	}
@@ -371,6 +390,7 @@ func (m *Manager) StartAll(ctx context.Context) error {
 			m.status[langID] = StatusStarting
 		}
 	}
+	m.invalidateRuntimeStatusCacheLocked()
 	m.mu.Unlock()
 
 	var wg sync.WaitGroup
@@ -384,11 +404,13 @@ func (m *Manager) StartAll(ctx context.Context) error {
 				slog.Warn("lsp: failed to start server", "language", langID, "error", err)
 				m.mu.Lock()
 				m.status[langID] = StatusCrashed
+				m.invalidateRuntimeStatusCacheLocked()
 				m.mu.Unlock()
 				return
 			}
 			m.mu.Lock()
 			m.status[langID] = StatusRunning
+			m.invalidateRuntimeStatusCacheLocked()
 			m.mu.Unlock()
 		}(item.langID, item.srv)
 	}
@@ -410,6 +432,7 @@ func (m *Manager) StopAll(ctx context.Context) error {
 			m.status[langID] = StatusInstalled
 		}
 	}
+	m.invalidateRuntimeStatusCacheLocked()
 	m.mu.Unlock()
 	return nil
 }
@@ -556,6 +579,7 @@ func (m *Manager) startCommand(ctx context.Context, langID string, cmd ServerCom
 	m.configureServerPathCapabilityLocked(langID, srv)
 	m.configureTraceLocked(langID, srv)
 	m.status[langID] = StatusStarting
+	m.invalidateRuntimeStatusCacheLocked()
 	m.mu.Unlock()
 
 	startCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
@@ -564,11 +588,13 @@ func (m *Manager) startCommand(ctx context.Context, langID string, cmd ServerCom
 	if err != nil {
 		m.mu.Lock()
 		m.status[langID] = StatusCrashed
+		m.invalidateRuntimeStatusCacheLocked()
 		m.mu.Unlock()
 		return m.runtimeErrorForCommand(cmd, err)
 	}
 	m.mu.Lock()
 	m.status[langID] = StatusRunning
+	m.invalidateRuntimeStatusCacheLocked()
 	m.mu.Unlock()
 	return nil
 }
@@ -692,11 +718,13 @@ func (m *Manager) stopLanguage(ctx context.Context, langID string, stoppedStatus
 	if srv == nil {
 		if _, ok := m.status[langID]; ok {
 			m.status[langID] = stoppedStatus
+			m.invalidateRuntimeStatusCacheLocked()
 		}
 		m.mu.Unlock()
 		return nil
 	}
 	m.status[langID] = stoppedStatus
+	m.invalidateRuntimeStatusCacheLocked()
 	m.mu.Unlock()
 
 	err := srv.Stop(ctx)
@@ -704,6 +732,7 @@ func (m *Manager) stopLanguage(ctx context.Context, langID string, stoppedStatus
 	m.mu.Lock()
 	delete(m.servers, langID)
 	m.status[langID] = stoppedStatus
+	m.invalidateRuntimeStatusCacheLocked()
 	m.mu.Unlock()
 	return err
 }
@@ -749,6 +778,11 @@ func (m *Manager) InstallLanguageWithOptions(ctx context.Context, langID string,
 			return m.refreshAdapterRegistration(langID)
 		}
 		path, err := installer.InstallWithOptions(ctx, installAdapter, opts)
+		if err == nil {
+			m.mu.Lock()
+			m.invalidateRuntimeStatusCacheLocked()
+			m.mu.Unlock()
+		}
 		return path, err
 	}
 	if !adapter.CanInstall() {
@@ -757,6 +791,11 @@ func (m *Manager) InstallLanguageWithOptions(ctx context.Context, langID string,
 	path, err := adapter.Install(ctx, installer.baseDir)
 	if err == nil {
 		err = m.refreshAdapterRegistration(langID)
+	}
+	if err == nil {
+		m.mu.Lock()
+		m.invalidateRuntimeStatusCacheLocked()
+		m.mu.Unlock()
 	}
 	return path, err
 }
@@ -770,7 +809,13 @@ func (m *Manager) CleanupLanguage(langID string) error {
 	m.mu.Lock()
 	installer := m.installerLocked()
 	m.mu.Unlock()
-	return installer.Cleanup(langID)
+	err := installer.Cleanup(langID)
+	if err == nil {
+		m.mu.Lock()
+		m.invalidateRuntimeStatusCacheLocked()
+		m.mu.Unlock()
+	}
+	return err
 }
 
 // LogTail is a bounded tail of a language runtime or trace log.
@@ -934,7 +979,10 @@ func (m *Manager) refreshAdapterRegistration(langID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if adapter := m.adapters[langID]; adapter != nil {
-		return m.registerAdapterLocked(adapter)
+		if err := m.registerAdapterLocked(adapter); err != nil {
+			return err
+		}
+		m.invalidateRuntimeStatusCacheLocked()
 	}
 	return nil
 }

--- a/internal/lsp/plugin_adapter.go
+++ b/internal/lsp/plugin_adapter.go
@@ -8,10 +8,11 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	knownsprocess "github.com/howznguyen/knowns/internal/process"
 )
 
 // PluginAdapterManifest is the JSON schema for user-contributed LSP adapters.
@@ -178,7 +179,7 @@ func (a *PluginAdapter) CheckPrerequisites(ctx context.Context) error {
 		if len(fields) == 0 {
 			continue
 		}
-		cmd := exec.CommandContext(ctx, fields[0], fields[1:]...)
+		cmd := knownsprocess.CommandContext(ctx, fields[0], fields[1:]...)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			name := prereq.Name

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	knownsprocess "github.com/howznguyen/knowns/internal/process"
 )
 
 type Server struct {
@@ -110,7 +112,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.mu.Lock()
 	s.clearCapabilitiesLocked()
 	s.clearDiagnosticsLocked()
-	cmd := exec.Command(s.Command.Path, s.Command.Args...)
+	cmd := knownsprocess.Command(s.Command.Path, s.Command.Args...)
 	cmd.Dir = s.Root
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/lsp/status.go
+++ b/internal/lsp/status.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -35,7 +36,10 @@ const (
 	RuntimeStatusDegraded = "degraded"
 )
 
-const runtimeStatusProbeTimeout = 2 * time.Second
+const (
+	runtimeStatusProbeTimeout = 2 * time.Second
+	runtimeStatusCacheTTL     = 30 * time.Second
+)
 
 // LanguageRuntimeStatus is the canonical per-language LSP runtime snapshot used
 // by CLI, MCP/API status, and server routes.
@@ -101,6 +105,11 @@ type RuntimeStatusOptions struct {
 // CollectRuntimeStatuses returns status for adapters without starting servers
 // or installing dependencies.
 func CollectRuntimeStatuses(ctx context.Context, opts RuntimeStatusOptions) []LanguageRuntimeStatus {
+	statuses := collectRuntimeInventoryStatuses(ctx, opts)
+	return applyRuntimeStatusOverlays(statuses, opts)
+}
+
+func collectRuntimeInventoryStatuses(ctx context.Context, opts RuntimeStatusOptions) []LanguageRuntimeStatus {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -154,10 +163,23 @@ func CollectRuntimeStatuses(ctx context.Context, opts RuntimeStatusOptions) []La
 		} else {
 			status.LogPath = LanguageLogPath(opts.Root, langID)
 		}
-		applyLiveStatus(&status, opts.Status[langID], opts.Servers[langID])
-		applyCapabilityStatus(&status, capabilityProfileForAdapter(adapter), opts.Servers[langID])
-		finalizeRuntimeStatus(&status)
 		statuses = append(statuses, status)
+	}
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i].ID < statuses[j].ID })
+	return statuses
+}
+
+func applyRuntimeStatusOverlays(statuses []LanguageRuntimeStatus, opts RuntimeStatusOptions) []LanguageRuntimeStatus {
+	profileByLanguage := make(map[string]CapabilityProfile, len(opts.Adapters))
+	for _, adapter := range opts.Adapters {
+		if adapter != nil {
+			profileByLanguage[adapter.ID()] = capabilityProfileForAdapter(adapter)
+		}
+	}
+	for i := range statuses {
+		applyLiveStatus(&statuses[i], opts.Status[statuses[i].ID], opts.Servers[statuses[i].ID])
+		applyCapabilityStatus(&statuses[i], profileByLanguage[statuses[i].ID], opts.Servers[statuses[i].ID])
+		finalizeRuntimeStatus(&statuses[i])
 	}
 	sort.Slice(statuses, func(i, j int) bool { return statuses[i].ID < statuses[j].ID })
 	return statuses
@@ -181,7 +203,58 @@ func applyExpectedBackendStatus(status *LanguageRuntimeStatus, adapter LanguageA
 // RuntimeStatuses returns manager-backed runtime status, including live process
 // and readiness state when a server exists.
 func (m *Manager) RuntimeStatuses(ctx context.Context) []LanguageRuntimeStatus {
-	m.mu.Lock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	inventory, opts := m.runtimeStatusInventory(ctx)
+	return applyRuntimeStatusOverlays(inventory, opts)
+}
+
+func (m *Manager) runtimeStatusInventory(ctx context.Context) ([]LanguageRuntimeStatus, RuntimeStatusOptions) {
+	for {
+		m.mu.Lock()
+		opts := m.runtimeStatusOptionsLocked()
+		if m.runtimeStatusCacheCond == nil {
+			m.runtimeStatusCacheCond = sync.NewCond(&m.mu)
+		}
+		if m.runtimeStatusCacheFreshLocked(time.Now()) {
+			inventory := cloneLanguageRuntimeStatuses(m.runtimeStatusCache)
+			m.mu.Unlock()
+			return inventory, opts
+		}
+		if m.runtimeStatusCacheLoading {
+			m.runtimeStatusCacheCond.Wait()
+			m.mu.Unlock()
+			continue
+		}
+		m.runtimeStatusCacheLoading = true
+		generation := m.runtimeStatusCacheGeneration
+		m.mu.Unlock()
+
+		inventory := collectRuntimeInventoryStatuses(ctx, opts)
+		cacheable := ctx.Err() == nil
+
+		m.mu.Lock()
+		if cacheable && generation == m.runtimeStatusCacheGeneration {
+			m.runtimeStatusCache = cloneLanguageRuntimeStatuses(inventory)
+			m.runtimeStatusCacheAt = time.Now()
+		}
+		m.runtimeStatusCacheLoading = false
+		m.runtimeStatusCacheCond.Broadcast()
+		freshOpts := m.runtimeStatusOptionsLocked()
+		if cacheable && generation == m.runtimeStatusCacheGeneration {
+			m.mu.Unlock()
+			return cloneLanguageRuntimeStatuses(inventory), freshOpts
+		}
+		if ctx.Err() != nil {
+			m.mu.Unlock()
+			return cloneLanguageRuntimeStatuses(inventory), freshOpts
+		}
+		m.mu.Unlock()
+	}
+}
+
+func (m *Manager) runtimeStatusOptionsLocked() RuntimeStatusOptions {
 	adapters := make([]LanguageAdapter, 0, len(m.adapters))
 	for _, adapter := range m.adapters {
 		adapters = append(adapters, adapter)
@@ -194,16 +267,46 @@ func (m *Manager) RuntimeStatuses(ctx context.Context) []LanguageRuntimeStatus {
 	for id, server := range m.servers {
 		servers[id] = server
 	}
-	opts := RuntimeStatusOptions{
-		Root:     m.root,
-		Config:   m.config,
-		Adapters: adapters,
-		Detector: m.detector,
-		Status:   status,
-		Servers:  servers,
+	return RuntimeStatusOptions{
+		Root:      m.root,
+		Config:    cloneManagerConfig(m.config),
+		Adapters:  adapters,
+		Detector:  m.detector,
+		Installer: m.installerLocked(),
+		Status:    status,
+		Servers:   servers,
 	}
-	m.mu.Unlock()
-	return CollectRuntimeStatuses(ctx, opts)
+}
+
+func (m *Manager) runtimeStatusCacheFreshLocked(now time.Time) bool {
+	return len(m.runtimeStatusCache) > 0 && !m.runtimeStatusCacheAt.IsZero() && now.Sub(m.runtimeStatusCacheAt) < runtimeStatusCacheTTL
+}
+
+func (m *Manager) invalidateRuntimeStatusCacheLocked() {
+	m.runtimeStatusCache = nil
+	m.runtimeStatusCacheAt = time.Time{}
+	m.runtimeStatusCacheGeneration++
+	if m.runtimeStatusCacheCond != nil {
+		m.runtimeStatusCacheCond.Broadcast()
+	}
+}
+
+func cloneLanguageRuntimeStatuses(statuses []LanguageRuntimeStatus) []LanguageRuntimeStatus {
+	if statuses == nil {
+		return nil
+	}
+	out := make([]LanguageRuntimeStatus, len(statuses))
+	copy(out, statuses)
+	for i := range out {
+		out[i].Attempts = append([]BackendAttempt(nil), statuses[i].Attempts...)
+		out[i].DaemonLeaseOwners = append([]string(nil), statuses[i].DaemonLeaseOwners...)
+		out[i].Capabilities = append([]string(nil), statuses[i].Capabilities...)
+		out[i].AdvertisedCapabilities = append([]string(nil), statuses[i].AdvertisedCapabilities...)
+		out[i].ObservedCapabilities = append([]string(nil), statuses[i].ObservedCapabilities...)
+		out[i].RequiredCapabilities = append([]string(nil), statuses[i].RequiredCapabilities...)
+		out[i].MissingCapabilities = append([]string(nil), statuses[i].MissingCapabilities...)
+	}
+	return out
 }
 
 func detectedRuntimeLanguages(root string, cfg Config, adapters []LanguageAdapter, detector *Detector) map[string]bool {

--- a/internal/lsp/status_test.go
+++ b/internal/lsp/status_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -165,6 +167,165 @@ func TestCollectRuntimeStatusesBinaryCheckUsesTimeout(t *testing.T) {
 	}
 	if statuses[0].InstallState != RuntimeInstallInstalled {
 		t.Fatalf("InstallState = %q, want installed", statuses[0].InstallState)
+	}
+}
+
+func TestManagerRuntimeStatusesCachesInventoryProbes(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	adapter := statusMockAdapter{
+		id:         "go",
+		name:       "Go",
+		extensions: []string{".go"},
+		binaries:   []BinaryCandidate{{Name: "gopls", CheckArgs: []string{"version"}}},
+	}
+	m := NewManager(root, Config{})
+	if err := m.RegisterAdapter(adapter); err != nil {
+		t.Fatal(err)
+	}
+	var checks, commands atomic.Int64
+	m.SetDetector(&Detector{
+		Registry: m.registry,
+		LookPath: func(name string) (string, error) {
+			if name == "gopls" {
+				return "/opt/knowns/bin/gopls", nil
+			}
+			return "", errors.New("missing")
+		},
+		RunCheck: func(context.Context, string, ...string) error {
+			checks.Add(1)
+			return nil
+		},
+		RunCommand: func(context.Context, string, ...string) ([]byte, error) {
+			commands.Add(1)
+			return []byte("gopls v1.2.3\n"), nil
+		},
+		Installer: NewInstaller(t.TempDir()),
+	})
+
+	first := m.RuntimeStatuses(context.Background())
+	second := m.RuntimeStatuses(context.Background())
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("statuses = %#v / %#v, want one status each", first, second)
+	}
+	if got := checks.Load(); got != 1 {
+		t.Fatalf("RunCheck calls = %d, want 1 cached probe", got)
+	}
+	if got := commands.Load(); got != 1 {
+		t.Fatalf("RunCommand calls = %d, want 1 cached version probe", got)
+	}
+}
+
+func TestManagerRuntimeStatusesCoalescesConcurrentInventoryProbes(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	adapter := statusMockAdapter{
+		id:         "go",
+		name:       "Go",
+		extensions: []string{".go"},
+		binaries:   []BinaryCandidate{{Name: "gopls", CheckArgs: []string{"version"}}},
+	}
+	m := NewManager(root, Config{})
+	if err := m.RegisterAdapter(adapter); err != nil {
+		t.Fatal(err)
+	}
+	var checks, commands atomic.Int64
+	m.SetDetector(&Detector{
+		Registry: m.registry,
+		LookPath: func(name string) (string, error) {
+			if name == "gopls" {
+				return "/opt/knowns/bin/gopls", nil
+			}
+			return "", errors.New("missing")
+		},
+		RunCheck: func(context.Context, string, ...string) error {
+			checks.Add(1)
+			time.Sleep(50 * time.Millisecond)
+			return nil
+		},
+		RunCommand: func(context.Context, string, ...string) ([]byte, error) {
+			commands.Add(1)
+			return []byte("gopls v1.2.3\n"), nil
+		},
+		Installer: NewInstaller(t.TempDir()),
+	})
+
+	var wg sync.WaitGroup
+	errCh := make(chan string, 10)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			statuses := m.RuntimeStatuses(context.Background())
+			if len(statuses) != 1 || statuses[0].InstallState != RuntimeInstallInstalled {
+				errCh <- "unexpected status"
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for errMsg := range errCh {
+		t.Fatal(errMsg)
+	}
+	if got := checks.Load(); got != 1 {
+		t.Fatalf("RunCheck calls = %d, want 1 coalesced probe", got)
+	}
+	if got := commands.Load(); got != 1 {
+		t.Fatalf("RunCommand calls = %d, want 1 coalesced version probe", got)
+	}
+}
+
+func TestManagerRuntimeStatusesInvalidatesInventoryCacheOnConfigChange(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "config.pathfirst"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	adapter := statusMockAdapter{
+		id:         "pathfirst",
+		name:       "PATH first",
+		extensions: []string{".pathfirst"},
+		binaries:   []BinaryCandidate{{Name: "pathfirst-ls", CheckArgs: []string{"--version"}}},
+	}
+	m := NewManager(root, Config{})
+	if err := m.RegisterAdapter(adapter); err != nil {
+		t.Fatal(err)
+	}
+	var checks atomic.Int64
+	m.SetDetector(&Detector{
+		Registry: m.registry,
+		LookPath: func(name string) (string, error) {
+			switch name {
+			case "pathfirst-ls":
+				return "/usr/bin/pathfirst-ls", nil
+			case "/opt/custom/pathfirst-ls":
+				return "/opt/custom/pathfirst-ls", nil
+			default:
+				return "", os.ErrNotExist
+			}
+		},
+		RunCheck: func(context.Context, string, ...string) error {
+			checks.Add(1)
+			return nil
+		},
+		Installer: NewInstaller(t.TempDir()),
+	})
+
+	_ = m.RuntimeStatuses(context.Background())
+	_ = m.RuntimeStatuses(context.Background())
+	if got := checks.Load(); got != 1 {
+		t.Fatalf("RunCheck calls before invalidation = %d, want 1", got)
+	}
+	m.SetConfig(Config{Languages: map[string]LanguageConfig{"pathfirst": {Binary: "/opt/custom/pathfirst-ls"}}})
+	statuses := m.RuntimeStatuses(context.Background())
+	if got := checks.Load(); got != 2 {
+		t.Fatalf("RunCheck calls after config invalidation = %d, want 2", got)
+	}
+	if len(statuses) != 1 || statuses[0].BinaryPath != "/opt/custom/pathfirst-ls" || statuses[0].Source != RuntimeSourceConfig {
+		t.Fatalf("status after config invalidation = %#v, want custom config binary", statuses)
 	}
 }
 

--- a/internal/mcp/handlers/mutation_response_test.go
+++ b/internal/mcp/handlers/mutation_response_test.go
@@ -2,10 +2,13 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/howznguyen/knowns/internal/models"
 	"github.com/howznguyen/knowns/internal/storage"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -197,6 +200,137 @@ func TestTaskMutationResponseModes(t *testing.T) {
 	}
 	if _, ok := fullCreatePayload["success"]; ok {
 		t.Fatalf("full task create unexpectedly wrapped: %#v", fullCreatePayload)
+	}
+}
+
+func TestMCPTaskUpdateUsesBestEffortIndexing(t *testing.T) {
+	store := storage.NewStore(filepath.Join(t.TempDir(), ".knowns"))
+	if err := store.Init("mcp-task-update-indexing"); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	getStore := func() *storage.Store { return store }
+	seedTask(t, store, "fast01", "Fast MCP update")
+
+	oldBestEffortIndexTask := mcpBestEffortIndexTask
+	oldReconcileTaskIndex := mcpReconcileTaskIndex
+	t.Cleanup(func() {
+		mcpBestEffortIndexTask = oldBestEffortIndexTask
+		mcpReconcileTaskIndex = oldReconcileTaskIndex
+	})
+
+	bestEffortCalls := 0
+	reconcileCalls := 0
+	mcpBestEffortIndexTask = func(_ *storage.Store, id string) {
+		bestEffortCalls++
+		if id != "fast01" {
+			t.Fatalf("best-effort index id = %q, want fast01", id)
+		}
+	}
+	mcpReconcileTaskIndex = func(_ *storage.Store, id string) error {
+		reconcileCalls++
+		return errors.New("synchronous task reconciliation must not run for MCP update")
+	}
+
+	result, err := handleTaskUpdate(getStore, mutationRequest(map[string]any{
+		"taskId":      "fast01",
+		"status":      "in-progress",
+		"appendNotes": "update should return before semantic indexing",
+	}))
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("update task returned error result: %s", mutationResultText(t, result))
+	}
+	if bestEffortCalls != 1 {
+		t.Fatalf("best-effort index calls = %d, want 1", bestEffortCalls)
+	}
+	if reconcileCalls != 0 {
+		t.Fatalf("sync reconcile calls = %d, want 0", reconcileCalls)
+	}
+	storedTask, err := store.Tasks.Get("fast01")
+	if err != nil {
+		t.Fatalf("get updated task: %v", err)
+	}
+	if storedTask.Status != "in-progress" || storedTask.ImplementationNotes != "update should return before semantic indexing" {
+		t.Fatalf("stored task = status %q notes %q", storedTask.Status, storedTask.ImplementationNotes)
+	}
+}
+
+func TestMCPTimeMutationsUseBestEffortIndexing(t *testing.T) {
+	store := storage.NewStore(filepath.Join(t.TempDir(), ".knowns"))
+	if err := store.Init("mcp-time-indexing"); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	getStore := func() *storage.Store { return store }
+	seedTask(t, store, "time01", "Fast MCP time")
+
+	oldBestEffortIndexTask := mcpBestEffortIndexTask
+	oldReconcileTaskIndex := mcpReconcileTaskIndex
+	t.Cleanup(func() {
+		mcpBestEffortIndexTask = oldBestEffortIndexTask
+		mcpReconcileTaskIndex = oldReconcileTaskIndex
+	})
+
+	bestEffortCalls := 0
+	reconcileCalls := 0
+	mcpBestEffortIndexTask = func(_ *storage.Store, id string) {
+		bestEffortCalls++
+		if id != "time01" {
+			t.Fatalf("best-effort index id = %q, want time01", id)
+		}
+	}
+	mcpReconcileTaskIndex = func(_ *storage.Store, id string) error {
+		reconcileCalls++
+		return errors.New("synchronous task reconciliation must not run for MCP time mutation")
+	}
+
+	addResult, err := handleTimeAdd(getStore, mutationRequest(map[string]any{
+		"taskId":   "time01",
+		"duration": "5m",
+		"note":     "manual entry",
+	}))
+	if err != nil {
+		t.Fatalf("add time: %v", err)
+	}
+	if addResult == nil || addResult.IsError {
+		t.Fatalf("add time returned error result: %s", mutationResultText(t, addResult))
+	}
+	if bestEffortCalls != 1 {
+		t.Fatalf("best-effort calls after add = %d, want 1", bestEffortCalls)
+	}
+
+	if err := store.Time.Start("time01", "Fast MCP time"); err != nil {
+		t.Fatalf("start timer: %v", err)
+	}
+	stopResult, err := handleTimeStop(getStore, mutationRequest(map[string]any{"taskId": "time01"}))
+	if err != nil {
+		t.Fatalf("stop time: %v", err)
+	}
+	if stopResult == nil || stopResult.IsError {
+		t.Fatalf("stop time returned error result: %s", mutationResultText(t, stopResult))
+	}
+	if bestEffortCalls != 2 {
+		t.Fatalf("best-effort calls after stop = %d, want 2", bestEffortCalls)
+	}
+	if reconcileCalls != 0 {
+		t.Fatalf("sync reconcile calls = %d, want 0", reconcileCalls)
+	}
+}
+
+func seedTask(t *testing.T, store *storage.Store, id, title string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := store.Tasks.Create(&models.Task{
+		ID:        id,
+		Title:     title,
+		Status:    "todo",
+		Priority:  "medium",
+		Labels:    []string{},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed task: %v", err)
 	}
 }
 

--- a/internal/mcp/handlers/task.go
+++ b/internal/mcp/handlers/task.go
@@ -168,6 +168,13 @@ type taskMutationSummary struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 }
 
+var (
+	mcpBestEffortIndexTask  = search.BestEffortIndexTask
+	mcpBestEffortRemoveTask = search.BestEffortRemoveTask
+	mcpReconcileTaskIndex   = search.ReconcileTaskIndex
+	mcpReconcileTaskRemoval = search.ReconcileTaskRemoval
+)
+
 func taskMutationResult(task *models.Task, returnMode string) *mcp.CallToolResult {
 	var payload any = task
 	if returnMode == mutationReturnSummary {
@@ -265,7 +272,7 @@ func handleTaskCreate(getStore func() *storage.Store, req mcp.CallToolRequest) (
 		Snapshot: storage.TaskToSnapshot(task),
 	})
 
-	search.BestEffortIndexTask(store, task.ID)
+	mcpBestEffortIndexTask(store, task.ID)
 	go notifyTaskUpdated(store, task.ID)
 
 	return taskMutationResult(task, returnMode), nil
@@ -313,7 +320,7 @@ func handleTaskUpdate(getStore func() *storage.Store, req mcp.CallToolRequest) (
 		return errResult(err.Error())
 	}
 	clearFields := stringSetArg(args, "clear")
-	service := newMCPTaskLifecycleService(store)
+	service := newMCPTaskMutationService(store)
 	task, err := service.UpdateTask(context.Background(), taskID, tasklifecycle.TaskUpdateOptions{Actor: "mcp", Mutate: func(task *models.Task) error {
 
 		if clearFields["title"] {
@@ -491,10 +498,23 @@ func handleTaskList(getStore func() *storage.Store, req mcp.CallToolRequest) (*m
 	return mcp.NewToolResultText(string(out)), nil
 }
 
+func newMCPTaskMutationService(store *storage.Store) *tasklifecycle.Service {
+	return tasklifecycle.New(store, tasklifecycle.WithHooks(tasklifecycle.Hooks{
+		IndexTask: func(id string) error {
+			mcpBestEffortIndexTask(store, id)
+			return nil
+		},
+		RemoveTask: func(id string) error {
+			mcpBestEffortRemoveTask(store, id)
+			return nil
+		},
+	}))
+}
+
 func newMCPTaskLifecycleService(store *storage.Store) *tasklifecycle.Service {
 	return tasklifecycle.New(store, tasklifecycle.WithHooks(tasklifecycle.Hooks{
-		IndexTask:  func(id string) error { return search.ReconcileTaskIndex(store, id) },
-		RemoveTask: func(id string) error { return search.ReconcileTaskRemoval(store, id) },
+		IndexTask:  func(id string) error { return mcpReconcileTaskIndex(store, id) },
+		RemoveTask: func(id string) error { return mcpReconcileTaskRemoval(store, id) },
 	}))
 }
 

--- a/internal/mcp/handlers/time.go
+++ b/internal/mcp/handlers/time.go
@@ -119,7 +119,7 @@ func handleTimeStop(getStore func() *storage.Store, req mcp.CallToolRequest) (*m
 		return errResult(ErrTaskIDReq)
 	}
 
-	entry, err := newMCPTaskLifecycleService(store).StopTimer(context.Background(), taskID, "mcp")
+	entry, err := newMCPTaskMutationService(store).StopTimer(context.Background(), taskID, "mcp")
 	if err != nil {
 		return errFailed("stop timer", err)
 	}
@@ -184,7 +184,7 @@ func handleTimeAdd(getStore func() *storage.Store, req mcp.CallToolRequest) (*mc
 		entry.Note = note
 	}
 
-	if _, err := newMCPTaskLifecycleService(store).AddTimeEntry(context.Background(), taskID, tasklifecycle.TimeMutationOptions{Actor: "mcp", Entry: entry}); err != nil {
+	if _, err := newMCPTaskMutationService(store).AddTimeEntry(context.Background(), taskID, tasklifecycle.TimeMutationOptions{Actor: "mcp", Entry: entry}); err != nil {
 		return errFailed("save time entry", err)
 	}
 

--- a/internal/process/command.go
+++ b/internal/process/command.go
@@ -1,0 +1,23 @@
+package process
+
+import (
+	"context"
+	"os/exec"
+)
+
+// CommandContext returns an exec.Cmd configured with the project's default
+// child-process policy. On Windows, short-lived probes should not allocate
+// visible console windows when invoked by long-running browser/daemon paths.
+func CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	ApplyNoWindow(cmd)
+	return cmd
+}
+
+// Command returns an exec.Cmd configured with the project's default
+// child-process policy.
+func Command(name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(name, args...)
+	ApplyNoWindow(cmd)
+	return cmd
+}

--- a/internal/process/nowindow_other.go
+++ b/internal/process/nowindow_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package process
+
+import "os/exec"
+
+// ApplyNoWindow is a no-op on non-Windows platforms.
+func ApplyNoWindow(cmd *exec.Cmd) {}
+
+// NoWindowApplied reports whether ApplyNoWindow should set Windows-specific
+// process attributes on this platform.
+func NoWindowApplied(cmd *exec.Cmd) bool { return false }

--- a/internal/process/nowindow_windows.go
+++ b/internal/process/nowindow_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package process
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// ApplyNoWindow prevents short-lived console-subsystem child processes from
+// opening or attaching a visible console host when spawned by browser/daemon
+// status probes on Windows.
+func ApplyNoWindow(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	attr := cmd.SysProcAttr
+	if attr == nil {
+		attr = &syscall.SysProcAttr{}
+		cmd.SysProcAttr = attr
+	}
+	attr.CreationFlags |= windows.CREATE_NO_WINDOW
+	attr.HideWindow = true
+}
+
+// NoWindowApplied reports whether ApplyNoWindow configured the Windows process
+// attributes expected by runtime probe call sites.
+func NoWindowApplied(cmd *exec.Cmd) bool {
+	if cmd == nil || cmd.SysProcAttr == nil {
+		return false
+	}
+	return cmd.SysProcAttr.HideWindow && cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW != 0
+}

--- a/internal/process/nowindow_windows_test.go
+++ b/internal/process/nowindow_windows_test.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package process
+
+import "testing"
+
+func TestCommandContextAppliesNoWindow(t *testing.T) {
+	cmd := Command("dotnet", "--version")
+	if !NoWindowApplied(cmd) {
+		t.Fatalf("Command did not apply Windows no-window process attributes: %#v", cmd.SysProcAttr)
+	}
+}

--- a/internal/services/status.go
+++ b/internal/services/status.go
@@ -19,6 +19,7 @@ import (
 	"github.com/howznguyen/knowns/internal/lsp"
 	"github.com/howznguyen/knowns/internal/lsp/adapters"
 	"github.com/howznguyen/knowns/internal/models"
+	knownsprocess "github.com/howznguyen/knowns/internal/process"
 	"github.com/howznguyen/knowns/internal/runtimequeue"
 	goruntime "runtime"
 
@@ -373,13 +374,13 @@ func serviceStatusFromLSP(status lsp.LanguageRuntimeStatus) string {
 // isProcessRunning checks if a process with the given binary name is running.
 func isProcessRunning(name string) bool {
 	if goruntime.GOOS == "windows" {
-		out, err := exec.Command("tasklist", "/FI", "IMAGENAME eq "+name+".exe", "/NH").Output()
+		out, err := knownsprocess.Command("tasklist", "/FI", "IMAGENAME eq "+name+".exe", "/NH").Output()
 		if err != nil {
 			return false
 		}
 		return strings.Contains(string(out), name)
 	}
-	err := exec.Command("pgrep", "-f", name).Run()
+	err := knownsprocess.Command("pgrep", "-f", name).Run()
 	return err == nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #138.

This PR addresses the Windows `conhost.exe` / `OpenConsole.exe` growth reported when leaving `kn browser` running in repositories that trigger runtime probes such as Docker and .NET detection.

## Changes

- Cache LSP/runtime inventory probes so browser/status polling does not rerun expensive probes on every tick.
- Route spawned probe commands through a shared process helper.
- On Windows, start child probe processes with no allocated console window.
- Add tests for runtime probe caching and Windows no-window process attributes.
- Defer derived MCP task/time mutation indexing to best-effort background work.
- Refresh README badges/AI integration guidance and add uninstall docs.

## Verification

- Added unit coverage for runtime probe caching.
- Added Windows-specific coverage for no-window process attributes.
- Ran staged diff validation before commit.

## Notes

The direct fix for #138 is commit `2ecd073`.
Follow-up commits:
- `1dd66db` improves MCP mutation responsiveness.
- `d7beb0a` updates README/uninstall documentation.
