### PR TITLE
Stop docs, skills and hints from describing a CLI that does not exist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Golden files are compared byte for byte against output the code generates
+# with "\n", so they must stay LF even where core.autocrlf rewrites checkouts.
+**/testdata/** text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,19 @@ jobs:
           CGO_ENABLED: '1'
         run: go vet ./...
 
+      # Catches a reference page describing a command the binary does not have,
+      # and a command with no page at all. Unix only: the output is identical
+      # across platforms, so running it three times buys nothing.
+      - name: Check CLI reference matches the command tree
+        if: runner.os == 'Linux'
+        run: go run ./tools/gendocs --check
+
+      # Catches a README or embedded skill telling a reader (or an agent) to run
+      # a command or flag the binary does not have.
+      - name: Check docs only use commands that exist
+        if: runner.os == 'Linux'
+        run: go run ./tools/gendocs --lint
+
       - name: Run tests (Unix)
         if: runner.os != 'Windows'
         run: go test -v -race -count=1 ./...

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tmp/
 *.exe
 /knowns
 /knowns-embed
+/gendocs
 
 # npm platform binaries
 npm/knowns-*/knowns

--- a/.knowns/decisions/20260827-1528-retire-fully-superseded-specs-and-docs-by-deleting-them-never-by-bannering-them-in-place.md
+++ b/.knowns/decisions/20260827-1528-retire-fully-superseded-specs-and-docs-by-deleting-them-never-by-bannering-them-in-place.md
@@ -1,0 +1,68 @@
+---
+id: 20260827-1528-retire-fully-superseded-specs-and-docs-by-deleting-them-never-by-bannering-them-in-place
+title: Retire fully superseded specs and docs by deleting them, never by bannering them in place
+status: draft
+supersedes: []
+supersededBy: []
+tags:
+  - workflow
+  - docs
+  - staleness
+  - skills
+  - supersession
+sources:
+  - internal/instructions/skills/kn-implement/SKILL.md
+  - internal/instructions/skills/kn-flow/SKILL.md
+  - '@doc/features/init-process'
+  - '@doc/features/model-command'
+  - internal/cli/provider.go
+relatedDocs:
+  - features/init-process
+  - features/model-command
+  - specs/chat-ui
+relatedTasks:
+  - 6i2roz
+verification: []
+reviewState: needs_evidence
+reviewBlockers:
+  - 'linked task "6i2roz" is "todo"; all linked tasks must be done before accepting decision "20260827-1528-retire-fully-superseded-specs-and-docs-by-deleting-them-never-by-bannering-them-in-place"'
+reviewMatches: []
+reviewAllowedResolutions: []
+reviewEvaluatedAt: '2026-08-27T08:28:37.408Z'
+createdAt: '2026-08-27T08:28:03.625Z'
+updatedAt: '2026-08-27T08:28:37.408Z'
+---
+
+## Context
+
+The System Decision Impact checkpoint in `kn-implement` and `kn-flow` told a completing task to create a draft Decision and append an impact marker, but said nothing about retiring the document the work replaced. The result was that supersession was recorded as a banner or tag on a document that stayed resident in `.knowns/docs/`.
+
+An adversarial review of this repository found the failure had already occurred here, under a single maintainer using the tool daily:
+
+- `.knowns/docs/features/init-process.md` has `tags: []` — no staleness marker of any kind — and still walks a new user through "Group 3: Chat UI / Enable Chat UI? (confirm)" (lines 77-78), "Download ONNX Runtime / Download model files" (lines 105-106, 222), and `knowns model download <model>` (line 223). The Chat UI was removed in full by @decision/20260819-1703-remove-the-opencode-chat-ui, and `internal/cli/provider.go:118-121` records that `knowns model` was removed with the local ONNX path.
+- `.knowns/docs/features/model-command.md` is tagged `superseded` in its frontmatter, yet its body still documents `knowns model` in the present tense (line 22), while `docs/en/reference/commands.md:342` correctly states "There is no `knowns model` command."
+- Of 45 spec documents in `.knowns/docs/specs/`, 7 are tagged `superseded` and 4 are tagged `partially-superseded`, all still resident.
+
+A banner does not stop a document being returned by search, and it does not change the body text, which still reads as current instruction. The banner records the rot; it does not remove it.
+
+## Decision
+
+When completed work fully supersedes a spec or doc, delete that document in the same change. Record the supersession in the superseding Decision's `consequences`, not in the retired document.
+
+When the work only partially voids a document, do not delete it. Name the void parts explicitly — for example `FR-5`, `AC-6`, `Scenario 4` — and leave the remainder live.
+
+This distinction is load-bearing. @decision/20260819-1703-remove-the-opencode-chat-ui already applies it correctly, marking `specs/knowns-hub-mode` as "Partially void, NOT superseded" with a named list of void requirements. Treating `superseded` and `partially-superseded` as the same tag and deleting both would destroy guidance that is still in force.
+
+## Alternatives Considered
+
+Keep bannering and add a separate cleanup pass. Rejected: it defers the work to a moment that never arrives, and the evidence above is what deferral produces. The cost of deleting is lowest at the moment the superseding work is done, when the author knows exactly what the replacement covers.
+
+Automate staleness detection by re-embedding docs and scoring drift against code. Rejected under the project's own Anti-Goal 7 ("Do not use multi-agent orchestration by default. Complexity should be justified by a measurable win over the simple phased baseline") — it adds a subsystem to detect a problem that a one-sentence workflow rule prevents at the source.
+
+## Consequences
+
+`internal/instructions/skills/kn-implement/SKILL.md` gains a "Retire what the work replaced" block in the System Decision Impact checkpoint, plus a checklist item and a red flag. `internal/instructions/skills/kn-flow/SKILL.md` gains the compressed mirror of the rule in checkpoint step 7, plus a red flag. Both were edited and `go test ./internal/instructions/skills/` passes.
+
+The 7 fully superseded specs, `model-command.md`, and the stale sections of `init-process.md` are NOT cleaned up by this Decision. They predate the rule and remain outstanding; cleaning them is a separate, explicitly approved change.
+
+This rule does not catch a second staleness mechanism found in the same review: `path:line` citations rotting as code moves. See the companion draft on citation anchors.

--- a/.knowns/decisions/20260827-1529-anchor-durable-citations-to-symbols-not-line-numbers.md
+++ b/.knowns/decisions/20260827-1529-anchor-durable-citations-to-symbols-not-line-numbers.md
@@ -1,0 +1,68 @@
+---
+id: 20260827-1529-anchor-durable-citations-to-symbols-not-line-numbers
+title: Anchor durable citations to symbols, not line numbers
+status: draft
+supersedes: []
+supersededBy: []
+tags:
+  - provenance
+  - citations
+  - staleness
+  - evidence
+  - workflow
+sources:
+  - internal/search/engine.go
+  - '@task-npgfm4'
+relatedDocs: []
+relatedTasks:
+  - npgfm4
+verification: []
+reviewState: needs_evidence
+reviewBlockers:
+  - 'linked task "npgfm4" is "todo"; all linked tasks must be done before accepting candidate'
+reviewMatches: []
+reviewAllowedResolutions: []
+reviewEvaluatedAt: '2026-08-27T08:29:12.066Z'
+createdAt: '2026-08-27T08:29:12.066Z'
+updatedAt: '2026-08-27T08:29:12.066Z'
+---
+
+## Context
+
+`path:line` is the provenance unit across Knowns — task descriptions, Decision `sources` and `verification`, doc evidence, review findings. Line numbers move whenever the file above them changes, and nothing in the system notices.
+
+A verified instance exists in this repository, in the task whose whole purpose is to fix the retrieval measurement gate. @task-npgfm4 cites `internal/search/engine.go:1254` for `topK = opts.Limit * 2` and `:1723` for the per-chunk score bonus. Checked on 2026-08-27:
+
+- `engine.go:1254` now holds an unrelated SQL query for a `code` chunk
+- `engine.go:1723` now holds a `ChunkTypeDecision` key assignment
+- the logic the task actually describes is at `engine.go:1302` (`topK := opts.Limit * 2`) and `engine.go:1783` (`finalScore += sr.scores[i] * 0.1 // 10% bonus per additional relevant chunk`)
+
+`engine.go` took three commits between the task being written on 2026-08-22 and 2026-08-27. Five days produced two dead pointers in a task nobody had reason to distrust.
+
+This is a different failure from stale prose. The task's words are still correct; only its pointers rotted. A keyword or content-based staleness check cannot detect it, because there is nothing wrong with the text.
+
+## Decision
+
+In durable records — task descriptions, Decision `sources` and `verification`, doc evidence, extracted patterns — cite code by a stable anchor rather than a bare line number:
+
+- prefer the symbol: `internal/search/engine.go` → `hybridSearch`, or a quoted code fragment distinctive enough to grep
+- when a line number genuinely helps a reader, pair it with the anchor so the anchor survives the drift: `engine.go:1302 (topK := opts.Limit * 2)`
+- never make a line number the only way to find what a record refers to
+
+Transient records — a review finding on a specific diff, a debugging note within one session — may keep bare `path:line`, because they are consumed before the code moves.
+
+## Alternatives Considered
+
+Add a validator that re-checks every cited line still contains the described code. Rejected as the primary fix: it requires the record to declare what it expects to find at that line, which is the anchor this Decision asks for anyway — so the anchor is the cheaper half, and the validator becomes optional once anchors exist.
+
+Auto-rewrite drifted citations by locating the moved code. Rejected: it edits durable records without review, which conflicts with the project's Anti-Goal 3 on autonomous in-place evolution of trusted knowledge.
+
+Accept the drift as unavoidable. Rejected: the evidence shows it takes five days and three commits to break a citation, and the resulting record looks trustworthy while pointing at nothing.
+
+## Consequences
+
+No code changes. This binds authoring behaviour in skills that write durable records — `kn-plan`, `kn-implement`, `kn-extract`, `kn-decision`, `kn-research`, `kn-review` — and those skills are not yet updated to state it. Updating them is follow-up work, not part of this draft.
+
+@task-npgfm4 keeps its original line numbers; a note recording the drift and the correct locations was appended rather than rewriting the description, so the instance stays visible as evidence.
+
+Existing durable records across the repository still use bare `path:line` and are not retro-fitted by this Decision.

--- a/.knowns/decisions/20260827-1529-defer-the-sub-agent-debate-harness-until-a-measurable-win-exists.md
+++ b/.knowns/decisions/20260827-1529-defer-the-sub-agent-debate-harness-until-a-measurable-win-exists.md
@@ -1,0 +1,62 @@
+---
+id: 20260827-1529-defer-the-sub-agent-debate-harness-until-a-measurable-win-exists
+title: Defer the sub-agent debate harness until a measurable win exists
+status: draft
+supersedes: []
+supersededBy: []
+tags:
+  - agents
+  - orchestration
+  - anti-goal
+  - deferred
+  - research
+sources:
+  - '@doc/research/knowns-evolution-research-2026'
+  - internal/tasklifecycle/public_test.go
+  - internal/mcp/handlers/doc.go
+  - 'https://arxiv.org/html/2607.26212v1'
+relatedDocs:
+  - research/knowns-evolution-research-2026
+relatedTasks: []
+verification: []
+reviewState: needs_evidence
+reviewBlockers:
+  - candidate needs at least one linked task or a spec with linked tasks before acceptance
+reviewMatches: []
+reviewAllowedResolutions: []
+reviewEvaluatedAt: '2026-08-27T08:29:39.357Z'
+createdAt: '2026-08-27T08:29:39.357Z'
+updatedAt: '2026-08-27T08:29:39.357Z'
+---
+
+## Context
+
+A harness letting sub-agents debate each other was researched end to end on 2026-08-27. It is technically feasible: the hard primitive already exists and is tested. `internal/tasklifecycle/public_test.go` → `TestUpdateTaskConcurrentSameBaseHasOnePublicWinner` runs two concurrent services updating one task from the same base hash and asserts exactly one winner, `storage.ErrHistoryConflict` for the loser, exactly one new history revision, exactly one index-hook call, and no content leak in the loser's error. `expectedHash` is wired through MCP on both `doc.update` and `task.update`. That is leaderless compare-and-swap — enough to build a peer blackboard with no coordinating master.
+
+What is missing is evidence that debate helps. A survey of 141 multi-agent-debate studies (arxiv 2607.26212) reports the field converged on a narrow design pattern "by convention rather than systematic comparison," and the two findings that reproduce most clearly are downside risks: judge quality dominates outcomes, and inter-agent sycophancy reinforces bias.
+
+The project's own @doc/research/knowns-evolution-research-2026 Anti-Goal 7 already governs this: "Do not use multi-agent orchestration by default. Complexity should be justified by a measurable win over the simple phased baseline." Its Priority Matrix lists three P0 "Build now" workstreams; a debate harness appears at no priority level.
+
+A session in this repository then demonstrated the failure mode first-hand. Five sub-agents on one cheap model tier produced a well-evidenced critique, but all five missed the same four factual errors, which a different model tier caught on the first pass. Agreement among same-tier agents was not corroboration.
+
+## Decision
+
+Do not build a sub-agent debate harness now.
+
+The gate to revisit is the one Anti-Goal 7 already names: a measurable win over the simple phased baseline. The cheapest experiment that could produce it is a bounded adversarial pass over `kn-review` P1 findings, measured against the pain that skill already documents ("Not everything is P1. Severity inflation wastes time"), with the outcome metric being a reduction in false P1s.
+
+When multiple agents are used for a question that matters, fan out to generate hypotheses and change model tier to verify them. Same-tier agreement is not evidence.
+
+## Alternatives Considered
+
+Build the peer blackboard mesh now — per-peer lane docs under `debates/<slug>/round-<t>/`, a CAS-guarded `state` document, a filesystem round barrier, and a collective stop predicate. Rejected: it is the shape a leaderless design should take, and the primitives are real, but roster, barrier, and stop predicate would live only in prompt text with nothing enforcing them, and nothing measures whether the output is better.
+
+Use the Workflow tool's existing judge-panel and adversarial-verify patterns instead of a new harness. Not rejected — this is the cheap path if the experiment above is ever run. It needs no new Knowns surface.
+
+## Consequences
+
+No code changes. The research does not need repeating; the substrate findings above are the durable part.
+
+Building this later would touch @decision/20260819-1703-remove-the-opencode-chat-ui, which removed Knowns' own agent runtime and states that Knowns "no longer manages a runtime service of its own." Any debate harness must therefore live in the skill layer with Knowns providing state, not process management.
+
+This draft has a standing review blocker because it has no linked task. That is expected — the decision is not to do work.

--- a/.knowns/decisions/20260827-1559-skill-materialization-scope-is-a-project-setting-not-an-implicit-default.md
+++ b/.knowns/decisions/20260827-1559-skill-materialization-scope-is-a-project-setting-not-an-implicit-default.md
@@ -1,0 +1,65 @@
+---
+id: 20260827-1559-skill-materialization-scope-is-a-project-setting-not-an-implicit-default
+title: Skill materialization scope is a project setting, not an implicit default
+status: draft
+supersedes: []
+supersededBy: []
+tags:
+  - cli
+  - sync
+  - skills
+  - config
+  - workflow
+sources:
+  - internal/models/config.go
+  - internal/cli/sync.go
+  - internal/cli/setup_global.go
+  - internal/codegen/skill_sync.go
+  - internal/cli/sync_skills_scope_test.go
+  - internal/storage/embedding_settings_store.go
+  - ~/.knowns/settings.json
+relatedDocs: []
+relatedTasks:
+  - or6x99
+verification: []
+reviewState: needs_evidence
+reviewBlockers:
+  - 'linked task "or6x99" is "in-review"; all linked tasks must be done before accepting decision "20260827-1559-skill-materialization-scope-is-a-project-setting-not-an-implicit-default"'
+reviewMatches: []
+reviewAllowedResolutions: []
+reviewEvaluatedAt: '2026-08-27T09:08:17.057Z'
+createdAt: '2026-08-27T08:59:00.591Z'
+updatedAt: '2026-08-27T09:08:17.057Z'
+---
+
+## Context
+
+`knowns sync` used to materialize built-in skills into project directories unconditionally. `SyncSkillsForPlatforms` picked targets from `settings.platforms` and called `os.MkdirAll` on each, never asking whether the directory existed or whether the user had installed skills globally instead. Combined with `force := true` in `runSync`, a user who installed globally could not get rid of the project copy: deleting it only lasted until the next sync, and the project copy takes precedence over `~/.claude/skills`, so sync silently overrode their configuration.
+
+Every other part of the product already knew about global skills. `syncGlobalSkills` writes to `~/.claude/skills`, `~/.kiro/skills`, and `~/.agents/skills`; `codegen.GlobalStaleSkillDirs` exists; doctor wires it in as `globalSkills` and reports on it. `StaleSkillDirs`, in the same file as the bug, states the right principle for reads: "Directories that do not exist are skipped: a platform that was never synced is not stale, it is simply absent."
+
+The reason sync could not honour any of that: `internal/models/config.go` had no skills setting at all. `setup --global` had nowhere to record its choice, and sync reconciles from config.json.
+
+## Decision
+
+Where skills are materialized is a recorded project setting, `settings.skillsScope`, with values `project`, `global`, and `none`. An unset value resolves to `project`, so existing projects and fresh clones are unaffected.
+
+`knowns sync` reads that setting and routes accordingly. It never infers scope from what happens to be on disk, and it never creates a directory the setting did not ask for.
+
+The general rule this instance establishes: a command that generates files must record the intent behind them in config, because `sync` reconciles from config and will otherwise undo the choice. Generating without recording creates a second write surface that has to be reconciled by hand, which is the same defect pattern found in the doc corpus.
+
+## Alternatives Considered
+
+Add a `--global` flag to sync, mirroring `setup --global`. Rejected: a flag is not remembered, so the next bare `knowns sync` reintroduces the bug. The missing thing was persisted intent, not a one-shot switch.
+
+Only write to skill directories that already exist, mirroring the principle in `StaleSkillDirs`. Rejected on its own: it fixes the reported case but breaks the documented clone path, where `git clone` followed by `knowns sync` must produce skills that were never there before.
+
+Infer the scope by detecting whether a global install exists. Rejected: implicit and surprising, and it makes the outcome depend on machine state rather than on what the project declared.
+
+## Consequences
+
+`ProjectSettings.SkillsScope` is added with `NormalizeSkillsScope` and `SkillsScopeOrDefault`; `Normalize` rejects an unknown value. `runSyncSkillsForScope` in `internal/cli/sync.go` dispatches. `recordGlobalSkillsScope` in `internal/cli/setup_global.go` persists the scope after a successful global setup. Four tests in `internal/cli/sync_skills_scope_test.go`; 546 tests pass across the touched packages.
+
+Still open: `init` does not ask for the scope, and `doctor` does not warn when a project copy and a global copy both exist, which is exactly the state that produced the original report.
+
+This does not resolve the wider `setup` versus `sync` overlap. `setup` still generates files on the platform axis without persisting `settings.platforms`, which is the same class of defect one level up.

--- a/.knowns/decisions/20260827-1559-skill-materialization-scope-is-a-project-setting-not-an-implicit-default.md
+++ b/.knowns/decisions/20260827-1559-skill-materialization-scope-is-a-project-setting-not-an-implicit-default.md
@@ -18,18 +18,21 @@ sources:
   - internal/cli/sync_skills_scope_test.go
   - internal/storage/embedding_settings_store.go
   - ~/.knowns/settings.json
+  - internal/doctor/ai_checks.go
+  - internal/doctor/local.go
+  - '@memory/dulbcb'
 relatedDocs: []
 relatedTasks:
   - or6x99
 verification: []
 reviewState: needs_evidence
 reviewBlockers:
-  - 'linked task "or6x99" is "in-review"; all linked tasks must be done before accepting decision "20260827-1559-skill-materialization-scope-is-a-project-setting-not-an-implicit-default"'
+  - 'linked task "or6x99" has unchecked acceptance criteria'
 reviewMatches: []
 reviewAllowedResolutions: []
-reviewEvaluatedAt: '2026-08-27T09:08:17.057Z'
+reviewEvaluatedAt: '2026-08-27T09:48:45.412Z'
 createdAt: '2026-08-27T08:59:00.591Z'
-updatedAt: '2026-08-27T09:08:17.057Z'
+updatedAt: '2026-08-27T09:48:45.412Z'
 ---
 
 ## Context

--- a/.knowns/decisions/20260903-1654-persisted-filesystem-paths-are-stored-in-their-on-disk-spelling.md
+++ b/.knowns/decisions/20260903-1654-persisted-filesystem-paths-are-stored-in-their-on-disk-spelling.md
@@ -1,0 +1,44 @@
+---
+id: 20260903-1654-persisted-filesystem-paths-are-stored-in-their-on-disk-spelling
+title: Persisted filesystem paths are stored in their on-disk spelling
+status: draft
+supersedes: []
+supersededBy: []
+tags:
+  - registry
+  - paths
+  - cross-platform
+sources:
+  - 'https://github.com/knowns-dev/knowns/issues/144'
+  - '@doc/specs/browser-any-pwd-and-workspace-switching'
+relatedDocs:
+  - specs/browser-any-pwd-and-workspace-switching
+relatedTasks:
+  - zyxxj7
+verification: []
+reviewState: ready_for_review
+reviewBlockers: []
+reviewMatches: []
+reviewAllowedResolutions:
+  - accept_new
+  - reject_new
+reviewEvaluatedAt: '2026-09-03T09:55:02.736Z'
+createdAt: '2026-09-03T09:54:14.381Z'
+updatedAt: '2026-09-03T09:55:02.736Z'
+---
+
+## Context
+
+The workspace registry keyed projects by the exact path string it was handed. On Windows and the default macOS filesystem, two capitalizations of one folder are the same directory but two different strings, so one project accumulated multiple registry rows (GitHub issue knowns-dev/knowns#144). Auto-scan made it routine rather than rare, because its candidate list carries both capitalizations of every well-known project folder.
+
+## Decision
+
+Any filesystem path Knowns persists or compares as an identity key is first resolved to its on-disk spelling with util.CanonicalPath, which walks each component against its parent's directory listing and accepts a case-insensitive match only when os.SameFile proves the two spellings name one directory. Case folding by platform is not used, because on a case-sensitive filesystem two directories differing only in capitalization are genuinely different and must stay distinct. Readers of an existing store canonicalize on load and collapse rows that turn out to name one path, so stores written before this rule repair themselves.
+
+## Alternatives Considered
+
+Comparing case-insensitively on Windows and macOS was rejected: it needs a platform switch, and it silently merges distinct directories when a store is shared or synced across platforms. Keying the registry on the stable id in .knowns/config.json is the more robust design and remains open, but it changes the registry format and needs a migration.
+
+## Consequences
+
+Path identity is decided by the filesystem rather than by string comparison, so it stays correct on all three platforms with one code path. Canonicalization costs one directory read per path component, which is acceptable at registry and scan frequency but should not be placed in a hot loop. Paths that do not exist on disk keep the caller's spelling and are never merged.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,331 +1,310 @@
 # Architecture
 
-Technical overview of how Knowns is built.
+Knowns is a single Go binary. It keeps a project's durable knowledge (tasks,
+docs, decisions, memory, templates) as markdown on disk, and exposes that same
+store to humans through a CLI and a web UI, and to AI agents through an MCP
+server.
 
-For design principles, see [PHILOSOPHY.md](./PHILOSOPHY.md).
+Everything below describes the code as it is. If a statement here disagrees
+with the tree, the tree wins and this file is the bug. `make cli-docs-check`
+enforces that for the command surface.
 
----
+## Core principles
 
-## Overview
+### Files are the source of truth
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         User Layer                               │
-├─────────────┬─────────────┬─────────────┬──────────────────────┤
-│     CLI     │   Web UI    │  MCP Server │    AI Agents         │
-│  (primary)  │  (visual)   │  (Claude)   │  (consumers)         │
-└──────┬──────┴──────┬──────┴──────┬──────┴──────────┬───────────┘
-       │             │             │                 │
-       ▼             ▼             ▼                 ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      Command Layer                               │
-│  task.ts │ doc.ts │ time.ts │ search.ts │ browser.ts │ mcp.ts  │
-└─────────────────────────────┬───────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      Storage Layer                               │
-│         file-store.ts  │  version-store.ts  │  config.ts        │
-└─────────────────────────────┬───────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      File System                                 │
-│                        .knowns/                                  │
-│     tasks/  │  docs/  │  config.json  │  .timer  │  .versions   │
-└─────────────────────────────────────────────────────────────────┘
-```
+There is no database of record. A task is a markdown file with YAML
+frontmatter; so is a doc, a decision, and a memory entry. You can read the
+whole store with `cat`, diff it in a pull request, and recover it from git.
 
----
+What is *not* the source of truth is anything under `.knowns/.search/`. That
+directory holds a derived index and is safe to delete: `knowns search index`
+rebuilds it. The distinction matters because the index is a SQLite file, and
+"no database" is only true of the record, not of the cache.
 
-## Core Principles
-
-### 1. Files as Database
-
-No SQLite. No JSON database. Just markdown files.
-
-```
-.knowns/
-├── config.json           # Project configuration
-├── tasks/
-│   ├── task-KN-4F7Q2M - Title.md
-│   └── task-KN-9B3XKD - Title.md
-├── docs/
-│   ├── patterns/
-│   │   └── auth.md
-│   └── architecture/
-│       └── overview.md
-└── .versions/            # Version history (hidden)
-```
-
-**Why:** Portable, debuggable, Git-friendly, survives tool changes.
-
-### 2. Markdown + Frontmatter
-
-Every file follows the same pattern:
+### Markdown plus frontmatter
 
 ```markdown
 ---
-id: "42"
-title: "Add authentication"
-status: "in-progress"
-priority: "high"
-createdAt: "2025-01-15T10:00:00Z"
-updatedAt: "2025-01-15T14:30:00Z"
+id: KN-4F7Q2M
+title: Add JWT authentication
+status: in-progress
+priority: high
 ---
 
 ## Description
 
-Content here...
+We need JWT auth because sessions do not scale across services.
 ```
 
-**Why:** Human-readable, machine-parseable, standard format.
+Frontmatter carries the structured fields the CLI and UI query. The body stays
+prose, so it is useful to a human reading the file directly and to a model
+reading it as context.
 
-### 3. Reference Resolution
+### References resolve across entity kinds
 
-References like `@doc/patterns/auth` resolve to real file paths:
+`@task-<id>` and `@doc/<path>` inside any body are resolved by
+`internal/references` and `internal/storage/reference_resolution.go`, so a
+decision can cite the task that produced it and a task can cite the doc that
+constrains it. Resolution is what makes the store a graph rather than a folder.
 
-```
-Input:  @doc/patterns/auth
-Output: .knowns/docs/patterns/auth.md
-
-Input:  @task-KN-4F7Q2M
-Output: .knowns/tasks/task-KN-4F7Q2M - Title.md
-```
-
-**Why:** Deterministic, no magic, AI can follow links.
-
----
-
-## Directory Structure
+## Repository layout
 
 ```
-src/
-├── index.ts              # CLI entry point
-├── commands/             # CLI commands
-│   ├── task.ts           # knowns task *
-│   ├── doc.ts            # knowns doc *
-│   ├── time.ts           # knowns time *
-│   ├── search.ts         # knowns search
-│   ├── browser.ts        # knowns browser
-│   └── agents.ts         # knowns agents
-├── models/               # Domain models
-│   ├── task.ts           # Task entity
-│   └── doc.ts            # Document entity
-├── storage/              # Persistence layer
-│   ├── file-store.ts     # File operations
-│   ├── version-store.ts  # Version history
-│   └── paths.ts          # Path resolution
-├── server/               # Web UI backend
-│   └── index.ts          # Express + WebSocket
-├── mcp/                  # MCP server
-│   └── server.ts         # Claude integration
-├── ui/                   # React frontend
-│   ├── App.tsx
-│   └── components/
-└── utils/                # Shared utilities
-    ├── markdown.ts       # Markdown parsing
-    ├── mention-refs.ts   # Reference resolution
-    └── formatting.ts     # Output formatting
+cmd/knowns/main.go        Entry point; calls internal/cli.Execute
+internal/                 All application code (30 packages, 34 with subpackages)
+ui/                       React 19 + Vite web UI, embedded into the binary
+tools/gendocs/            Generates and verifies the CLI reference
+docs/                     Hand-written docs (en, vi) plus the generated reference
+tests/                    CLI and MCP end-to-end tests
 ```
 
----
-
-## Data Flow
-
-### CLI Command
+A project's store lives in `.knowns/` next to the code it describes:
 
 ```
-User: knowns task view KN-4F7Q2M --plain
-
-1. CLI parses command (commander.js)
-2. Command calls storage layer
-3. Storage reads .knowns/tasks/task-KN-4F7Q2M - *.md
-4. Markdown parsed, frontmatter extracted
-5. Output formatted (plain text for AI)
-6. Result printed to stdout
+.knowns/
+  tasks/          task-<id> - <slug>.md
+  docs/           <path>.md
+  decisions/      <timestamp>-<slug>.md
+  memory/         memory entries by layer
+  templates/      code generation templates
+  history/        JSONL change history, plus locks and watermark state
+  imports/        imported Knowns packages
+  archive/        archived entities
+  versions/       entity version snapshots
+  config.json     project configuration
+  .search/        derived index (SQLite); rebuildable, safe to delete
 ```
+
+## Package map
+
+Sized by non-test lines, because where the code actually is tends to differ
+from where people assume it is.
+
+| Package | Lines | Responsibility |
+|---|---:|---|
+| `cli` | 20.3k | Cobra command tree, TUI rendering, all 33 top-level commands |
+| `storage` | 15.6k | Entity stores, mutation transactions, locks, history, reconciliation |
+| `search` | 14.3k | Chunking, embeddings, BM25 lexical backend, SQLite and Qdrant vector stores |
+| `lsp` | 8.9k | Language server adapters, detection, install, file sync |
+| `server` | 8.3k | HTTP API (chi), SSE broker, WebSocket, embedded UI |
+| `mcp` | 7.2k | MCP server and its 12 tool handlers |
+| `doctor` | 3.0k | Read-only diagnostics and remediation model |
+| `models` | 2.7k | Entity types: task, doc, decision, memory, template, config |
+| `tasklifecycle` | 2.4k | Task status policy and permitted transitions |
+| `runtimequeue` | 2.2k | Background job queue for indexing and reconciliation |
+| `lspdaemon` | 1.7k | Project-scoped LSP daemon and leases |
+| `runtimememory` | 1.4k | Builds the memory payload that agent hooks inject |
+| `codegen` | 1.2k | Handlebars-compatible template engine |
+| `decisionmigration` | 1.1k | Reversible bridge from legacy decision memories |
+| `decisionreview` | 1.1k | Detects decisions that overlap or contradict existing ones |
+| `qdrantruntime` | 1.0k | Installs and supervises a managed Qdrant process |
+| `runtimeinstall` | 1.0k | Writes agent hooks for Claude Code, Codex, Kiro, OpenCode |
+| `validate` | 0.9k | Shared validation for tasks, docs, templates, spec compliance |
+| `memoryreview` | 0.6k | Memory promotion, demotion, staleness review |
+
+Smaller packages: `services`, `util`, `permissions`, `readiness`,
+`references`, `tunnel`, `registry`, `safepath`, `instructions`, `process`,
+`gitauth`.
+
+## Entry points
+
+All three read and write the same markdown store through `internal/storage`.
+None of them owns state the others cannot see.
+
+### CLI
+
+```
+cmd/knowns/main.go
+  -> cli.Execute
+     -> cobra dispatch
+        -> internal/storage (read/write markdown)
+        -> internal/runtimequeue (enqueue reindex)
+```
+
+### MCP server
+
+`knowns mcp` starts an MCP server over stdio using `mark3labs/mcp-go`. It
+exposes 12 tools, each an action dispatcher rather than one tool per verb:
+
+`initial`, `help`, `tasks`, `docs`, `search`, `code`, `decision`, `memory`,
+`templates`, `time`, `validate`, `project`.
+
+`search` carries the retrieval actions (`search`, `retrieve`, `resolve`); there
+is no separate `retrieve` tool.
 
 ### Web UI
 
-```
-User: Opens browser, views task
-
-1. knowns browser starts Express server
-2. React app loads in browser
-3. App fetches GET /api/tasks/42
-4. Server reads file, returns JSON
-5. React renders task details
-6. WebSocket notifies other clients on changes
-```
-
-### MCP Server
+`knowns browser` starts the HTTP server and opens the UI. The compiled React
+app is embedded via `ui/embed.go` (`//go:embed dist/*`) and served from the
+binary, so a release needs no separate asset deployment.
 
 ```
-AI: Requests task via MCP
-
-1. Claude calls list_tasks or get_task tool
-2. MCP server receives request
-3. Server reads files from .knowns/
-4. Returns structured data to Claude
-5. Claude uses context for implementation
+internal/server/server.go   chi router, static UI, WebSocket upgrade
+internal/server/routes/     REST endpoints per entity kind
+                            broker.go carries SSE fan-out
 ```
 
----
+Mutations made through the CLI reach an open browser tab because the server
+watches the store with `fsnotify` and pushes changes over SSE and WebSocket.
 
-## Real-time Sync (Web UI)
+## Search
 
+Two independent paths, so the tool stays useful without a model:
+
+- **Lexical.** BM25 over chunked content (`search/code_bm25.go`,
+  `search/lexical_backend.go`). No embeddings, no network, always available.
+- **Semantic.** Chunk, embed, then nearest-neighbour search. Embeddings come
+  from Ollama or a configured provider API (`search/embedding_api.go`,
+  `search/ollama_detect.go`).
+
+Vectors live in one of two backends behind the same interface:
+
+- `search/sqlite_vecstore.go` writes `.knowns/.search/index.db`, holding
+  `chunks`, `metadata`, `content_hashes`, and `code_file_hashes`. This is the
+  default and needs nothing installed.
+- `search/qdrant_vecstore.go` talks to a Qdrant instance that
+  `internal/qdrantruntime` can install and supervise. Chosen for larger stores.
+
+Indexing does not happen inline. `internal/runtimequeue` accepts jobs
+(`index-task`, `index-doc`, `index-decision`, `index-memory`, `index-file`,
+`index-all-files`, `reconcile-knowledge`, `reconcile-qdrant`) and drains them
+in a background runtime, so writing a task never blocks on an embedding call.
+
+## Background runtimes
+
+Three long-lived processes, all optional, all started on demand and addressed
+by hidden commands the binary invokes on itself:
+
+| Process | Started by | Purpose |
+|---|---|---|
+| Runtime worker | `knowns __runtime run` | Drains the indexing and reconciliation queue |
+| LSP daemon | `knowns __lsp-daemon run --project <root>` | Shares language servers across sessions via leases |
+| Qdrant | `internal/qdrantruntime` | Managed vector backend when configured |
+
+Those `__`-prefixed commands are hidden but locked: they appear in
+`internal/cli/testdata/command-contract.txt`, so renaming one is a reviewed
+diff rather than a runtime surprise. See "Extension points".
+
+## Agent integration
+
+`internal/runtimeinstall` writes hook artifacts into a user's home directory
+for Claude Code, Codex, Kiro, and OpenCode. Each hook invokes
+`knowns runtime-memory hook --runtime <name> --event <event>`, and
+`internal/runtimememory` answers with the memory payload the agent injects into
+its context.
+
+Those artifacts are written by one version of the binary and executed by a
+later one, so that argv is a compatibility contract, not an implementation
+detail. `TestInstalledHookArgvResolves` installs every adapter into a temporary
+home and resolves the argv it finds back against the live command tree.
+
+`internal/instructions` embeds the skills (`kn-*`) and unified guidelines that
+`knowns sync` writes into a project. They ship inside the binary, which is why
+editing a skill in the source tree has no effect until you rebuild.
+
+## Technology stack
+
+| Layer | Choice |
+|---|---|
+| Language | Go 1.25 |
+| CLI | `spf13/cobra` |
+| TUI | `charm.land/bubbletea/v2`, `bubbles/v2`, `lipgloss/v2`, `glamour/v2` |
+| HTTP | `go-chi/chi/v5`, `rs/cors` |
+| MCP | `mark3labs/mcp-go` |
+| Storage | Markdown plus `gopkg.in/yaml.v3` frontmatter |
+| Derived index | `modernc.org/sqlite` (pure Go, no cgo) |
+| File watching | `fsnotify/fsnotify` |
+| Web UI | React 19, Vite 7, TypeScript 5.7, Tailwind 4, Radix UI, dnd-kit |
+
+The build sets `CGO_ENABLED=1` for the race detector, not because anything in
+the module binds to C. The SQLite driver is pure Go, which is what keeps the
+single-binary distribution possible.
+
+## Key design decisions
+
+### Why markdown instead of a database
+
+The store is meant to be read by three audiences that do not share a client: a
+human in an editor, a diff in code review, and a model given the file as
+context. A database serves the first two badly and the third not at all. The
+cost is that queries need an index, which is what `.knowns/.search/` is.
+
+### Why SQLite is present anyway
+
+Semantic search needs vectors somewhere. Putting them in markdown would be
+absurd, and requiring a server would break the single-binary promise. SQLite is
+the smallest thing that works, and it is confined to derived data: delete
+`.knowns/.search/` and nothing is lost but time.
+
+### Why indexing is queued rather than inline
+
+Embedding a task takes long enough to be felt on `knowns task create`. The
+queue keeps writes at filesystem speed and lets indexing fail, retry, and
+dead-letter without taking the write with it.
+
+### Why MCP tools are action dispatchers
+
+Twelve tools with an `action` argument, rather than sixty tools. Agent context
+is finite, and a tool list is paid for on every request.
+
+### Why hidden commands exist
+
+`__runtime run` and `__lsp-daemon run` are process entry points, not user
+commands, and `runtime-memory hook` is invoked by files on a user's machine.
+Hiding them keeps the help output honest; the contract snapshot keeps hiding
+them from turning into forgetting them.
+
+## Extension points
+
+### Adding a command
+
+Add the command in `internal/cli`, register it on `rootCmd`, then:
+
+```bash
+make cli-docs        # regenerate docs/en/cli-reference and the contract snapshot
+make cli-docs-check  # verify both, plus that hand-written docs still typecheck
 ```
-┌─────────┐     WebSocket      ┌─────────┐
-│ Browser │◄──────────────────►│ Server  │
-│   Tab 1 │                    │         │
-└─────────┘                    │         │
-                               │         │
-┌─────────┐     WebSocket      │         │
-│ Browser │◄──────────────────►│         │
-│   Tab 2 │                    │         │
-└─────────┘                    │         │
-                               │         │
-┌─────────┐   CLI + notify     │         │
-│   CLI   │───────────────────►│         │
-└─────────┘                    └─────────┘
-```
 
-When CLI modifies a task:
-1. CLI writes to file
-2. CLI calls POST /api/notify
-3. Server broadcasts to all WebSocket clients
-4. Browsers update in real-time
+Do not hand-edit `docs/en/cli-reference/` or
+`internal/cli/testdata/command-contract.txt`.
 
----
+### Retiring a command
 
-## Self-Hosted Sync (Planned)
+Add an entry to `commandLifecycle` in `internal/cli/lifecycle.go` rather than
+deleting the command. A deprecated command keeps working and is hidden; a
+removed one leaves a tombstone that names its replacement instead of failing
+with "unknown command". Anything a machine invokes must keep `Announce: false`,
+because cobra writes its deprecation notice into output that adapters parse.
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        Team Network                              │
-│                                                                  │
-│  ┌─────────┐      ┌─────────┐      ┌─────────┐                 │
-│  │ Dev A   │      │ Dev B   │      │ Dev C   │                 │
-│  │.knowns/ │      │.knowns/ │      │.knowns/ │                 │
-│  └────┬────┘      └────┬────┘      └────┬────┘                 │
-│       │                │                │                       │
-│       └────────────────┼────────────────┘                       │
-│                        │                                         │
-│                        ▼                                         │
-│              ┌─────────────────┐                                │
-│              │   Sync Server   │                                │
-│              │  (self-hosted)  │                                │
-│              │                 │                                │
-│              │ • Task mirror   │                                │
-│              │ • Activity feed │                                │
-│              │ • Team dashboard│                                │
-│              └─────────────────┘                                │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
+### Adding an MCP tool
 
-**Sync Logic:**
+Add a handler under `internal/mcp/handlers/` and register it in the server.
+Prefer a new action on an existing tool over a new tool.
 
-```
-1. Local .knowns/ is always source of truth
-2. CLI pushes changes to sync server
-3. Server stores latest state + history
-4. Team members can view (read-only) or pull
-5. Conflicts resolved by timestamp (last-write-wins) or manual merge
-```
+### Adding an API endpoint
 
-**What syncs:**
-- Task metadata and content
-- Document metadata and content
-- Activity log (who changed what, when)
+Add the route file under `internal/server/routes/` and mount it in
+`router.go`.
 
-**What stays local:**
-- Timer state
-- Local configuration
-- Uncommitted drafts
+## Security
 
----
+- `internal/safepath` resolves untrusted paths inside an explicit root, so a
+  crafted doc path cannot escape `.knowns/`.
+- `internal/permissions` holds the shared action registry and policy model used
+  to gate mutating operations.
+- `internal/gitauth` applies Git HTTP credentials only to a host that has been
+  explicitly trusted.
+- The HTTP server binds to localhost by default. `knowns tunnel` can expose it
+  through a Cloudflare Quick Tunnel, which is opt-in and per-invocation.
 
-## Technology Stack
+## Performance notes
 
-| Layer | Technology |
-|-------|------------|
-| CLI | TypeScript, Commander.js |
-| Storage | File system, gray-matter (frontmatter) |
-| Web Server | Express 5, WebSocket (ws) |
-| Web UI | React 19, Vite, TailwindCSS |
-| MCP | @modelcontextprotocol/sdk |
-| Build | esbuild (CLI), Vite (UI) |
-| Test | Vitest |
-| Lint | Biome |
-
----
-
-## Key Design Decisions
-
-### Why Express over Bun.serve?
-
-Node.js compatibility. Knowns should run anywhere Node runs, not just Bun.
-
-### Why no database?
-
-- Files are simpler to debug
-- Git provides version control for free
-- No migration headaches
-- Portable across machines
-
-### Why markdown?
-
-- Human-readable without tools
-- Syntax highlighting everywhere
-- Frontmatter for structured data
-- Easy to parse programmatically
-
-### Why WebSocket for sync?
-
-- Real-time updates without polling
-- Low latency for collaborative editing
-- Simple pub/sub model
-
----
-
-## Extension Points
-
-### Adding a new command
-
-1. Create `src/commands/mycommand.ts`
-2. Export command function
-3. Register in `src/index.ts`
-
-### Adding a new MCP tool
-
-1. Edit `src/mcp/server.ts`
-2. Add tool definition
-3. Add handler function
-
-### Adding a new API endpoint
-
-1. Edit `src/server/index.ts`
-2. Add route handler
-3. Update WebSocket broadcast if needed
-
----
-
-## Security Considerations
-
-- **Local-first:** Data never leaves your machine unless you enable sync
-- **No auth by default:** Web UI is localhost-only
-- **Sync server:** Will require authentication when implemented
-- **File permissions:** Respect OS file permissions
-
----
-
-## Performance
-
-- **File reads:** Cached in memory during server lifetime
-- **Search:** Full-text scan (fast enough for typical project sizes)
-- **WebSocket:** Lightweight JSON messages
-- **Startup:** < 100ms for CLI commands
-
-For very large projects (1000+ tasks), consider pagination or indexing.
+- Reads go straight to the filesystem; there is no daemon in the path of a CLI
+  read.
+- Writes take a per-entity lock (`.knowns/history/locks/`) so concurrent agents
+  do not interleave edits to the same file.
+- Content hashes in the index let reindexing skip unchanged chunks, so a
+  reindex after a small edit is proportional to the edit, not the store.
+- Language servers are shared through the LSP daemon's leases rather than
+  started per invocation.

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ PLATFORMS := \
 	windows/amd64 \
 	windows/arm64
 
-.PHONY: all build clean test test-e2e test-e2e-semantic test-e2e-ui lint dev dev-go dev-ui dev-all install cross-compile ui embed npm-build release runtime-docker-build runtime-docker-smoke runtime-docker-project-stress runtime-docker-ai-stress runtime-docker-shell runtime-docker-lsp-build runtime-docker-lsp-fixtures
+.PHONY: all build clean test test-e2e test-e2e-semantic test-e2e-ui lint cli-docs cli-docs-check dev dev-go dev-ui dev-all install cross-compile ui embed npm-build release runtime-docker-build runtime-docker-smoke runtime-docker-project-stress runtime-docker-ai-stress runtime-docker-shell runtime-docker-lsp-build runtime-docker-lsp-fixtures
 
 all: ui build
 
@@ -226,6 +226,19 @@ test-e2e-ui: all
 
 test-ui-report: all
 	cd ui && bun exec playwright show-report
+
+# Regenerate everything derived from the command tree: the human CLI reference
+# and the contract snapshot that also covers hidden, machine-facing commands.
+cli-docs:
+	go run ./tools/gendocs
+	go test ./internal/cli -run TestCommandContract -update-contract
+
+# Fail if the committed CLI reference drifted from the command tree, or if a
+# hand-written doc shows a command or flag the binary does not have. The
+# contract snapshot is checked by `go test ./...`, so CI needs only this.
+cli-docs-check:
+	go run ./tools/gendocs --check
+	go run ./tools/gendocs --lint
 
 # Run linter
 lint:

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ knowns doc "architecture/api-design" --smart --plain
 Three-layer memory system - **project**, **session**, and **global** - so AI recalls patterns, conventions, and preferences without you repeating them.
 
 ```bash
-knowns memory add "We use repository pattern for data access" --category pattern
+knowns memory create "We use repository pattern for data access" --category pattern
 knowns memory list --plain
 ```
 
@@ -276,7 +276,7 @@ Handlebars-based templates for scaffolding. Define patterns once, generate consi
 
 ```bash
 knowns template list
-knowns template run <name> --name "UserService"
+knowns template run <name> --var name=UserService
 ```
 
 ### AI Agent Workspaces
@@ -524,7 +524,7 @@ knowns doc "doc-name" --section "2" --plain
 
 # Templates
 knowns template list
-knowns template run <name> --name "X"
+knowns template run <name> --var name=X
 knowns template create <name>
 
 # Imports

--- a/README.vi.md
+++ b/README.vi.md
@@ -224,7 +224,7 @@ knowns doc "architecture/api-design" --smart --plain
 Memory 3 layer — **project**, **session**, **global** — AI recall patterns, conventions, preferences mà không cần bạn nhắc lại.
 
 ```bash
-knowns memory add "We use repository pattern for data access" --category pattern
+knowns memory create "We use repository pattern for data access" --category pattern
 knowns memory list --plain
 ```
 
@@ -276,7 +276,7 @@ Handlebars-based templates cho scaffolding. Define pattern một lần, generate
 
 ```bash
 knowns template list
-knowns template run <name> --name "UserService"
+knowns template run <name> --var name=UserService
 ```
 
 ### AI agent workspaces
@@ -522,7 +522,7 @@ knowns doc "doc-name" --section "2" --plain
 
 # Templates
 knowns template list
-knowns template run <name> --name "X"
+knowns template run <name> --var name=X
 knowns template create <name>
 
 # Imports

--- a/docs/allowed-missing-paths.txt
+++ b/docs/allowed-missing-paths.txt
@@ -1,0 +1,18 @@
+# File references in docs that this check should not try to resolve.
+# One token per line, exactly as it appears in the doc.
+#
+# Add an entry only with a reason. An unexplained entry is how a genuinely
+# broken reference gets hidden, which is the failure this check exists to stop.
+
+# Library and framework names that happen to end in a source extension.
+Commander.js
+commander.js
+Next.js
+
+# Deliberately fictional repositories in the cross-repo handoff and research
+# skills. They illustrate a frontend/backend split; no such repo exists here.
+knowns-api/internal/services/refund_service.go
+knowns-web/src/features/orders/hooks/useRefund.ts
+
+# Placeholder output name in a template example.
+component.tsx

--- a/docs/en/cli-reference/knowns.md
+++ b/docs/en/cli-reference/knowns.md
@@ -1,0 +1,59 @@
+# knowns
+
+The memory layer for AI-native software development
+
+## Usage
+
+```
+knowns [options] [command]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns agents`](knowns_agents.md) — Manage agent instruction files
+- [`knowns audit`](knowns_audit.md) — Inspect MCP tool call audit trail
+- [`knowns board`](knowns_board.md) — Show the Kanban board
+- [`knowns browser`](knowns_browser.md) — Launch the Knowns web UI
+- [`knowns code`](knowns_code.md) — Code intelligence commands
+- [`knowns config`](knowns_config.md) — Manage project configuration
+- [`knowns decision`](knowns_decision.md) — Manage System Decision records
+- [`knowns doc`](knowns_doc.md) — Manage documentation
+- [`knowns doctor`](knowns_doctor.md) — Diagnose project and local integration health
+- [`knowns eval`](knowns_eval.md) — Evaluate deterministic quality gates
+- [`knowns import`](knowns_import.md) — Manage imported Knowns packages
+- [`knowns init`](knowns_init.md) — Initialize a new Knowns project
+- [`knowns lsp`](knowns_lsp.md) — Manage LSP language servers
+- [`knowns mcp`](knowns_mcp.md) — Start the MCP (Model Context Protocol) server
+- [`knowns memory`](knowns_memory.md) — Manage memory entries
+- [`knowns migrate`](knowns_migrate.md) — Apply pending project config schema migrations
+- [`knowns provider`](knowns_provider.md) — Manage embedding API providers
+- [`knowns qdrant`](knowns_qdrant.md) — Inspect and control the semantic Qdrant runtime
+- [`knowns reconcile`](knowns_reconcile.md) — Preview or apply canonical Task/Doc filesystem reconciliation
+- [`knowns resolve`](knowns_resolve.md) — Resolve a semantic reference
+- [`knowns retrieve`](knowns_retrieve.md) — Retrieve ranked context for docs, tasks, and memories
+- [`knowns runtime`](knowns_runtime.md) — Install and inspect runtime hooks and status integrations
+- [`knowns search`](knowns_search.md) — Search tasks and documentation
+- [`knowns settings`](knowns_settings.md) — Open interactive project settings
+- [`knowns setup`](knowns_setup.md) — Configure AI tool integrations
+- [`knowns status`](knowns_status.md) — Show project readiness summary
+- [`knowns sync`](knowns_sync.md) — Sync project from config.json (skills, instructions, model, search index)
+- [`knowns task`](knowns_task.md) — Manage tasks
+- [`knowns template`](knowns_template.md) — Manage code generation templates
+- [`knowns time`](knowns_time.md) — Time tracking
+- [`knowns tunnel`](knowns_tunnel.md) — Manage Cloudflare Quick Tunnels for the local server
+- [`knowns update`](knowns_update.md) — Update Knowns CLI to the latest version and sync project configs
+- [`knowns validate`](knowns_validate.md) — Validate tasks, docs, and templates
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_agents.md
+++ b/docs/en/cli-reference/knowns_agents.md
@@ -1,0 +1,34 @@
+# knowns agents
+
+Manage agent instruction files
+
+Manage AI agent instruction files
+(CLAUDE.md, OPENCODE.md, GEMINI.md, AGENTS.md,
+.github/copilot-instructions.md).
+
+Shows the status of instruction files for each supported AI platform and
+can sync/generate them from project configuration.
+
+## Usage
+
+```
+knowns agents
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_audit.md
+++ b/docs/en/cli-reference/knowns_audit.md
@@ -1,0 +1,26 @@
+# knowns audit
+
+Inspect MCP tool call audit trail
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns audit recent`](knowns_audit_recent.md) — Show recent MCP tool calls
+- [`knowns audit stats`](knowns_audit_stats.md) — Show MCP tool call statistics
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_audit_recent.md
+++ b/docs/en/cli-reference/knowns_audit_recent.md
@@ -1,0 +1,36 @@
+# knowns audit recent
+
+Show recent MCP tool calls
+
+## Usage
+
+```
+knowns audit recent [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--limit` | `int` | `50` | Maximum number of events to show |
+| `--project` | `string` | — | Filter by project root path |
+| `--result` | `string` | — | Filter by result (success, error, denied) |
+| `--tool` | `string` | — | Filter by tool name |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns audit`](knowns_audit.md) — Inspect MCP tool call audit trail
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_audit_stats.md
+++ b/docs/en/cli-reference/knowns_audit_stats.md
@@ -1,0 +1,34 @@
+# knowns audit stats
+
+Show MCP tool call statistics
+
+## Usage
+
+```
+knowns audit stats [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--project` | `string` | — | Filter by project root path |
+| `--tool` | `string` | — | Filter by tool name |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns audit`](knowns_audit.md) — Inspect MCP tool call audit trail
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_board.md
+++ b/docs/en/cli-reference/knowns_board.md
@@ -1,0 +1,27 @@
+# knowns board
+
+Show the Kanban board
+
+## Usage
+
+```
+knowns board
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_browser.md
+++ b/docs/en/cli-reference/knowns_browser.md
@@ -1,0 +1,46 @@
+# knowns browser
+
+Launch the Knowns web UI
+
+Start the Knowns HTTP server and optionally open it in a browser.
+Can be launched outside a repo to use the workspace picker.
+
+## Usage
+
+```
+knowns browser [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--allow-task-hard-delete` | `bool` | — | Grant this server instance Task hard-delete capability |
+| `--dev` | `bool` | — | Enable development mode (verbose logging) |
+| `--no-open` | `bool` | — | Don't automatically open browser |
+| `--open` | `bool` | — | Open browser after starting |
+| `--password` | `string` | — | Protect WebUI with a password (in-memory only) |
+| `--port` | `int` | `0` | HTTP server port (default: 6420; tries next ports if busy) |
+| `--project` | `string` | — | Project path to open directly |
+| `--restart` | `bool` | — | Restart server if already running |
+| `--scan` | `string` | — | Comma-separated directories to scan for projects |
+| `--tunnel` | `bool` | — | Expose via a Cloudflare Quick Tunnel (requires cloudflared) |
+| `--watch` | `bool` | — | Enable file watcher for auto-indexing on code changes |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_code.md
+++ b/docs/en/cli-reference/knowns_code.md
@@ -1,0 +1,40 @@
+# knowns code
+
+Code intelligence commands
+
+Code intelligence commands for AST-based indexing and graph analysis.
+
+Recommended context flow:
+  1. Use 'knowns code search <query>' for keyword code discovery across LSP symbols.
+  2. Use 'knowns code symbols' to verify what was actually indexed in a file or scope.
+  3. Use 'knowns code deps' to inspect raw relationships such as calls, imports, ownership, and inheritance.
+
+Examples:
+  knowns code search "login auth"
+  knowns code search "handleCodeDefinition" --path internal/mcp
+  knowns code deps --type calls
+  knowns code symbols --kind function
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns code deps`](knowns_code_deps.md) — Inspect code dependency data
+- [`knowns code search`](knowns_code_search.md) — Keyword search across LSP code symbols
+- [`knowns code symbols`](knowns_code_symbols.md) — Inspect indexed code symbols
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_code_deps.md
+++ b/docs/en/cli-reference/knowns_code_deps.md
@@ -1,0 +1,34 @@
+# knowns code deps
+
+Inspect code dependency data
+
+## Usage
+
+```
+knowns code deps [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--limit` | `int` | `200` | Limit dependency results |
+| `--type` | `string` | — | Filter dependency edges by type |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns code`](knowns_code.md) — Code intelligence commands
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_code_search.md
+++ b/docs/en/cli-reference/knowns_code_search.md
@@ -1,0 +1,34 @@
+# knowns code search
+
+Keyword search across LSP code symbols
+
+## Usage
+
+```
+knowns code search <query> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--limit` | `int` | `20` | Limit search results |
+| `--path` | `string` | — | Search within a specific file or directory |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns code`](knowns_code.md) — Code intelligence commands
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_code_symbols.md
+++ b/docs/en/cli-reference/knowns_code_symbols.md
@@ -1,0 +1,35 @@
+# knowns code symbols
+
+Inspect indexed code symbols
+
+## Usage
+
+```
+knowns code symbols [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--kind` | `string` | — | Filter symbols by kind |
+| `--limit` | `int` | `100` | Limit symbol results |
+| `--path` | `string` | — | Filter symbols by file path |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns code`](knowns_code.md) — Code intelligence commands
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_config.md
+++ b/docs/en/cli-reference/knowns_config.md
@@ -1,0 +1,28 @@
+# knowns config
+
+Manage project configuration
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns config get`](knowns_config_get.md) — Get a config value
+- [`knowns config list`](knowns_config_list.md) — List all config settings
+- [`knowns config reset`](knowns_config_reset.md) — Reset config to defaults
+- [`knowns config set`](knowns_config_set.md) — Set a config value
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_config_get.md
+++ b/docs/en/cli-reference/knowns_config_get.md
@@ -1,0 +1,27 @@
+# knowns config get
+
+Get a config value
+
+## Usage
+
+```
+knowns config get <key>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns config`](knowns_config.md) — Manage project configuration
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_config_list.md
+++ b/docs/en/cli-reference/knowns_config_list.md
@@ -1,0 +1,27 @@
+# knowns config list
+
+List all config settings
+
+## Usage
+
+```
+knowns config list
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns config`](knowns_config.md) — Manage project configuration
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_config_reset.md
+++ b/docs/en/cli-reference/knowns_config_reset.md
@@ -1,0 +1,33 @@
+# knowns config reset
+
+Reset config to defaults
+
+## Usage
+
+```
+knowns config reset [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-y, --yes` | `bool` | — | Skip confirmation prompt |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns config`](knowns_config.md) — Manage project configuration
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_config_set.md
+++ b/docs/en/cli-reference/knowns_config_set.md
@@ -1,0 +1,27 @@
+# knowns config set
+
+Set a config value
+
+## Usage
+
+```
+knowns config set <key> <value>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns config`](knowns_config.md) — Manage project configuration
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision.md
+++ b/docs/en/cli-reference/knowns_decision.md
@@ -1,0 +1,41 @@
+# knowns decision
+
+Manage System Decision records
+
+Create draft System Decisions, link evidence, verify acceptance, supersede current guidance, and migrate Legacy Decision Memories.
+
+## Usage
+
+```
+knowns decision
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns decision accept`](knowns_decision_accept.md) — Accept a verified draft decision
+- [`knowns decision create`](knowns_decision_create.md) — Create a decision record
+- [`knowns decision get`](knowns_decision_get.md) — View a decision record
+- [`knowns decision inbox`](knowns_decision_inbox.md) — List unresolved persisted Decision candidates
+- [`knowns decision link`](knowns_decision_link.md) — Link docs, tasks, or sources to a decision
+- [`knowns decision list`](knowns_decision_list.md) — List decision records
+- [`knowns decision migrate`](knowns_decision_migrate.md) — Review and migrate legacy Decision Memories
+- [`knowns decision resolve`](knowns_decision_resolve.md) — Resolve a persisted System Decision candidate
+- [`knowns decision supersede`](knowns_decision_supersede.md) — Mark one decision as superseded by another
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_accept.md
+++ b/docs/en/cli-reference/knowns_decision_accept.md
@@ -1,0 +1,33 @@
+# knowns decision accept
+
+Accept a verified draft decision
+
+## Usage
+
+```
+knowns decision accept <id> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--supersede` | `stringArray` | — | Current decision ID replaced on acceptance (repeatable) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision`](knowns_decision.md) — Manage System Decision records
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_create.md
+++ b/docs/en/cli-reference/knowns_decision_create.md
@@ -1,0 +1,42 @@
+# knowns decision create
+
+Create a decision record
+
+## Usage
+
+```
+knowns decision create <title> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--alternatives` | `string` | — | Alternatives Considered section body |
+| `--body` | `string` | — | Full markdown decision body |
+| `--consequences` | `string` | — | Consequences section body |
+| `--context` | `string` | — | Context section body |
+| `--decision` | `string` | — | Decision section body |
+| `--doc` | `stringArray` | — | Related doc path (repeatable) |
+| `--source` | `stringArray` | — | Source reference (repeatable) |
+| `--status` | `string` | — | Decision status; new System Decisions must be draft |
+| `-t, --tag` | `stringArray` | — | Decision tag (repeatable) |
+| `--task` | `stringArray` | — | Related task ID (repeatable) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision`](knowns_decision.md) — Manage System Decision records
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_get.md
+++ b/docs/en/cli-reference/knowns_decision_get.md
@@ -1,0 +1,27 @@
+# knowns decision get
+
+View a decision record
+
+## Usage
+
+```
+knowns decision get <id>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision`](knowns_decision.md) — Manage System Decision records
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_inbox.md
+++ b/docs/en/cli-reference/knowns_decision_inbox.md
@@ -1,0 +1,27 @@
+# knowns decision inbox
+
+List unresolved persisted Decision candidates
+
+## Usage
+
+```
+knowns decision inbox
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision`](knowns_decision.md) — Manage System Decision records
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_link.md
+++ b/docs/en/cli-reference/knowns_decision_link.md
@@ -1,0 +1,35 @@
+# knowns decision link
+
+Link docs, tasks, or sources to a decision
+
+## Usage
+
+```
+knowns decision link <id> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--doc` | `stringArray` | — | Related doc path (repeatable) |
+| `--source` | `stringArray` | — | Source reference (repeatable) |
+| `--task` | `stringArray` | — | Related task ID (repeatable) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision`](knowns_decision.md) — Manage System Decision records
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_list.md
+++ b/docs/en/cli-reference/knowns_decision_list.md
@@ -1,0 +1,35 @@
+# knowns decision list
+
+List decision records
+
+## Usage
+
+```
+knowns decision list [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--all-statuses` | `bool` | — | Include draft, superseded, rejected, and archived decisions |
+| `--status` | `string` | — | Filter by decision status |
+| `--tag` | `string` | — | Filter by tag |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision`](knowns_decision.md) — Manage System Decision records
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_migrate.md
+++ b/docs/en/cli-reference/knowns_decision_migrate.md
@@ -1,0 +1,29 @@
+# knowns decision migrate
+
+Review and migrate legacy Decision Memories
+
+Preview legacy Decision Memories without writes, apply one explicit reviewed resolution, or roll back a prior migration.
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns decision migrate apply`](knowns_decision_migrate_apply.md) — Apply one explicit reviewed migration resolution
+- [`knowns decision migrate preview`](knowns_decision_migrate_preview.md) — Preview legacy Decision Memory candidates without writing
+- [`knowns decision migrate rollback`](knowns_decision_migrate_rollback.md) — Roll back a reviewed legacy Decision Memory migration
+
+## See also
+
+- [`knowns decision`](knowns_decision.md) — Manage System Decision records
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_migrate_apply.md
+++ b/docs/en/cli-reference/knowns_decision_migrate_apply.md
@@ -1,0 +1,41 @@
+# knowns decision migrate apply
+
+Apply one explicit reviewed migration resolution
+
+## Usage
+
+```
+knowns decision migrate apply [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--accept-verified` | `bool` | — | Accept only if linked evidence passes System Decision verification |
+| `--category` | `string` | — | Non-decision Memory category for reclassification |
+| `--decision-id` | `string` | — | Existing or explicit System Decision ID |
+| `--doc` | `stringArray` | — | Related doc path for created/linked Decision (repeatable) |
+| `--memory` | `string` | — | Legacy Decision Memory ID (required) |
+| `--reason` | `string` | — | Reviewed archive/reject rationale |
+| `--resolution` | `string` | — | Reviewed resolution: create_decision, link_existing, consolidate_duplicate, reclassify, archive_noise, reject_noise, leave_unchanged |
+| `--target-memory` | `string` | — | Migrated target Memory ID for duplicate consolidation |
+| `--task` | `stringArray` | — | Related completed task for verified acceptance (repeatable) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision migrate`](knowns_decision_migrate.md) — Review and migrate legacy Decision Memories
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_migrate_preview.md
+++ b/docs/en/cli-reference/knowns_decision_migrate_preview.md
@@ -1,0 +1,27 @@
+# knowns decision migrate preview
+
+Preview legacy Decision Memory candidates without writing
+
+## Usage
+
+```
+knowns decision migrate preview
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision migrate`](knowns_decision_migrate.md) — Review and migrate legacy Decision Memories
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_migrate_rollback.md
+++ b/docs/en/cli-reference/knowns_decision_migrate_rollback.md
@@ -1,0 +1,27 @@
+# knowns decision migrate rollback
+
+Roll back a reviewed legacy Decision Memory migration
+
+## Usage
+
+```
+knowns decision migrate rollback <memory-id>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision migrate`](knowns_decision_migrate.md) — Review and migrate legacy Decision Memories
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_resolve.md
+++ b/docs/en/cli-reference/knowns_decision_resolve.md
@@ -1,0 +1,36 @@
+# knowns decision resolve
+
+Resolve a persisted System Decision candidate
+
+Resolve a persisted candidate with accept_new, link_as_related, reject_new, or supersede_existing. Link and replace require --target.
+
+## Usage
+
+```
+knowns decision resolve <resolution> <candidate-id> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--replacement-id` | `string` | — | Existing verified replacement Decision ID for supersede_existing |
+| `--target` | `string` | — | Existing Decision ID required by link_as_related or supersede_existing |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision`](knowns_decision.md) — Manage System Decision records
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_decision_supersede.md
+++ b/docs/en/cli-reference/knowns_decision_supersede.md
@@ -1,0 +1,27 @@
+# knowns decision supersede
+
+Mark one decision as superseded by another
+
+## Usage
+
+```
+knowns decision supersede <old-id> <new-id>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns decision`](knowns_decision.md) — Manage System Decision records
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_doc.md
+++ b/docs/en/cli-reference/knowns_doc.md
@@ -1,0 +1,49 @@
+# knowns doc
+
+Manage documentation
+
+Create, view, and edit project documentation.
+
+## Usage
+
+```
+knowns doc [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--info` | `bool` | — | Show document stats without content |
+| `--line` | `string` | — | Show specific lines (e.g., '42' or '10-20') |
+| `--section` | `string` | — | Show specific section by number or title |
+| `--smart` | `bool` | — | Auto-optimize reading for large documents |
+| `--toc` | `bool` | — | Show table of contents only |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns doc create`](knowns_doc_create.md) — Create a new documentation file
+- [`knowns doc delete`](knowns_doc_delete.md) — Delete a document permanently
+- [`knowns doc edit`](knowns_doc_edit.md) — Edit a documentation file
+- [`knowns doc hard-delete`](knowns_doc_hard-delete.md) — Permanently purge a document and its verified history
+- [`knowns doc history`](knowns_doc_history.md) — Show version history of a document
+- [`knowns doc list`](knowns_doc_list.md) — List all documentation files
+- [`knowns doc view`](knowns_doc_view.md) — View a documentation file
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_doc_create.md
+++ b/docs/en/cli-reference/knowns_doc_create.md
@@ -1,0 +1,36 @@
+# knowns doc create
+
+Create a new documentation file
+
+## Usage
+
+```
+knowns doc create <title> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-c, --content` | `string` | — | Initial content |
+| `-d, --description` | `string` | — | Document description |
+| `-f, --folder` | `string` | — | Folder path within docs/ |
+| `-t, --tag` | `stringArray` | — | Document tag (repeatable) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns doc`](knowns_doc.md) — Manage documentation
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_doc_delete.md
+++ b/docs/en/cli-reference/knowns_doc_delete.md
@@ -1,0 +1,35 @@
+# knowns doc delete
+
+Delete a document permanently
+
+## Usage
+
+```
+knowns doc delete <path> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--dry-run` | `bool` | — | Preview what would be deleted without deleting |
+| `--expected-hash` | `string` | — | Expected canonical hash for optimistic concurrency |
+| `--force` | `bool` | — | Skip confirmation prompt |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns doc`](knowns_doc.md) — Manage documentation
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_doc_edit.md
+++ b/docs/en/cli-reference/knowns_doc_edit.md
@@ -1,0 +1,40 @@
+# knowns doc edit
+
+Edit a documentation file
+
+## Usage
+
+```
+knowns doc edit <path> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-a, --append` | `string` | — | Append to content |
+| `-c, --content` | `string` | — | Replace content |
+| `-d, --description` | `string` | — | New description |
+| `--expected-hash` | `string` | — | Expected canonical hash for optimistic concurrency |
+| `--path` | `string` | — | Rename doc to a new path |
+| `--section` | `string` | — | Target section to replace (used with --content) |
+| `--tags` | `string` | — | New tags (comma-separated) |
+| `-t, --title` | `string` | — | New title |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns doc`](knowns_doc.md) — Manage documentation
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_doc_hard-delete.md
+++ b/docs/en/cli-reference/knowns_doc_hard-delete.md
@@ -1,0 +1,36 @@
+# knowns doc hard-delete
+
+Permanently purge a document and its verified history
+
+## Usage
+
+```
+knowns doc hard-delete <path> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--allow-hard-delete` | `bool` | — | Grant this local invocation trusted hard-delete capability |
+| `--expected-hash` | `string` | — | Expected canonical hash for optimistic concurrency |
+| `--reason` | `string` | — | Required audit reason for permanent purge |
+| `--yes` | `bool` | — | Confirm permanent purge |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns doc`](knowns_doc.md) — Manage documentation
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_doc_history.md
+++ b/docs/en/cli-reference/knowns_doc_history.md
@@ -1,0 +1,36 @@
+# knowns doc history
+
+Show version history of a document
+
+## Usage
+
+```
+knowns doc history <path> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--limit` | `int` | `0` | Metadata page size (0 means all) |
+| `--metadata` | `bool` | — | List payload-free revision metadata |
+| `--offset` | `int` | `0` | Metadata page offset (newest first) |
+| `--revision` | `string` | — | Load one revision detail (vN or numeric) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns doc`](knowns_doc.md) — Manage documentation
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_doc_list.md
+++ b/docs/en/cli-reference/knowns_doc_list.md
@@ -1,0 +1,33 @@
+# knowns doc list
+
+List all documentation files
+
+## Usage
+
+```
+knowns doc list [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--tag` | `string` | — | Filter by tag |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns doc`](knowns_doc.md) — Manage documentation
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_doc_view.md
+++ b/docs/en/cli-reference/knowns_doc_view.md
@@ -1,0 +1,37 @@
+# knowns doc view
+
+View a documentation file
+
+## Usage
+
+```
+knowns doc view <path> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--info` | `bool` | — | Show document stats without content |
+| `--line` | `string` | — | Show specific lines (e.g., '42' or '10-20') |
+| `--section` | `string` | — | Show specific section by number or title |
+| `--smart` | `bool` | — | Auto-optimize reading for large documents |
+| `--toc` | `bool` | — | Show table of contents only |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns doc`](knowns_doc.md) — Manage documentation
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_doctor.md
+++ b/docs/en/cli-reference/knowns_doctor.md
@@ -1,0 +1,41 @@
+# knowns doctor
+
+Diagnose project and local integration health
+
+Run read-only diagnostics for the active Knowns project.
+
+Every applicable check runs, including bounded probes of the configured
+embedding provider. Use --scope to select diagnostic areas and --verbose to
+show passing and skipped checks.
+
+## Usage
+
+```
+knowns doctor [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--scope` | `stringSlice` | — | Diagnostic scope (repeatable or comma-separated) |
+| `--strict` | `bool` | — | Return exit code 1 when the verdict is degraded |
+| `--verbose` | `bool` | — | Show passing and skipped checks |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_eval.md
+++ b/docs/en/cli-reference/knowns_eval.md
@@ -1,0 +1,25 @@
+# knowns eval
+
+Evaluate deterministic quality gates
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns eval retrieval`](knowns_eval_retrieval.md) — Evaluate retrieval and final ContextPack quality
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_eval_retrieval.md
+++ b/docs/en/cli-reference/knowns_eval_retrieval.md
@@ -1,0 +1,39 @@
+# knowns eval retrieval
+
+Evaluate retrieval and final ContextPack quality
+
+## Usage
+
+```
+knowns eval retrieval [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--baseline` | `string` | — | Baseline file override (canonical runs only) |
+| `--cases` | `string` | — | Project-local fixture path (report-only; never gates or updates canonical baselines) |
+| `--mode` | `string` | `keyword` | Evaluation mode: keyword\|semantic\|hybrid |
+| `--output` | `string` | — | Write the versioned JSON report to this explicit path |
+| `--reason` | `string` | — | Review reason required with --update-baseline |
+| `--runtime-id` | `string` | — | Pinned runtime/model identity required by semantic and hybrid evaluation |
+| `--update-baseline` | `bool` | — | Explicitly replace a canonical baseline from the current reviewed result |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns eval`](knowns_eval.md) — Evaluate deterministic quality gates
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_import.md
+++ b/docs/en/cli-reference/knowns_import.md
@@ -1,0 +1,29 @@
+# knowns import
+
+Manage imported Knowns packages
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns import add`](knowns_import_add.md) — Add an import source
+- [`knowns import list`](knowns_import_list.md) — List all imported packages
+- [`knowns import remove`](knowns_import_remove.md) — Remove an imported package
+- [`knowns import status`](knowns_import_status.md) — Show import status
+- [`knowns import sync`](knowns_import_sync.md) — Sync all imported packages
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_import_add.md
+++ b/docs/en/cli-reference/knowns_import_add.md
@@ -1,0 +1,31 @@
+# knowns import add
+
+Add an import source
+
+Add a Knowns package import. The source can be:
+  - A local path: ./path/to/package
+  - An npm package: @scope/package or package-name
+
+## Usage
+
+```
+knowns import add <source>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns import`](knowns_import.md) — Manage imported Knowns packages
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_import_list.md
+++ b/docs/en/cli-reference/knowns_import_list.md
@@ -1,0 +1,27 @@
+# knowns import list
+
+List all imported packages
+
+## Usage
+
+```
+knowns import list
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns import`](knowns_import.md) — Manage imported Knowns packages
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_import_remove.md
+++ b/docs/en/cli-reference/knowns_import_remove.md
@@ -1,0 +1,27 @@
+# knowns import remove
+
+Remove an imported package
+
+## Usage
+
+```
+knowns import remove <name>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns import`](knowns_import.md) — Manage imported Knowns packages
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_import_status.md
+++ b/docs/en/cli-reference/knowns_import_status.md
@@ -1,0 +1,27 @@
+# knowns import status
+
+Show import status
+
+## Usage
+
+```
+knowns import status
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns import`](knowns_import.md) — Manage imported Knowns packages
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_import_sync.md
+++ b/docs/en/cli-reference/knowns_import_sync.md
@@ -1,0 +1,27 @@
+# knowns import sync
+
+Sync all imported packages
+
+## Usage
+
+```
+knowns import sync
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns import`](knowns_import.md) — Manage imported Knowns packages
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_init.md
+++ b/docs/en/cli-reference/knowns_init.md
@@ -1,0 +1,43 @@
+# knowns init
+
+Initialize a new Knowns project
+
+Initialize a new Knowns project in the current directory.
+Creates a .knowns/ directory with the required structure and a default config.json.
+
+## Usage
+
+```
+knowns init [name] [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-f, --force` | `bool` | — | Force reinitialize even if already initialized |
+| `--git-ignored` | `bool` | — | Add .knowns/ to .gitignore |
+| `--git-tracked` | `bool` | — | Track .knowns/ files in git |
+| `--no-open` | `bool` | — | Skip the web UI launch prompt after init |
+| `--no-wizard` | `bool` | — | Skip interactive prompts, use defaults |
+| `--open` | `bool` | — | Launch the web UI immediately after init |
+| `--task-prefix` | `string` | — | Default task ID prefix (2-8 alphanumeric characters, e.g. KN) |
+| `--wizard` | `bool` | — | Run interactive setup wizard |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_lsp.md
+++ b/docs/en/cli-reference/knowns_lsp.md
@@ -1,0 +1,27 @@
+# knowns lsp
+
+Manage LSP language servers
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns lsp cleanup`](knowns_lsp_cleanup.md) — Remove old LSP server versions
+- [`knowns lsp install`](knowns_lsp_install.md) — Install an LSP language server
+- [`knowns lsp list`](knowns_lsp_list.md) — List supported LSP language servers
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_lsp_cleanup.md
+++ b/docs/en/cli-reference/knowns_lsp_cleanup.md
@@ -1,0 +1,27 @@
+# knowns lsp cleanup
+
+Remove old LSP server versions
+
+## Usage
+
+```
+knowns lsp cleanup
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns lsp`](knowns_lsp.md) — Manage LSP language servers
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_lsp_install.md
+++ b/docs/en/cli-reference/knowns_lsp_install.md
@@ -1,0 +1,35 @@
+# knowns lsp install
+
+Install an LSP language server
+
+## Usage
+
+```
+knowns lsp install <language> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--latest` | `bool` | — | Install the latest upstream version (requires confirmation) |
+| `--version` | `string` | — | Install an explicit upstream version or tag (requires confirmation) |
+| `-y, --yes` | `bool` | — | Confirm a non-recommended version selection |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns lsp`](knowns_lsp.md) — Manage LSP language servers
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_lsp_list.md
+++ b/docs/en/cli-reference/knowns_lsp_list.md
@@ -1,0 +1,27 @@
+# knowns lsp list
+
+List supported LSP language servers
+
+## Usage
+
+```
+knowns lsp list
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns lsp`](knowns_lsp.md) — Manage LSP language servers
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_mcp.md
+++ b/docs/en/cli-reference/knowns_mcp.md
@@ -1,0 +1,39 @@
+# knowns mcp
+
+Start the MCP (Model Context Protocol) server
+
+Start the Knowns MCP server, which exposes project management tools
+to AI agents via the Model Context Protocol.
+
+Use --stdio to communicate over stdin/stdout (default for MCP clients).
+
+## Usage
+
+```
+knowns mcp [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--project` | `string` | — | Project root directory (auto-detected from cwd if not set) |
+| `--stdio` | `bool` | — | Use stdio transport (for MCP clients) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_memory.md
+++ b/docs/en/cli-reference/knowns_memory.md
@@ -1,0 +1,40 @@
+# knowns memory
+
+Manage memory entries
+
+Create, view, and manage project and global memory entries.
+
+## Usage
+
+```
+knowns memory
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns memory cleanup`](knowns_memory_cleanup.md) — List stale memory cleanup candidates
+- [`knowns memory create`](knowns_memory_create.md) — Create a new memory entry
+- [`knowns memory delete`](knowns_memory_delete.md) — Delete a memory entry
+- [`knowns memory demote`](knowns_memory_demote.md) — Demote a memory entry down one layer
+- [`knowns memory edit`](knowns_memory_edit.md) — Edit a memory entry
+- [`knowns memory list`](knowns_memory_list.md) — List memory entries
+- [`knowns memory promote`](knowns_memory_promote.md) — Promote a memory entry up one layer
+- [`knowns memory view`](knowns_memory_view.md) — View a memory entry
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_memory_cleanup.md
+++ b/docs/en/cli-reference/knowns_memory_cleanup.md
@@ -1,0 +1,35 @@
+# knowns memory cleanup
+
+List stale memory cleanup candidates
+
+## Usage
+
+```
+knowns memory cleanup [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--layer` | `string` | `project` | Memory layer (project, global; default: project) |
+| `--limit` | `int` | `20` | Maximum cleanup candidates to return |
+| `--older-than` | `int` | `7` | Minimum stale age in days |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns memory`](knowns_memory.md) — Manage memory entries
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_memory_create.md
+++ b/docs/en/cli-reference/knowns_memory_create.md
@@ -1,0 +1,38 @@
+# knowns memory create
+
+Create a new memory entry
+
+## Usage
+
+```
+knowns memory create <title> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--category` | `string` | — | Memory category (pattern, convention, preference, failure); decision is legacy and rejected |
+| `-c, --content` | `string` | — | Memory content |
+| `--create-anyway` | `bool` | — | Create even when duplicate review candidates are found |
+| `--layer` | `string` | — | Memory layer (working, project, global; default: project) |
+| `--status` | `string` | — | Explicit memory status for human create/override |
+| `-t, --tag` | `stringArray` | — | Memory tag (repeatable) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns memory`](knowns_memory.md) — Manage memory entries
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_memory_delete.md
+++ b/docs/en/cli-reference/knowns_memory_delete.md
@@ -1,0 +1,34 @@
+# knowns memory delete
+
+Delete a memory entry
+
+## Usage
+
+```
+knowns memory delete <id> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--dry-run` | `bool` | — | Preview what would be deleted |
+| `--force` | `bool` | — | Skip confirmation prompt |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns memory`](knowns_memory.md) — Manage memory entries
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_memory_demote.md
+++ b/docs/en/cli-reference/knowns_memory_demote.md
@@ -1,0 +1,27 @@
+# knowns memory demote
+
+Demote a memory entry down one layer
+
+## Usage
+
+```
+knowns memory demote <id>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns memory`](knowns_memory.md) — Manage memory entries
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_memory_edit.md
+++ b/docs/en/cli-reference/knowns_memory_edit.md
@@ -1,0 +1,37 @@
+# knowns memory edit
+
+Edit a memory entry
+
+## Usage
+
+```
+knowns memory edit <id> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-a, --append` | `string` | — | Append to content |
+| `--category` | `string` | — | New category |
+| `-c, --content` | `string` | — | Replace content |
+| `--tag` | `stringArray` | — | New tags (replaces existing) |
+| `-t, --title` | `string` | — | New title |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns memory`](knowns_memory.md) — Manage memory entries
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_memory_list.md
+++ b/docs/en/cli-reference/knowns_memory_list.md
@@ -1,0 +1,37 @@
+# knowns memory list
+
+List memory entries
+
+## Usage
+
+```
+knowns memory list [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--all-statuses` | `bool` | — | Include non-active memory statuses |
+| `--category` | `string` | — | Filter by category |
+| `--layer` | `string` | — | Filter by layer (working, project, global) |
+| `--status` | `string` | — | Filter by memory status |
+| `--tag` | `string` | — | Filter by tag |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns memory`](knowns_memory.md) — Manage memory entries
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_memory_promote.md
+++ b/docs/en/cli-reference/knowns_memory_promote.md
@@ -1,0 +1,27 @@
+# knowns memory promote
+
+Promote a memory entry up one layer
+
+## Usage
+
+```
+knowns memory promote <id>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns memory`](knowns_memory.md) — Manage memory entries
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_memory_view.md
+++ b/docs/en/cli-reference/knowns_memory_view.md
@@ -1,0 +1,27 @@
+# knowns memory view
+
+View a memory entry
+
+## Usage
+
+```
+knowns memory view <id>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns memory`](knowns_memory.md) — Manage memory entries
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_migrate.md
+++ b/docs/en/cli-reference/knowns_migrate.md
@@ -1,0 +1,37 @@
+# knowns migrate
+
+Apply pending project config schema migrations
+
+Preview or apply registered project config schema migrations.
+
+Preview (no flags) reports what is pending and changes nothing. --write applies every pending migration in order and stamps the new schema version. There is no rollback subcommand: the config is in git, and git is the rollback.
+
+## Usage
+
+```
+knowns migrate [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--write` | `bool` | — | Apply pending migrations and write the config |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_provider.md
+++ b/docs/en/cli-reference/knowns_provider.md
@@ -1,0 +1,30 @@
+# knowns provider
+
+Manage embedding API providers
+
+Register, list, remove, and test OpenAI-compatible embedding API providers.
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns provider add`](knowns_provider_add.md) — Register a new embedding provider
+- [`knowns provider list`](knowns_provider_list.md) — List registered providers
+- [`knowns provider remove`](knowns_provider_remove.md) — Remove a provider
+- [`knowns provider test`](knowns_provider_test.md) — Health-check a provider
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_provider_add.md
+++ b/docs/en/cli-reference/knowns_provider_add.md
@@ -1,0 +1,38 @@
+# knowns provider add
+
+Register a new embedding provider
+
+Register an OpenAI-compatible embedding API provider. Tests connectivity before saving.
+
+## Usage
+
+```
+knowns provider add [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--api-base` | `string` | — | API base URL (e.g., http://localhost:11434/v1) |
+| `--api-key` | `string` | — | API key (optional for local providers) |
+| `--id` | `string` | — | Provider ID (e.g., ollama, openai) |
+| `--name` | `string` | — | Display name |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns provider`](knowns_provider.md) — Manage embedding API providers
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_provider_list.md
+++ b/docs/en/cli-reference/knowns_provider_list.md
@@ -1,0 +1,27 @@
+# knowns provider list
+
+List registered providers
+
+## Usage
+
+```
+knowns provider list
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns provider`](knowns_provider.md) — Manage embedding API providers
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_provider_remove.md
+++ b/docs/en/cli-reference/knowns_provider_remove.md
@@ -1,0 +1,27 @@
+# knowns provider remove
+
+Remove a provider
+
+## Usage
+
+```
+knowns provider remove [id]
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns provider`](knowns_provider.md) — Manage embedding API providers
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_provider_test.md
+++ b/docs/en/cli-reference/knowns_provider_test.md
@@ -1,0 +1,27 @@
+# knowns provider test
+
+Health-check a provider
+
+## Usage
+
+```
+knowns provider test [id]
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns provider`](knowns_provider.md) — Manage embedding API providers
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_qdrant.md
+++ b/docs/en/cli-reference/knowns_qdrant.md
@@ -1,0 +1,37 @@
+# knowns qdrant
+
+Inspect and control the semantic Qdrant runtime
+
+Inspect and control the Qdrant runtime used by semantic vector search.
+
+Managed mode owns a local Qdrant process rooted at ~/.knowns/runtime/qdrant.
+External URL mode reports the configured endpoint and bypasses local process
+start/stop/cleanup ownership.
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns qdrant cleanup`](knowns_qdrant_cleanup.md) — Remove stale managed Qdrant runtime metadata
+- [`knowns qdrant install`](knowns_qdrant_install.md) — Install the pinned managed Qdrant binary with checksum verification
+- [`knowns qdrant logs`](knowns_qdrant_logs.md) — Show managed Qdrant log lines
+- [`knowns qdrant purge`](knowns_qdrant_purge.md) — Immediately purge positively owned semantic collections
+- [`knowns qdrant start`](knowns_qdrant_start.md) — Start managed Qdrant when in managed mode
+- [`knowns qdrant status`](knowns_qdrant_status.md) — Show Qdrant runtime status and paths
+- [`knowns qdrant stop`](knowns_qdrant_stop.md) — Stop managed Qdrant when Knowns owns a local process
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_qdrant_cleanup.md
+++ b/docs/en/cli-reference/knowns_qdrant_cleanup.md
@@ -1,0 +1,29 @@
+# knowns qdrant cleanup
+
+Remove stale managed Qdrant runtime metadata
+
+Remove stale managed Qdrant PID/status metadata. This does not delete vector data or collections.
+
+## Usage
+
+```
+knowns qdrant cleanup
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns qdrant`](knowns_qdrant.md) — Inspect and control the semantic Qdrant runtime
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_qdrant_install.md
+++ b/docs/en/cli-reference/knowns_qdrant_install.md
@@ -1,0 +1,27 @@
+# knowns qdrant install
+
+Install the pinned managed Qdrant binary with checksum verification
+
+## Usage
+
+```
+knowns qdrant install
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns qdrant`](knowns_qdrant.md) — Inspect and control the semantic Qdrant runtime
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_qdrant_logs.md
+++ b/docs/en/cli-reference/knowns_qdrant_logs.md
@@ -1,0 +1,33 @@
+# knowns qdrant logs
+
+Show managed Qdrant log lines
+
+## Usage
+
+```
+knowns qdrant logs [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-n, --tail` | `int` | `50` | Number of trailing lines to show |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns qdrant`](knowns_qdrant.md) — Inspect and control the semantic Qdrant runtime
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_qdrant_purge.md
+++ b/docs/en/cli-reference/knowns_qdrant_purge.md
@@ -1,0 +1,29 @@
+# knowns qdrant purge
+
+Immediately purge positively owned semantic collections
+
+Explicit privacy/hard purge. Retention is bypassed, but deletion fails closed unless pointer and generation history prove ownership.
+
+## Usage
+
+```
+knowns qdrant purge
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns qdrant`](knowns_qdrant.md) — Inspect and control the semantic Qdrant runtime
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_qdrant_start.md
+++ b/docs/en/cli-reference/knowns_qdrant_start.md
@@ -1,0 +1,27 @@
+# knowns qdrant start
+
+Start managed Qdrant when in managed mode
+
+## Usage
+
+```
+knowns qdrant start
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns qdrant`](knowns_qdrant.md) — Inspect and control the semantic Qdrant runtime
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_qdrant_status.md
+++ b/docs/en/cli-reference/knowns_qdrant_status.md
@@ -1,0 +1,27 @@
+# knowns qdrant status
+
+Show Qdrant runtime status and paths
+
+## Usage
+
+```
+knowns qdrant status
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns qdrant`](knowns_qdrant.md) — Inspect and control the semantic Qdrant runtime
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_qdrant_stop.md
+++ b/docs/en/cli-reference/knowns_qdrant_stop.md
@@ -1,0 +1,27 @@
+# knowns qdrant stop
+
+Stop managed Qdrant when Knowns owns a local process
+
+## Usage
+
+```
+knowns qdrant stop
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns qdrant`](knowns_qdrant.md) — Inspect and control the semantic Qdrant runtime
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_reconcile.md
+++ b/docs/en/cli-reference/knowns_reconcile.md
@@ -1,0 +1,34 @@
+# knowns reconcile
+
+Preview or apply canonical Task/Doc filesystem reconciliation
+
+## Usage
+
+```
+knowns reconcile [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--execute` | `bool` | — | apply revisions and manifest updates (default is preview) |
+| `--wait` | `bool` | — | wait for the reconciliation job to complete |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_resolve.md
+++ b/docs/en/cli-reference/knowns_resolve.md
@@ -1,0 +1,36 @@
+# knowns resolve
+
+Resolve a semantic reference
+
+## Usage
+
+```
+knowns resolve <semantic-ref> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--depth` | `int` | `0` | Max traversal hops (1-3, default 1) |
+| `--direction` | `string` | — | Traversal direction: outbound (default), inbound, or both |
+| `--relation` | `string` | — | Filter by relation kinds (comma-separated) |
+| `--type` | `string` | — | Filter result entities by kind (comma-separated) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_retrieve.md
+++ b/docs/en/cli-reference/knowns_retrieve.md
@@ -1,0 +1,42 @@
+# knowns retrieve
+
+Retrieve ranked context for docs, tasks, and memories
+
+## Usage
+
+```
+knowns retrieve <query> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--assignee` | `string` | — | Filter tasks by assignee |
+| `--expand-references` | `bool` | — | Expand @doc/@task/@memory/@decision references into the result |
+| `--include-historical` | `bool` | — | Include historical entities; Task retrieval adds done and archived Tasks |
+| `--keyword` | `bool` | — | Force keyword-only retrieval |
+| `--label` | `string` | — | Filter tasks by label |
+| `--limit` | `int` | `20` | Limit ranked candidates |
+| `--priority` | `string` | — | Filter tasks by priority |
+| `--source-types` | `string` | — | Comma-separated source types: doc,task,memory,decision |
+| `--status` | `string` | — | Filter by task, memory, or decision status |
+| `--tag` | `string` | — | Filter docs, memories, or decisions by tag |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_runtime.md
+++ b/docs/en/cli-reference/knowns_runtime.md
@@ -1,0 +1,32 @@
+# knowns runtime
+
+Install and inspect runtime hooks and status integrations
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns runtime install`](knowns_runtime_install.md) — Install a runtime memory adapter
+- [`knowns runtime logs`](knowns_runtime_logs.md) — Show runtime / MCP server log files
+- [`knowns runtime memory`](knowns_runtime_memory.md) — Manage runtime memory hook behavior
+- [`knowns runtime ps`](knowns_runtime_ps.md) — Show live runtime processes and jobs, not readiness or integration status
+- [`knowns runtime reload`](knowns_runtime_reload.md) — Reload shared runtime semantic providers and config
+- [`knowns runtime status`](knowns_runtime_status.md) — Show runtime hook and integration installation state
+- [`knowns runtime stop`](knowns_runtime_stop.md) — Request the shared runtime to shut down gracefully
+- [`knowns runtime uninstall`](knowns_runtime_uninstall.md) — Remove a runtime memory adapter
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_runtime_install.md
+++ b/docs/en/cli-reference/knowns_runtime_install.md
@@ -1,0 +1,27 @@
+# knowns runtime install
+
+Install a runtime memory adapter
+
+## Usage
+
+```
+knowns runtime install <runtime>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns runtime`](knowns_runtime.md) — Install and inspect runtime hooks and status integrations
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_runtime_logs.md
+++ b/docs/en/cli-reference/knowns_runtime_logs.md
@@ -1,0 +1,35 @@
+# knowns runtime logs
+
+Show runtime / MCP server log files
+
+## Usage
+
+```
+knowns runtime logs [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-f, --follow` | `bool` | — | Follow new log lines |
+| `-s, --source` | `string` | `all` | Which log to read: runtime\|mcp\|all |
+| `-n, --tail` | `int` | `50` | Number of trailing lines to show |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns runtime`](knowns_runtime.md) — Install and inspect runtime hooks and status integrations
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_runtime_memory.md
+++ b/docs/en/cli-reference/knowns_runtime_memory.md
@@ -1,0 +1,25 @@
+# knowns runtime memory
+
+Manage runtime memory hook behavior
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns runtime memory hook`](knowns_runtime_memory_hook.md) — Build a runtime memory payload for adapter hooks
+
+## See also
+
+- [`knowns runtime`](knowns_runtime.md) — Install and inspect runtime hooks and status integrations
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_runtime_memory_hook.md
+++ b/docs/en/cli-reference/knowns_runtime_memory_hook.md
@@ -1,0 +1,40 @@
+# knowns runtime memory hook
+
+Build a runtime memory payload for adapter hooks
+
+## Usage
+
+```
+knowns runtime memory hook [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--capture` | `string` | — | Override runtime memory capture mode |
+| `--cwd` | `string` | — | Working directory for scoring context |
+| `--event` | `string` | — | Hook event name |
+| `--max-bytes` | `int` | `0` | Override maximum serialized bytes |
+| `--max-items` | `int` | `0` | Override maximum number of memory items |
+| `--mode` | `string` | — | Override runtime memory mode |
+| `--project` | `string` | — | Project root (defaults to detected project) |
+| `--runtime` | `string` | — | Runtime adapter name |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns runtime memory`](knowns_runtime_memory.md) — Manage runtime memory hook behavior
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_runtime_ps.md
+++ b/docs/en/cli-reference/knowns_runtime_ps.md
@@ -1,0 +1,47 @@
+# knowns runtime ps
+
+Show live runtime processes and jobs, not readiness or integration status
+
+Show live shared runtime status: managed services, connected clients,
+current queue activity, and bounded recent job failures.
+
+Use this for process and queue visibility. For project readiness, use knowns status.
+For diagnostics and remediation, use knowns doctor. For runtime hook or plugin
+installation state, use knowns runtime status. For raw logs, use knowns runtime logs.
+
+## Usage
+
+```
+knowns runtime ps [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--all` | `bool` | — | Show all retained recent jobs |
+| `--clients` | `int` | `6` | Number of connected clients to show in compact output (0 hides client rows) |
+| `--failed` | `bool` | — | Show only failed recent jobs |
+| `--failures` | `int` | `3` | Number of grouped recent failures to show in compact output (0 hides failure rows) |
+| `--interval` | `duration` | `2s` | Refresh interval when --watch is set |
+| `--jobs` | `bool` | — | Show detailed runtime job history |
+| `--tail` | `int` | `10` | Number of recent jobs to show when job details are enabled |
+| `-w, --watch` | `bool` | — | Refresh continuously |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns runtime`](knowns_runtime.md) — Install and inspect runtime hooks and status integrations
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_runtime_reload.md
+++ b/docs/en/cli-reference/knowns_runtime_reload.md
@@ -1,0 +1,34 @@
+# knowns runtime reload
+
+Reload shared runtime semantic providers and config
+
+## Usage
+
+```
+knowns runtime reload [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--timeout` | `duration` | `10s` | Maximum time to wait for reload acknowledgement |
+| `--wait` | `bool` | — | Wait until runtime acknowledges reload |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns runtime`](knowns_runtime.md) — Install and inspect runtime hooks and status integrations
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_runtime_status.md
+++ b/docs/en/cli-reference/knowns_runtime_status.md
@@ -1,0 +1,27 @@
+# knowns runtime status
+
+Show runtime hook and integration installation state
+
+## Usage
+
+```
+knowns runtime status
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns runtime`](knowns_runtime.md) — Install and inspect runtime hooks and status integrations
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_runtime_stop.md
+++ b/docs/en/cli-reference/knowns_runtime_stop.md
@@ -1,0 +1,27 @@
+# knowns runtime stop
+
+Request the shared runtime to shut down gracefully
+
+## Usage
+
+```
+knowns runtime stop
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns runtime`](knowns_runtime.md) — Install and inspect runtime hooks and status integrations
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_runtime_uninstall.md
+++ b/docs/en/cli-reference/knowns_runtime_uninstall.md
@@ -1,0 +1,27 @@
+# knowns runtime uninstall
+
+Remove a runtime memory adapter
+
+## Usage
+
+```
+knowns runtime uninstall <runtime>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns runtime`](knowns_runtime.md) — Install and inspect runtime hooks and status integrations
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_search.md
+++ b/docs/en/cli-reference/knowns_search.md
@@ -1,0 +1,48 @@
+# knowns search
+
+Search tasks and documentation
+
+## Usage
+
+```
+knowns search <query> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--assignee` | `string` | — | Filter tasks by assignee |
+| `--include-historical` | `bool` | — | Include historical entities, including archived Tasks |
+| `--keyword` | `bool` | — | Force keyword-only search |
+| `--label` | `string` | — | Filter tasks by label |
+| `--limit` | `int` | `20` | Limit search results |
+| `--priority` | `string` | — | Filter tasks by priority |
+| `--reindex` | `bool` | — | Rebuild the search index |
+| `--setup` | `bool` | — | Set up semantic search |
+| `--status` | `string` | — | Filter by task, memory, or decision status |
+| `--status-check` | `bool` | — | Show semantic search status |
+| `--tag` | `string` | — | Filter docs, memories, or decisions by tag |
+| `--type` | `string` | — | Search type: all\|task\|doc\|memory\|decision (default: all) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns search index`](knowns_search_index.md) — Build the configured semantic index
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_search_index.md
+++ b/docs/en/cli-reference/knowns_search_index.md
@@ -1,0 +1,33 @@
+# knowns search index
+
+Build the configured semantic index
+
+## Usage
+
+```
+knowns search index [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--wait` | `bool` | — | Block until managed setup and indexing succeed or fail |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns search`](knowns_search.md) — Search tasks and documentation
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_settings.md
+++ b/docs/en/cli-reference/knowns_settings.md
@@ -1,0 +1,33 @@
+# knowns settings
+
+Open interactive project settings
+
+## Usage
+
+```
+knowns settings [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--global` | `bool` | — | Edit global defaults for future knowns init runs |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_setup.md
+++ b/docs/en/cli-reference/knowns_setup.md
@@ -1,0 +1,54 @@
+# knowns setup
+
+Configure AI tool integrations
+
+Configure AI tool integrations for an initialized Knowns project.
+
+Without a target, an interactive selector is shown.
+
+Targets:
+  claude    Generate CLAUDE.md, .mcp.json, skills, and runtime hooks
+  opencode  Generate OPENCODE.md, opencode.json, skills, and runtime hooks
+  hermes    Generate AGENTS.md, skills, and a project-pinned global Hermes MCP config
+  codex     Generate AGENTS.md, .codex/config.toml, skills, and runtime hooks
+  copilot   Generate .github/copilot-instructions.md
+  kiro      Generate .kiro steering/settings, skills, and runtime hooks
+  cursor    Generate .cursor/mcp.json
+  gemini    Generate GEMINI.md
+  antigravity Generate Antigravity rules/config and skills
+  agents    Generate AGENTS.md
+  all       Generate all supported AI integration files
+
+Use --global to install at user-level paths (no project required).
+Global MCP uses 'knowns mcp --stdio' without --project flag.
+
+## Usage
+
+```
+knowns setup [target] [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-f, --force` | `bool` | — | Overwrite generated files where supported |
+| `--global` | `bool` | — | Install to user-level paths (no project required) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_status.md
+++ b/docs/en/cli-reference/knowns_status.md
@@ -1,0 +1,35 @@
+# knowns status
+
+Show project readiness summary
+
+Display a unified readiness summary for the active Knowns project.
+
+Shows project identity, knowledge counts, search status, runtime health,
+and available capabilities in one view.
+
+Use --json for structured output consumed by scripts or AI clients.
+Use --plain for clean text output suitable for piping.
+
+## Usage
+
+```
+knowns status
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_sync.md
+++ b/docs/en/cli-reference/knowns_sync.md
@@ -1,0 +1,53 @@
+# knowns sync
+
+Sync project from config.json (skills, instructions, model, search index)
+
+Apply project configuration from .knowns/config.json.
+
+This is the recommended command after cloning a repo with Knowns:
+  git clone <repo>
+  knowns sync
+
+It reads config.json and sets up everything locally:
+  • Skills — copies built-in skills to platform directories
+  • Instructions — generates agent instruction files (CLAUDE.md, AGENTS.md, etc.)
+  • Runtime hooks — installs current memory hooks for configured runtimes
+  • Model — downloads the configured embedding model (if not installed)
+  • Search index — rebuilds the semantic search index
+  • Git integration — applies .gitignore rules for the configured tracking mode
+
+Use flags to sync only specific parts.
+
+## Usage
+
+```
+knowns sync [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--force` | `bool` | — | Force resync (overwrite existing files) [deprecated: sync always overwrites] |
+| `--instructions` | `bool` | — | Sync instruction files only |
+| `--model` | `bool` | — | Download embedding model only |
+| `--platform` | `string` | — | Sync specific platform (claude, opencode, codex, kiro, antigravity, cursor, gemini, copilot, agents, all) |
+| `--skills` | `bool` | — | Sync skills only |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task.md
+++ b/docs/en/cli-reference/knowns_task.md
@@ -1,0 +1,42 @@
+# knowns task
+
+Manage tasks
+
+Create, view, edit, and manage project tasks.
+
+## Usage
+
+```
+knowns task
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns task archive`](knowns_task_archive.md) — Archive a task
+- [`knowns task batch-archive`](knowns_task_batch-archive.md) — Preview or execute a batch archive
+- [`knowns task batch-unarchive`](knowns_task_batch-unarchive.md) — Preview or execute a batch unarchive
+- [`knowns task create`](knowns_task_create.md) — Create a new task
+- [`knowns task edit`](knowns_task_edit.md) — Edit a task
+- [`knowns task hard-delete`](knowns_task_hard-delete.md) — Permanently delete a task and retain a content-free tombstone
+- [`knowns task history`](knowns_task_history.md) — Show version history of a task
+- [`knowns task list`](knowns_task_list.md) — List tasks
+- [`knowns task unarchive`](knowns_task_unarchive.md) — Restore a task from the archive
+- [`knowns task view`](knowns_task_view.md) — View a task
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task_archive.md
+++ b/docs/en/cli-reference/knowns_task_archive.md
@@ -1,0 +1,34 @@
+# knowns task archive
+
+Archive a task
+
+## Usage
+
+```
+knowns task archive <id> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--expected-hash` | `string` | — | Expected canonical hash for optimistic concurrency |
+| `--yes` | `bool` | — | Execute; otherwise preview only |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns task`](knowns_task.md) — Manage tasks
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task_batch-archive.md
+++ b/docs/en/cli-reference/knowns_task_batch-archive.md
@@ -1,0 +1,33 @@
+# knowns task batch-archive
+
+Preview or execute a batch archive
+
+## Usage
+
+```
+knowns task batch-archive [ids...] [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--yes` | `bool` | — | Execute; otherwise preview only |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns task`](knowns_task.md) — Manage tasks
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task_batch-unarchive.md
+++ b/docs/en/cli-reference/knowns_task_batch-unarchive.md
@@ -1,0 +1,33 @@
+# knowns task batch-unarchive
+
+Preview or execute a batch unarchive
+
+## Usage
+
+```
+knowns task batch-unarchive <ids...> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--yes` | `bool` | — | Execute; otherwise preview only |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns task`](knowns_task.md) — Manage tasks
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task_create.md
+++ b/docs/en/cli-reference/knowns_task_create.md
@@ -1,0 +1,44 @@
+# knowns task create
+
+Create a new task
+
+## Usage
+
+```
+knowns task create <title> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--ac` | `stringArray` | — | Acceptance criterion (repeatable) |
+| `-a, --assignee` | `string` | — | Task assignee |
+| `-d, --description` | `string` | — | Task description |
+| `--fulfills` | `stringArray` | — | Spec AC this task fulfills (repeatable) |
+| `-l, --label` | `stringArray` | — | Task label (repeatable) |
+| `--notes` | `string` | — | Implementation notes |
+| `--parent` | `string` | — | Parent task ID |
+| `--plan` | `string` | — | Implementation plan |
+| `--prefix` | `string` | — | Custom task ID prefix (2-8 alphanumeric characters) |
+| `--priority` | `string` | — | Task priority (low\|medium\|high) |
+| `--spec` | `string` | — | Linked spec document path |
+| `-s, --status` | `string` | — | Task status |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns task`](knowns_task.md) — Manage tasks
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task_edit.md
+++ b/docs/en/cli-reference/knowns_task_edit.md
@@ -1,0 +1,50 @@
+# knowns task edit
+
+Edit a task
+
+## Usage
+
+```
+knowns task edit <id> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--ac` | `stringArray` | — | Add acceptance criterion (repeatable) |
+| `--append-notes` | `string` | — | Append to implementation notes |
+| `-a, --assignee` | `string` | — | New assignee |
+| `--check-ac` | `intSlice` | — | Check AC by 1-based index (repeatable) |
+| `-d, --description` | `string` | — | New description |
+| `--expected-hash` | `string` | — | Expected canonical hash for optimistic concurrency |
+| `--fulfills` | `stringArray` | — | Spec ACs this task fulfills (repeatable) |
+| `--labels` | `string` | — | New labels (comma-separated) |
+| `--notes` | `string` | — | Set implementation notes (replaces existing) |
+| `--order` | `int` | `0` | Display order (lower = first) |
+| `--parent` | `string` | — | Parent task ID |
+| `--plan` | `string` | — | Set implementation plan |
+| `--priority` | `string` | — | New priority |
+| `--remove-ac` | `intSlice` | — | Remove AC by 1-based index (repeatable) |
+| `--spec` | `string` | — | Linked spec document path |
+| `-s, --status` | `string` | — | New status |
+| `-t, --title` | `string` | — | New title |
+| `--uncheck-ac` | `intSlice` | — | Uncheck AC by 1-based index (repeatable) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns task`](knowns_task.md) — Manage tasks
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task_hard-delete.md
+++ b/docs/en/cli-reference/knowns_task_hard-delete.md
@@ -1,0 +1,35 @@
+# knowns task hard-delete
+
+Permanently delete a task and retain a content-free tombstone
+
+## Usage
+
+```
+knowns task hard-delete <id> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--allow-hard-delete` | `bool` | — | Grant this local CLI invocation hard-delete capability |
+| `--reason` | `string` | — | Required deletion reason |
+| `--yes` | `bool` | — | Explicitly confirm permanent deletion |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns task`](knowns_task.md) — Manage tasks
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task_history.md
+++ b/docs/en/cli-reference/knowns_task_history.md
@@ -1,0 +1,36 @@
+# knowns task history
+
+Show version history of a task
+
+## Usage
+
+```
+knowns task history <id> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--limit` | `int` | `0` | Metadata page size (0 means all) |
+| `--metadata` | `bool` | — | List payload-free revision metadata |
+| `--offset` | `int` | `0` | Metadata page offset (newest first) |
+| `--revision` | `string` | — | Load one revision detail (vN or numeric) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns task`](knowns_task.md) — Manage tasks
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task_list.md
+++ b/docs/en/cli-reference/knowns_task_list.md
@@ -1,0 +1,38 @@
+# knowns task list
+
+List tasks
+
+## Usage
+
+```
+knowns task list [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--assignee` | `string` | — | Filter by assignee |
+| `--include-historical` | `bool` | — | Include historical entities, including archived Tasks |
+| `--label` | `string` | — | Filter by label |
+| `--priority` | `string` | — | Filter by priority |
+| `--status` | `string` | — | Filter by status |
+| `--tree` | `bool` | — | Show tasks as tree hierarchy |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns task`](knowns_task.md) — Manage tasks
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task_unarchive.md
+++ b/docs/en/cli-reference/knowns_task_unarchive.md
@@ -1,0 +1,34 @@
+# knowns task unarchive
+
+Restore a task from the archive
+
+## Usage
+
+```
+knowns task unarchive <id> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--expected-hash` | `string` | — | Expected canonical hash for optimistic concurrency |
+| `--yes` | `bool` | — | Execute; otherwise preview only |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns task`](knowns_task.md) — Manage tasks
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_task_view.md
+++ b/docs/en/cli-reference/knowns_task_view.md
@@ -1,0 +1,27 @@
+# knowns task view
+
+View a task
+
+## Usage
+
+```
+knowns task view <id>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns task`](knowns_task.md) — Manage tasks
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_template.md
+++ b/docs/en/cli-reference/knowns_template.md
@@ -1,0 +1,36 @@
+# knowns template
+
+Manage code generation templates
+
+List, view, run, and create code generation templates.
+
+## Usage
+
+```
+knowns template
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns template create`](knowns_template_create.md) — Create a new template scaffold
+- [`knowns template list`](knowns_template_list.md) — List available templates
+- [`knowns template run`](knowns_template_run.md) — Run a code generation template
+- [`knowns template view`](knowns_template_view.md) — View template details
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_template_create.md
+++ b/docs/en/cli-reference/knowns_template_create.md
@@ -1,0 +1,34 @@
+# knowns template create
+
+Create a new template scaffold
+
+## Usage
+
+```
+knowns template create <name> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-d, --description` | `string` | — | Template description |
+| `--doc` | `string` | — | Link to documentation (e.g., 'patterns/controller') |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns template`](knowns_template.md) — Manage code generation templates
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_template_list.md
+++ b/docs/en/cli-reference/knowns_template_list.md
@@ -1,0 +1,34 @@
+# knowns template list
+
+List available templates
+
+## Usage
+
+```
+knowns template list [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--imported` | `bool` | — | Show only imported templates |
+| `--local` | `bool` | — | Show only local templates |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns template`](knowns_template.md) — Manage code generation templates
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_template_run.md
+++ b/docs/en/cli-reference/knowns_template_run.md
@@ -1,0 +1,34 @@
+# knowns template run
+
+Run a code generation template
+
+## Usage
+
+```
+knowns template run <name> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--dry-run` | `bool` | — | Preview without writing files |
+| `-v, --var` | `stringArray` | — | Template variable (key=value, repeatable) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns template`](knowns_template.md) — Manage code generation templates
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_template_view.md
+++ b/docs/en/cli-reference/knowns_template_view.md
@@ -1,0 +1,27 @@
+# knowns template view
+
+View template details
+
+## Usage
+
+```
+knowns template view <name>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns template`](knowns_template.md) — Manage code generation templates
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_time.md
+++ b/docs/en/cli-reference/knowns_time.md
@@ -1,0 +1,32 @@
+# knowns time
+
+Time tracking
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns time add`](knowns_time_add.md) — Manually add a time entry (e.g. 2h, 30m)
+- [`knowns time log`](knowns_time_log.md) — Show time log for a specific task
+- [`knowns time pause`](knowns_time_pause.md) — Pause the active timer
+- [`knowns time report`](knowns_time_report.md) — Generate time tracking report
+- [`knowns time resume`](knowns_time_resume.md) — Resume a paused timer
+- [`knowns time start`](knowns_time_start.md) — Start a timer for a task
+- [`knowns time status`](knowns_time_status.md) — Show current timer status
+- [`knowns time stop`](knowns_time_stop.md) — Stop the active timer
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_time_add.md
+++ b/docs/en/cli-reference/knowns_time_add.md
@@ -1,0 +1,35 @@
+# knowns time add
+
+Manually add a time entry (e.g. 2h, 30m)
+
+## Usage
+
+```
+knowns time add <taskId> <duration> [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-d, --date` | `string` | — | Date (YYYY-MM-DD, defaults to today) |
+| `--expected-hash` | `string` | — | Expected canonical task hash |
+| `-n, --note` | `string` | — | Note for this time entry |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns time`](knowns_time.md) — Time tracking
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_time_log.md
+++ b/docs/en/cli-reference/knowns_time_log.md
@@ -1,0 +1,27 @@
+# knowns time log
+
+Show time log for a specific task
+
+## Usage
+
+```
+knowns time log <taskId>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns time`](knowns_time.md) — Time tracking
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_time_pause.md
+++ b/docs/en/cli-reference/knowns_time_pause.md
@@ -1,0 +1,27 @@
+# knowns time pause
+
+Pause the active timer
+
+## Usage
+
+```
+knowns time pause [taskId]
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns time`](knowns_time.md) — Time tracking
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_time_report.md
+++ b/docs/en/cli-reference/knowns_time_report.md
@@ -1,0 +1,37 @@
+# knowns time report
+
+Generate time tracking report
+
+## Usage
+
+```
+knowns time report [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--by-label` | `bool` | — | Group by label |
+| `--by-status` | `bool` | — | Group by status |
+| `--csv` | `bool` | — | Output as CSV |
+| `--from` | `string` | — | Start date (YYYY-MM-DD) |
+| `--to` | `string` | — | End date (YYYY-MM-DD) |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns time`](knowns_time.md) — Time tracking
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_time_resume.md
+++ b/docs/en/cli-reference/knowns_time_resume.md
@@ -1,0 +1,27 @@
+# knowns time resume
+
+Resume a paused timer
+
+## Usage
+
+```
+knowns time resume [taskId]
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns time`](knowns_time.md) — Time tracking
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_time_start.md
+++ b/docs/en/cli-reference/knowns_time_start.md
@@ -1,0 +1,27 @@
+# knowns time start
+
+Start a timer for a task
+
+## Usage
+
+```
+knowns time start <taskId>
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns time`](knowns_time.md) — Time tracking
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_time_status.md
+++ b/docs/en/cli-reference/knowns_time_status.md
@@ -1,0 +1,27 @@
+# knowns time status
+
+Show current timer status
+
+## Usage
+
+```
+knowns time status
+```
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns time`](knowns_time.md) — Time tracking
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_time_stop.md
+++ b/docs/en/cli-reference/knowns_time_stop.md
@@ -1,0 +1,33 @@
+# knowns time stop
+
+Stop the active timer
+
+## Usage
+
+```
+knowns time stop [taskId] [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--expected-hash` | `string` | — | Expected canonical task hash |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns time`](knowns_time.md) — Time tracking
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_tunnel.md
+++ b/docs/en/cli-reference/knowns_tunnel.md
@@ -1,0 +1,26 @@
+# knowns tunnel
+
+Manage Cloudflare Quick Tunnels for the local server
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## Subcommands
+
+- [`knowns tunnel status`](knowns_tunnel_status.md) — Show the current tunnel URL for a port
+- [`knowns tunnel stop`](knowns_tunnel_stop.md) — Stop the cloudflared tunnel for a port
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_tunnel_status.md
+++ b/docs/en/cli-reference/knowns_tunnel_status.md
@@ -1,0 +1,33 @@
+# knowns tunnel status
+
+Show the current tunnel URL for a port
+
+## Usage
+
+```
+knowns tunnel status [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--port` | `int` | `6420` | Local port the tunnel targets |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns tunnel`](knowns_tunnel.md) — Manage Cloudflare Quick Tunnels for the local server
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_tunnel_stop.md
+++ b/docs/en/cli-reference/knowns_tunnel_stop.md
@@ -1,0 +1,33 @@
+# knowns tunnel stop
+
+Stop the cloudflared tunnel for a port
+
+## Usage
+
+```
+knowns tunnel stop [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--port` | `int` | `6420` | Local port the tunnel targets |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns tunnel`](knowns_tunnel.md) — Manage Cloudflare Quick Tunnels for the local server
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_update.md
+++ b/docs/en/cli-reference/knowns_update.md
@@ -1,0 +1,43 @@
+# knowns update
+
+Update Knowns CLI to the latest version and sync project configs
+
+Update the Knowns CLI binary to the latest version, then sync the current
+project's MCP configurations to use the local binary directly (instead of npx).
+
+This command:
+  1. Detects how Knowns was installed (Homebrew, npm, etc.)
+  2. Runs the appropriate upgrade command
+  3. Syncs MCP configs (.mcp.json, .kiro/settings/mcp.json) to use the local binary
+
+Use --check to only check for updates without installing.
+
+## Usage
+
+```
+knowns update [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--check` | `bool` | — | Only check for updates without installing |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/cli-reference/knowns_validate.md
+++ b/docs/en/cli-reference/knowns_validate.md
@@ -1,0 +1,36 @@
+# knowns validate
+
+Validate tasks, docs, and templates
+
+## Usage
+
+```
+knowns validate [flags]
+```
+
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--entity` | `string` | — | Validate a specific entity (task ID or doc path) |
+| `--fix` | `bool` | — | Auto-fix supported issues |
+| `--scope` | `string` | `all` | Validation scope: all\|tasks\|docs\|templates\|sdd |
+| `--strict` | `bool` | — | Treat warnings as errors |
+
+## Inherited flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--json` | `bool` | — | JSON output |
+| `--no-pager` | `bool` | — | Disable TUI pager (print styled output directly) |
+| `--page` | `int` | `0` | Page number for paginated output (e.g. --page 2) |
+| `--page-size` | `int` | `0` | Lines per page (default 50) |
+| `--plain` | `bool` | — | Plain text output (for AI agents) |
+
+## See also
+
+- [`knowns`](knowns.md) — The memory layer for AI-native software development
+
+---
+
+Generated from the command tree by `make cli-docs`. Do not edit by hand.

--- a/docs/en/guides/memory-system.md
+++ b/docs/en/guides/memory-system.md
@@ -27,7 +27,7 @@ Use docs when the information needs longer narrative explanation or structured s
 ## Commands
 
 ```bash
-knowns memory add "We use repository pattern" --category pattern
+knowns memory create "We use repository pattern" --category pattern
 knowns memory list --plain
 knowns memory <id> --plain
 ```

--- a/docs/en/guides/web-ui.md
+++ b/docs/en/guides/web-ui.md
@@ -18,6 +18,23 @@ Run the command from a Knowns project. Use `--open` when you want Knowns to star
 - **Graph / knowledge views**: explore relationships between tasks, docs, memory, and references.
 - **Configuration pages**: inspect project settings, search setup, code intelligence, and integration state.
 
+## Workspaces and auto-scan
+
+The Web UI can hold several Knowns projects at once. The workspace switcher lists every project Knowns knows about, and the list lives in `~/.knowns/registry.json`.
+
+Projects reach that list two ways:
+
+- running `knowns browser` inside a project registers that project
+- auto-scan, which runs when the Welcome page loads and each time the workspace switcher opens
+
+Auto-scan looks one level deep inside your home directory and the common project folders below it, and registers every subdirectory that contains an initialized `.knowns/`:
+
+`~`, `~/Projects`, `~/Developer`, `~/Documents`, `~/Code`, `~/repos`, `~/workspace`, `~/src`, `~/go/src`, and `~/dev`.
+
+Each of those is checked in both capitalizations, since either can be the real one. There is currently no setting that turns auto-scan off.
+
+Registry entries are stored under the spelling the folder actually has on disk. That matters on Windows and on the default macOS filesystem, where `~/Projects/app` and `~/projects/app` name one directory: both resolve to a single workspace instead of two. Registries written by earlier versions that already contain the same folder twice collapse to one entry the next time they are read. On a case-sensitive filesystem two directories that differ only in capitalization are genuinely different folders, and stay two separate workspaces.
+
 ## When to use it
 
 - when you want a board-oriented task view

--- a/docs/en/reference/commands.md
+++ b/docs/en/reference/commands.md
@@ -212,7 +212,7 @@ Use resolve to traverse structural relationships between docs, tasks, and other 
 ## Memory
 
 ```bash
-knowns memory add "We use repository pattern" --category pattern
+knowns memory create "We use repository pattern" --category pattern
 knowns memory list --plain
 knowns memory <id> --plain
 knowns memory edit <id> --append "More detail"

--- a/docs/vi/guides/memory-system.md
+++ b/docs/vi/guides/memory-system.md
@@ -31,7 +31,7 @@ Nội dung memory thường viết bằng tiếng Anh vì AI đọc trực tiế
 ## Lệnh
 
 ```bash
-knowns memory add "We use repository pattern" --category pattern
+knowns memory create "We use repository pattern" --category pattern
 knowns memory list --plain
 knowns memory <id> --plain
 ```

--- a/docs/vi/reference/commands.md
+++ b/docs/vi/reference/commands.md
@@ -102,7 +102,7 @@ knowns resolve "@doc/specs/auth{depends}" --direction inbound --depth 2 --plain
 ## Memory
 
 ```bash
-knowns memory add "We use repository pattern" --category pattern
+knowns memory create "We use repository pattern" --category pattern
 knowns memory list --plain
 knowns memory <id> --plain
 knowns memory edit <id> --append "More detail"

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -124,7 +124,7 @@ func runAgentsStatus(cmd *cobra.Command, projectRoot string, jsonOut bool) error
 		fmt.Printf("%s of %d instruction files found.\n", StyleBold.Render(fmt.Sprintf("%d", existing)), len(statuses))
 
 		if existing < len(statuses) {
-			fmt.Println(StyleDim.Render("Use 'knowns agents --sync' to generate missing files."))
+			fmt.Println(StyleDim.Render("Use 'knowns sync --instructions' to generate missing files."))
 		}
 	}
 

--- a/internal/cli/command_contract_test.go
+++ b/internal/cli/command_contract_test.go
@@ -43,15 +43,19 @@ func TestCommandContract(t *testing.T) {
 		return
 	}
 
-	want, err := os.ReadFile(contractPath)
+	raw, err := os.ReadFile(contractPath)
 	if err != nil {
 		t.Fatalf("read %s (regenerate with -update-contract): %v", contractPath, err)
 	}
-	if string(want) == got {
+	// git checks the snapshot out with CRLF wherever core.autocrlf is on, which
+	// is the default on the Windows runners. Comparing raw bytes there reports
+	// every line as changed and says nothing about the command surface.
+	want := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	if want == got {
 		return
 	}
 
-	for _, line := range diffLines(strings.Split(string(want), "\n"), strings.Split(got, "\n")) {
+	for _, line := range diffLines(strings.Split(want, "\n"), strings.Split(got, "\n")) {
 		t.Error(line)
 	}
 	t.Fatalf("command surface changed; if intended, regenerate:\n" +

--- a/internal/cli/command_contract_test.go
+++ b/internal/cli/command_contract_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var updateContract = flag.Bool("update-contract", false, "rewrite testdata/command-contract.txt")
+
+const contractPath = "testdata/command-contract.txt"
+
+// TestCommandContract locks the whole command surface, hidden commands included.
+//
+// The generated CLI reference (tools/gendocs) only covers what a human can see,
+// so it says nothing about `__runtime run`, `__lsp-daemon run`, or the legacy
+// `runtime-memory hook`. Those are invoked by other processes — the binary
+// re-execing itself, or hook files written to a user's machine — where a rename
+// or a dropped flag fails at runtime, far from this repo. This snapshot makes
+// any such change a visible diff a reviewer has to approve.
+//
+// Regenerate with: go test ./internal/cli -run TestCommandContract -update-contract
+func TestCommandContract(t *testing.T) {
+	got := renderContract(RootCommand())
+
+	if *updateContract {
+		// The directory is absent on a tree that has never had the snapshot,
+		// which is exactly when someone is regenerating it.
+		if err := os.MkdirAll(filepath.Dir(contractPath), 0o755); err != nil {
+			t.Fatalf("create %s: %v", filepath.Dir(contractPath), err)
+		}
+		if err := os.WriteFile(contractPath, []byte(got), 0o644); err != nil {
+			t.Fatalf("write %s: %v", contractPath, err)
+		}
+		t.Logf("rewrote %s", contractPath)
+		return
+	}
+
+	want, err := os.ReadFile(contractPath)
+	if err != nil {
+		t.Fatalf("read %s (regenerate with -update-contract): %v", contractPath, err)
+	}
+	if string(want) == got {
+		return
+	}
+
+	for _, line := range diffLines(strings.Split(string(want), "\n"), strings.Split(got, "\n")) {
+		t.Error(line)
+	}
+	t.Fatalf("command surface changed; if intended, regenerate:\n" +
+		"  go test ./internal/cli -run TestCommandContract -update-contract\n" +
+		"  make cli-docs")
+}
+
+// renderContract prints one line per command: its path, whether it is hidden and
+// runnable, and its own flags with types.
+func renderContract(root *cobra.Command) string {
+	var lines []string
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		if c.Name() == "help" {
+			return
+		}
+		vis := "visible"
+		if c.Hidden {
+			vis = "hidden"
+		}
+		// Retirement state travels in the snapshot so scheduling a command for
+		// removal, or actually removing it, shows up as a reviewed diff.
+		if st := lifecycleStateOf(c.CommandPath()); st != "" {
+			vis += "/" + st
+		}
+		run := "group"
+		if c.Runnable() {
+			run = "runnable"
+		}
+
+		var flags []string
+		c.NonInheritedFlags().VisitAll(func(f *pflag.Flag) {
+			flags = append(flags, fmt.Sprintf("--%s:%s", f.Name, f.Value.Type()))
+		})
+		sort.Strings(flags)
+
+		line := fmt.Sprintf("%s\t%s\t%s", c.CommandPath(), vis, run)
+		if len(flags) > 0 {
+			line += "\t" + strings.Join(flags, " ")
+		}
+		lines = append(lines, line)
+
+		subs := append([]*cobra.Command(nil), c.Commands()...)
+		sort.Slice(subs, func(i, j int) bool { return subs[i].Name() < subs[j].Name() })
+		for _, sub := range subs {
+			walk(sub)
+		}
+	}
+	walk(root)
+	sort.Strings(lines)
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// diffLines reports added and removed lines, which is all a reviewer needs here.
+func diffLines(want, got []string) []string {
+	inWant := map[string]bool{}
+	for _, l := range want {
+		inWant[l] = true
+	}
+	inGot := map[string]bool{}
+	for _, l := range got {
+		inGot[l] = true
+	}
+
+	var out []string
+	for _, l := range got {
+		if l != "" && !inWant[l] {
+			out = append(out, "+ "+l)
+		}
+	}
+	for _, l := range want {
+		if l != "" && !inGot[l] {
+			out = append(out, "- "+l)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -511,7 +511,7 @@ func runGlobalSettings() error {
 				return err
 			}
 		case "platforms":
-			if err := configurePlatformSettings(&defaults.Settings); err != nil {
+			if err := configurePlatformSettings(&defaults.Settings, true); err != nil {
 				return err
 			}
 		case "search":
@@ -631,7 +631,7 @@ func configureGitTrackingSettings(settings *models.ProjectSettings) error {
 }
 
 func configurePlatforms(store *storage.Store, project *models.Project) error {
-	if err := configurePlatformSettings(&project.Settings); err != nil {
+	if err := configurePlatformSettings(&project.Settings, false); err != nil {
 		return err
 	}
 	if err := store.Config.Save(project); err != nil {
@@ -641,7 +641,7 @@ func configurePlatforms(store *storage.Store, project *models.Project) error {
 	return nil
 }
 
-func configurePlatformSettings(settings *models.ProjectSettings) error {
+func configurePlatformSettings(settings *models.ProjectSettings, global bool) error {
 	selected := settings.Platforms
 	if len(selected) == 0 {
 		selected = []string{"claude-code", "agents"}
@@ -650,12 +650,37 @@ func configurePlatformSettings(settings *models.ProjectSettings) error {
 	for _, id := range wizardPlatformIDs {
 		options = append(options, huh.NewOption(platformLabel(id), id).Selected(sectionSelected(selected, id)))
 	}
+
+	// The empty option matters. Without a way to say "leave this unset", simply
+	// stepping through this form would stamp an explicit scope into the project
+	// and silently override the global default the user just configured.
+	inheritLabel := "Inherit global default"
+	scopeDescription := "Where knowns sync writes built-in skills for this project."
+	if global {
+		inheritLabel = "Not set (projects default to their own directory)"
+		scopeDescription = "Default for every project that has not set its own scope."
+	}
+	scope, err := models.NormalizeSkillsScope(settings.SkillsScope)
+	if err != nil {
+		scope = ""
+	}
+
 	form := huh.NewForm(huh.NewGroup(
 		huh.NewMultiSelect[string]().
 			Title("AI platforms").
 			Description("Select generated instruction and integration targets.").
 			Options(options...).
 			Value(&selected),
+		huh.NewSelect[string]().
+			Title("Skill location").
+			Description(scopeDescription).
+			Options(
+				huh.NewOption(inheritLabel, ""),
+				huh.NewOption("This project (.claude/skills, .agents/skills)", models.SkillsScopeProject),
+				huh.NewOption("Global only (~/.claude/skills, ~/.agents/skills)", models.SkillsScopeGlobal),
+				huh.NewOption("Do not manage skills", models.SkillsScopeNone),
+			).
+			Value(&scope),
 	)).WithTheme(huh.ThemeCatppuccin())
 	if err := form.Run(); err != nil {
 		if err == huh.ErrUserAborted {
@@ -664,6 +689,7 @@ func configurePlatformSettings(settings *models.ProjectSettings) error {
 		return err
 	}
 	settings.Platforms = selected
+	settings.SkillsScope = scope
 	return nil
 }
 

--- a/internal/cli/decision.go
+++ b/internal/cli/decision.go
@@ -8,6 +8,7 @@ import (
 	"github.com/howznguyen/knowns/internal/decisionreview"
 	"github.com/howznguyen/knowns/internal/models"
 	"github.com/howznguyen/knowns/internal/search"
+	"github.com/howznguyen/knowns/internal/storage"
 	"github.com/spf13/cobra"
 )
 
@@ -220,6 +221,9 @@ func runDecisionInbox(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(&b, "CANDIDATE: %s\n", candidate.ID)
 		fmt.Fprintf(&b, "  TITLE: %s\n", candidate.Title)
 		fmt.Fprintf(&b, "  REVIEW_STATE: %s\n", candidate.ReviewState)
+		if storage.DecisionReviewIsStale(candidate) {
+			fmt.Fprintln(&b, "  REVIEW_STALE: the decision changed after this review; re-run it")
+		}
 		for _, blocker := range candidate.ReviewBlockers {
 			fmt.Fprintf(&b, "  BLOCKER: %s\n", blocker)
 		}
@@ -544,6 +548,9 @@ func printDecisionPlain(cmd *cobra.Command, decision *models.DecisionEntry) {
 	}
 	if decision.ReviewState != "" {
 		fmt.Fprintf(&b, "REVIEW_STATE: %s\n", decision.ReviewState)
+	}
+	if storage.DecisionReviewIsStale(decision) {
+		fmt.Fprintln(&b, "REVIEW_STALE: the decision changed after this review; re-run it")
 	}
 	for _, blocker := range decision.ReviewBlockers {
 		fmt.Fprintf(&b, "REVIEW_BLOCKER: %s\n", blocker)

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Retiring a command is a lifecycle, not a delete. This file holds the whole
+// list, so "what is going away, and when" is one file to read rather than a
+// grep across the tree.
+//
+//	active     -> not listed here
+//	deprecated -> still works; scheduled to go
+//	removed    -> a tombstone that refuses with a reason, not "unknown command"
+//
+// The contract snapshot (TestCommandContract) records the state, so moving a
+// command between states is a reviewed diff, and lifecycle_test.go refuses a
+// deprecated command that vanishes without first becoming a tombstone.
+type lifecycleState string
+
+const (
+	stateDeprecated lifecycleState = "deprecated"
+	stateRemoved    lifecycleState = "removed"
+)
+
+// tombstoneAnnotation marks a command that exists only to report its own
+// removal, so tests can tell it apart from the command it replaced.
+const tombstoneAnnotation = "knowns.lifecycle/removed-in"
+
+// isTombstone reports whether cmd is a removal marker rather than a real command.
+func isTombstone(cmd *cobra.Command) bool {
+	_, ok := cmd.Annotations[tombstoneAnnotation]
+	return ok
+}
+
+type lifecycleEntry struct {
+	// Path is the command path below the root, e.g. {"runtime-memory", "hook"}.
+	Path  []string
+	State lifecycleState
+
+	// Since is the version the command entered this state.
+	Since string
+
+	// Replacement is the path users (or scripts) should move to.
+	Replacement string
+
+	// Reason explains why, and shows up in a tombstone's error.
+	Reason string
+
+	// Announce prints a warning when the command runs.
+	//
+	// It MUST stay false for anything a machine invokes. cobra writes the
+	// warning through OutOrStderr, so it lands on stdout the moment something
+	// calls SetOut, and adapters that capture combined output feed it straight
+	// into the agent's context either way. `runtime-memory hook` emits the
+	// memory payload itself, which is exactly the output that must stay clean.
+	Announce bool
+}
+
+func (e lifecycleEntry) path() string { return strings.Join(e.Path, " ") }
+
+// commandLifecycle is the full retirement schedule.
+var commandLifecycle = []lifecycleEntry{
+	{
+		Path:        []string{"runtime-memory"},
+		State:       stateDeprecated,
+		Since:       "0.33.0",
+		Replacement: "knowns runtime memory",
+		Reason:      "grouped under the runtime noun instead of sitting beside it",
+		// Silent on purpose: runtimeinstall baked this path into hook scripts,
+		// the OpenCode plugin, and Kiro hook files already on users' machines.
+		// It cannot be removed until those are all refreshed.
+		Announce: false,
+	},
+}
+
+// applyLifecycle wires the schedule into the command tree. Call it after every
+// command is registered.
+func applyLifecycle(root *cobra.Command) {
+	for _, entry := range commandLifecycle {
+		switch entry.State {
+		case stateDeprecated:
+			cmd := findByPath(root, entry.Path)
+			if cmd == nil {
+				// lifecycle_test.go turns this into a build-time failure; at
+				// runtime there is nothing useful to do.
+				continue
+			}
+			cmd.Hidden = true
+			if entry.Announce {
+				cmd.Deprecated = fmt.Sprintf("use %q instead (since %s)", entry.Replacement, entry.Since)
+			}
+		case stateRemoved:
+			addTombstone(root, entry)
+		}
+	}
+}
+
+// addTombstone registers a command that exists only to explain its own absence.
+// Without it the user gets cobra's "unknown command", which says nothing about
+// what replaced it.
+func addTombstone(root *cobra.Command, entry lifecycleEntry) {
+	parent := root
+	for _, name := range entry.Path[:len(entry.Path)-1] {
+		next := childByName(parent, name)
+		if next == nil {
+			next = &cobra.Command{Use: name, Hidden: true}
+			parent.AddCommand(next)
+		}
+		parent = next
+	}
+
+	leaf := entry.Path[len(entry.Path)-1]
+	if childByName(parent, leaf) != nil {
+		// The command is still registered, so the schedule and the tree
+		// disagree. Shadowing a working command would be worse than doing
+		// nothing; lifecycle_test.go fails on the contradiction instead.
+		return
+	}
+
+	msg := fmt.Sprintf("%q was removed in %s", "knowns "+entry.path(), entry.Since)
+	if entry.Reason != "" {
+		msg += ": " + entry.Reason
+	}
+	if entry.Replacement != "" {
+		msg += fmt.Sprintf("\nUse %q instead.", entry.Replacement)
+	}
+
+	parent.AddCommand(&cobra.Command{
+		Use:                leaf,
+		Hidden:             true,
+		DisableFlagParsing: true, // old call sites still pass their old flags
+		Annotations:        map[string]string{tombstoneAnnotation: entry.Since},
+		RunE: func(*cobra.Command, []string) error {
+			return fmt.Errorf("%s", msg)
+		},
+	})
+}
+
+func findByPath(root *cobra.Command, path []string) *cobra.Command {
+	cur := root
+	for _, name := range path {
+		cur = childByName(cur, name)
+		if cur == nil {
+			return nil
+		}
+	}
+	return cur
+}
+
+func childByName(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// lifecycleStateOf reports the scheduled state of a full command path
+// ("knowns runtime-memory"), or "" when the command is active.
+func lifecycleStateOf(commandPath string) string {
+	trimmed := strings.TrimPrefix(commandPath, "knowns ")
+	for _, entry := range commandLifecycle {
+		if entry.path() == trimmed {
+			return string(entry.State)
+		}
+	}
+	return ""
+}

--- a/internal/cli/lifecycle_test.go
+++ b/internal/cli/lifecycle_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLifecycleEntriesResolve keeps the schedule honest: you cannot deprecate a
+// command that does not exist, and a removed one must answer with a reason
+// rather than cobra's "unknown command".
+func TestLifecycleEntriesResolve(t *testing.T) {
+	root := RootCommand()
+
+	for _, entry := range commandLifecycle {
+		cmd := findByPath(root, entry.Path)
+		if cmd == nil {
+			t.Errorf("%s: listed as %s but no such command; a deprecated command must stay registered, and a removed one needs its tombstone", entry.path(), entry.State)
+			continue
+		}
+
+		switch entry.State {
+		case stateDeprecated:
+			if !cmd.Hidden {
+				t.Errorf("%s: deprecated commands should be hidden from help", entry.path())
+			}
+		case stateRemoved:
+			// Without this the test would call the live command's RunE and
+			// report success for a removal that never happened.
+			if !isTombstone(cmd) {
+				t.Errorf("%s: listed as removed but the real command is still registered; delete it, or drop the lifecycle entry", entry.path())
+				continue
+			}
+			if !cmd.Runnable() {
+				t.Errorf("%s: tombstone must be runnable so it can explain itself", entry.path())
+				continue
+			}
+			err := cmd.RunE(cmd, nil)
+			if err == nil {
+				t.Errorf("%s: tombstone must fail, not succeed silently", entry.path())
+				continue
+			}
+			if entry.Replacement != "" && !strings.Contains(err.Error(), entry.Replacement) {
+				t.Errorf("%s: tombstone error should point at %q, got: %v", entry.path(), entry.Replacement, err)
+			}
+		}
+
+		if entry.Since == "" {
+			t.Errorf("%s: needs the version it entered %s", entry.path(), entry.State)
+		}
+	}
+}
+
+// TestMachineFacingCommandsStaySilent is the rule that cost the most to learn.
+// cobra prints its deprecation notice through OutOrStderr, so it reaches stdout
+// as soon as anything calls SetOut, and adapters capturing combined output feed
+// it into the agent's context regardless. Any command whose output a machine
+// parses must therefore never announce.
+func TestMachineFacingCommandsStaySilent(t *testing.T) {
+	// Paths invoked by installed hook files or by the binary re-execing itself.
+	machineFacing := map[string]bool{
+		"runtime-memory":      true,
+		"runtime-memory hook": true,
+		"runtime memory hook": true,
+		"__runtime":           true,
+		"__runtime run":       true,
+		"__runtime status":    true,
+		"__lsp-daemon":        true,
+		"__lsp-daemon run":    true,
+	}
+
+	for _, entry := range commandLifecycle {
+		if machineFacing[entry.path()] && entry.Announce {
+			t.Errorf("%s is machine-facing; Announce must stay false or the warning corrupts the payload its caller parses", entry.path())
+		}
+	}
+
+	root := RootCommand()
+	for path := range machineFacing {
+		cmd := findByPath(root, strings.Fields(path))
+		if cmd == nil {
+			continue
+		}
+		if cmd.Deprecated != "" {
+			t.Errorf("%s has cobra Deprecated set; that prints into output a machine parses", path)
+		}
+	}
+}
+
+// TestDeprecatedCommandsStillRun guards the whole point of deprecation: the
+// command keeps working until its removal date.
+func TestDeprecatedCommandsStillRun(t *testing.T) {
+	root := RootCommand()
+	for _, entry := range commandLifecycle {
+		if entry.State != stateDeprecated {
+			continue
+		}
+		cmd := findByPath(root, entry.Path)
+		if cmd == nil {
+			continue
+		}
+		if !cmd.Runnable() && len(cmd.Commands()) == 0 {
+			t.Errorf("%s: deprecated command is neither runnable nor a group; it is effectively removed without a tombstone", entry.path())
+		}
+	}
+}

--- a/internal/cli/listview.go
+++ b/internal/cli/listview.go
@@ -196,7 +196,7 @@ func newListViewModel(title string, items []listItem) listViewModel {
 	}
 
 	// Style the title
-	l.Styles.Title = lipgloss.NewStyle().Bold(true).Foreground(colorCyan)
+	l.Styles.Title = StyleTitle
 
 	return listViewModel{
 		list:  l,
@@ -296,7 +296,7 @@ func (m listViewModel) View() tea.View {
 		}
 
 		width := m.viewport.Width()
-		titleStyle := lipgloss.NewStyle().Bold(true).Foreground(colorCyan)
+		titleStyle := StyleTitle
 		header := titleStyle.Render(truncateListLine(title, width))
 		sep := RenderSeparator(width)
 

--- a/internal/cli/machine_contract_test.go
+++ b/internal/cli/machine_contract_test.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/howznguyen/knowns/internal/runtimeinstall"
+	"github.com/spf13/cobra"
+)
+
+// TestInstalledHookArgvResolves is the gate for machine-facing commands, which
+// the generated CLI reference cannot cover because they are hidden.
+//
+// runtimeinstall bakes an argv into hook scripts, an OpenCode plugin, and a Kiro
+// hook file on users' machines. Those files are written by one version and
+// invoked by a later one, so a rename or a dropped flag breaks installations in
+// the field with nothing in this repo failing. This installs every adapter into
+// a temp HOME, recovers the argv actually written, and resolves it against the
+// live command tree.
+func TestInstalledHookArgvResolves(t *testing.T) {
+	home := t.TempDir()
+	// The Kiro adapter resolves its hook path from the working directory
+	// (runtimeinstall.kiroIDEHookPath), not from HomeDir. Without this the test
+	// writes .kiro/hooks/ into the package source tree, and the scanner never
+	// sees that artifact because it walks HomeDir.
+	t.Chdir(home)
+
+	opts := runtimeinstall.Options{
+		HomeDir:        home,
+		ExecutablePath: filepath.Join(home, "bin", "knowns"),
+		// Pretend each adapter's CLI is installed so Install writes its artifacts,
+		// but not knowns itself, so the argv keeps an absolute path like a real
+		// install on a machine without knowns on PATH.
+		LookPath: func(name string) (string, error) {
+			if name == "knowns" {
+				return "", errors.New("knowns not on PATH in tests")
+			}
+			return filepath.Join(home, "bin", name), nil
+		},
+		GOOS: runtime.GOOS,
+	}
+
+	for _, name := range runtimeinstall.RuntimeNames() {
+		if err := runtimeinstall.Install(name, opts); err != nil {
+			t.Fatalf("install %s: %v", name, err)
+		}
+	}
+
+	invocations := scanInvocations(t, home, RootCommand())
+	if len(invocations) == 0 {
+		t.Fatal("no knowns invocations found in installed artifacts; the scanner or the installer changed")
+	}
+
+	sawHook := false
+	for _, inv := range invocations {
+		cmd, _, err := RootCommand().Find(inv.path)
+		if err != nil || cmd == nil || cmd.CommandPath() != "knowns "+strings.Join(inv.path, " ") {
+			t.Errorf("%s: installed artifacts invoke %q, which no longer resolves to a command",
+				inv.source, strings.Join(inv.path, " "))
+			continue
+		}
+		if !cmd.Runnable() {
+			t.Errorf("%s: %q resolves to a group, not a runnable command", inv.source, cmd.CommandPath())
+		}
+		for _, flag := range inv.flags {
+			if cmd.Flags().Lookup(flag) == nil && cmd.InheritedFlags().Lookup(flag) == nil {
+				t.Errorf("%s: %q no longer accepts --%s", inv.source, cmd.CommandPath(), flag)
+			}
+		}
+		if strings.Join(inv.path, " ") == "runtime-memory hook" {
+			sawHook = true
+		}
+	}
+
+	if !sawHook {
+		t.Error("expected installed artifacts to still invoke the legacy `runtime-memory hook` path")
+	}
+}
+
+type invocation struct {
+	source string
+	path   []string
+	flags  []string
+}
+
+// scanInvocations recovers every knowns invocation written under dir. The three
+// artifact kinds spell argv differently — a shell line, a JSON string, and a JS
+// array of quoted tokens — so the text is flattened to bare tokens first and
+// then walked against the command tree, which works for all three.
+func scanInvocations(t *testing.T, dir string, root *cobra.Command) []invocation {
+	t.Helper()
+
+	replacer := strings.NewReplacer(`"`, " ", `'`, " ", ",", " ", "[", " ", "]", " ", "\\", " ")
+
+	var found []invocation
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(dir, path)
+		for _, line := range strings.Split(string(body), "\n") {
+			tokens := strings.Fields(replacer.Replace(line))
+			for i, tok := range tokens {
+				if sub := childNamed(root, tok); sub != nil {
+					if inv, ok := walkInvocation(sub, tokens[i+1:]); ok {
+						inv.source = rel
+						found = append(found, inv)
+					}
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return found
+}
+
+// walkInvocation consumes subcommand tokens then flag tokens, returning the
+// command path and the flags the artifact passes to it.
+func walkInvocation(cmd *cobra.Command, rest []string) (invocation, bool) {
+	inv := invocation{path: []string{cmd.Name()}}
+	cur := cmd
+	i := 0
+	for ; i < len(rest); i++ {
+		sub := childNamed(cur, rest[i])
+		if sub == nil {
+			break
+		}
+		inv.path = append(inv.path, sub.Name())
+		cur = sub
+	}
+	for ; i < len(rest); i++ {
+		if !strings.HasPrefix(rest[i], "--") {
+			continue
+		}
+		name := strings.TrimPrefix(rest[i], "--")
+		if eq := strings.Index(name, "="); eq >= 0 {
+			name = name[:eq]
+		}
+		if name != "" {
+			inv.flags = append(inv.flags, name)
+		}
+	}
+	return inv, len(inv.flags) > 0
+}
+
+func childNamed(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}

--- a/internal/cli/pager.go
+++ b/internal/cli/pager.go
@@ -93,7 +93,7 @@ func (m pagerModel) View() tea.View {
 	width := m.viewport.Width()
 
 	// Header
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(colorCyan)
+	titleStyle := StyleTitle
 	header := titleStyle.Render(m.title)
 	sep := RenderSeparator(width)
 

--- a/internal/cli/plainoutput.go
+++ b/internal/cli/plainoutput.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"os"
+	"sync/atomic"
+
+	"charm.land/lipgloss/v2"
+)
+
+// plainOutput reports whether ANSI styling is suppressed for this invocation.
+var plainOutput atomic.Bool
+
+// PlainOutput reports whether styling is currently suppressed.
+func PlainOutput() bool { return plainOutput.Load() }
+
+// plainStyleTargets are every package-level style that carries color or weight.
+// SetPlainOutput swaps them wholesale, which is what lets one call cover all
+// ~640 render sites without touching them.
+var plainStyleTargets = []*lipgloss.Style{
+	&StyleSuccess, &StyleError, &StyleWarning, &StyleInfo, &StyleDim, &StyleBold,
+	&StyleTitle, &StyleID, &StyleLabel, &StyleKey,
+}
+
+// styledDefaults snapshots the styles as declared, so plain mode is reversible
+// without restating the declarations (which would just reintroduce drift).
+var styledDefaults = func() []lipgloss.Style {
+	out := make([]lipgloss.Style, len(plainStyleTargets))
+	for i, p := range plainStyleTargets {
+		out[i] = *p
+	}
+	return out
+}()
+
+// SetPlainOutput turns ANSI styling off (or back on) for the whole CLI.
+//
+// lipgloss v2 renders full-fidelity ANSI unconditionally and downsamples at the
+// output layer (lipgloss.Writer). This CLI prints through fmt.Print*, which
+// bypasses that layer entirely, so neither --plain nor NO_COLOR could take
+// effect. Style is a plain value type, so clearing the package-level styles is
+// the one choke point that reaches every call site.
+func SetPlainOutput(on bool) {
+	plainOutput.Store(on)
+	blank := lipgloss.NewStyle()
+	for i, p := range plainStyleTargets {
+		if on {
+			*p = blank
+			continue
+		}
+		*p = styledDefaults[i]
+	}
+}
+
+// noColorRequested reports whether the environment asks for uncolored output,
+// per the NO_COLOR convention: set and non-empty, whatever the value.
+func noColorRequested() bool { return os.Getenv("NO_COLOR") != "" }
+
+// init applies NO_COLOR before anything can render. PersistentPreRun is too
+// late for --help, which cobra serves without running it.
+func init() {
+	if noColorRequested() {
+		SetPlainOutput(true)
+	}
+}

--- a/internal/cli/plainoutput_test.go
+++ b/internal/cli/plainoutput_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// hasANSI reports whether s carries any escape sequence.
+func hasANSI(s string) bool { return strings.Contains(s, "\x1b[") }
+
+// TestPlainOutputStripsStyling covers the defect where --plain was accepted on
+// every command but honored on none: lipgloss v2 renders full ANSI and only
+// downsamples at the output layer, which fmt.Print* bypasses.
+func TestPlainOutputStripsStyling(t *testing.T) {
+	t.Cleanup(func() { SetPlainOutput(false) })
+
+	SetPlainOutput(false)
+	styled := RenderSuccess("Created task abc123: Probe")
+	if !hasANSI(styled) {
+		t.Fatalf("default output should be styled, got %q", styled)
+	}
+
+	SetPlainOutput(true)
+	for name, got := range map[string]string{
+		"RenderSuccess":     RenderSuccess("Created task abc123: Probe"),
+		"RenderError":       RenderError("boom"),
+		"RenderWarning":     RenderWarning("careful"),
+		"RenderInfo":        RenderInfo("fyi"),
+		"RenderStatusBadge": RenderStatusBadge("in-progress"),
+		"RenderPriority":    RenderPriorityBadge("high"),
+		"RenderKeyValue":    RenderKeyValue("id", "abc123"),
+	} {
+		if hasANSI(got) {
+			t.Errorf("%s: plain mode must not emit ANSI, got %q", name, got)
+		}
+	}
+
+	if !strings.Contains(RenderSuccess("Created task abc123: Probe"), "Created task abc123: Probe") {
+		t.Error("plain mode dropped the message text")
+	}
+}
+
+// TestPlainOutputIsReversible guards the snapshot restore, so a plain-mode run
+// inside a test cannot leak styling changes into the next one.
+func TestPlainOutputIsReversible(t *testing.T) {
+	t.Cleanup(func() { SetPlainOutput(false) })
+
+	before := RenderSuccess("x")
+	SetPlainOutput(true)
+	if PlainOutput() != true {
+		t.Fatal("PlainOutput() should report true after enabling")
+	}
+	SetPlainOutput(false)
+	if got := RenderSuccess("x"); got != before {
+		t.Errorf("styles not restored: before %q, after %q", before, got)
+	}
+	if PlainOutput() != false {
+		t.Error("PlainOutput() should report false after disabling")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -159,6 +160,7 @@ func shouldSkipCLIWarnings(args []string) bool {
 
 // Execute runs the root command.
 func Execute() error {
+	RootCommand() // apply the lifecycle schedule before dispatch
 	args := os.Args[1:]
 	if shouldSkipCLIWarnings(args) {
 		return rootCmd.Execute()
@@ -216,4 +218,17 @@ func init() {
 	rootCmd.PersistentFlags().Bool("no-pager", false, "Disable TUI pager (print styled output directly)")
 	rootCmd.PersistentFlags().Int("page", 0, "Page number for paginated output (e.g. --page 2)")
 	rootCmd.PersistentFlags().Int("page-size", 0, "Lines per page (default 50)")
+}
+
+var lifecycleOnce sync.Once
+
+// RootCommand exposes the fully assembled command tree for documentation
+// generation. It is the same tree Execute runs, so generated docs cannot
+// describe a command surface the binary does not have.
+//
+// The lifecycle schedule is applied here rather than in an init(), which would
+// depend on the order Go happens to run this package's init functions.
+func RootCommand() *cobra.Command {
+	lifecycleOnce.Do(func() { applyLifecycle(rootCmd) })
+	return rootCmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -53,6 +53,12 @@ var rootCmd = &cobra.Command{
 
 // customHelpFunc renders a clean, styled help output matching the TS CLI style.
 func customHelpFunc(cmd *cobra.Command, args []string) {
+	// Cobra serves help without running PersistentPreRun, so --plain/--json
+	// have to be honored here too.
+	if isPlain(cmd) || isJSON(cmd) {
+		SetPlainOutput(true)
+	}
+
 	// Header
 	fmt.Printf("%s %s\n", StyleBold.Render(cmd.Short), StyleDim.Render("(v"+util.Version+")"))
 	fmt.Println()
@@ -200,6 +206,11 @@ func executeWithUpdateNotice(args []string, run func() error, check func() strin
 
 func init() {
 	rootCmd.SetHelpFunc(customHelpFunc)
+	// --plain and --json are global, so honoring them has to happen once, before
+	// any command renders. NO_COLOR rides along here for the same reason.
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
+		SetPlainOutput(isPlain(cmd) || isJSON(cmd) || noColorRequested())
+	}
 	rootCmd.PersistentFlags().Bool("plain", false, "Plain text output (for AI agents)")
 	rootCmd.PersistentFlags().Bool("json", false, "JSON output")
 	rootCmd.PersistentFlags().Bool("no-pager", false, "Disable TUI pager (print styled output directly)")

--- a/internal/cli/runtime_memory.go
+++ b/internal/cli/runtime_memory.go
@@ -13,15 +13,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var runtimeMemoryCmd = &cobra.Command{
-	Use:   "runtime-memory",
-	Short: "Manage runtime memory hook behavior",
-}
-
-var runtimeMemoryHookCmd = &cobra.Command{
-	Use:   "hook",
-	Short: "Build a runtime memory payload for adapter hooks",
-	RunE:  runRuntimeMemoryHook,
+// newRuntimeMemoryHookCmd builds a fresh hook command. Two identical instances
+// are registered — one under `knowns runtime memory`, one under the original
+// top-level `knowns runtime-memory` — because a cobra.Command can only have one
+// parent, and the old path must keep working: it is baked into every hook
+// script, OpenCode plugin, and Kiro hook file that runtimeinstall has already
+// written to users' machines.
+func newRuntimeMemoryHookCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "hook",
+		Short: "Build a runtime memory payload for adapter hooks",
+		RunE:  runRuntimeMemoryHook,
+	}
+	c.Flags().String("runtime", "", "Runtime adapter name")
+	c.Flags().String("event", "", "Hook event name")
+	c.Flags().String("project", "", "Project root (defaults to detected project)")
+	c.Flags().String("cwd", "", "Working directory for scoring context")
+	c.Flags().String("mode", "", "Override runtime memory mode")
+	c.Flags().String("capture", "", "Override runtime memory capture mode")
+	c.Flags().Int("max-items", 0, "Override maximum number of memory items")
+	c.Flags().Int("max-bytes", 0, "Override maximum serialized bytes")
+	return c
 }
 
 func runRuntimeMemoryHook(cmd *cobra.Command, args []string) error {
@@ -142,14 +154,22 @@ func stringFromMap(payload map[string]any, keys ...string) string {
 }
 
 func init() {
-	runtimeMemoryHookCmd.Flags().String("runtime", "", "Runtime adapter name")
-	runtimeMemoryHookCmd.Flags().String("event", "", "Hook event name")
-	runtimeMemoryHookCmd.Flags().String("project", "", "Project root (defaults to detected project)")
-	runtimeMemoryHookCmd.Flags().String("cwd", "", "Working directory for scoring context")
-	runtimeMemoryHookCmd.Flags().String("mode", "", "Override runtime memory mode")
-	runtimeMemoryHookCmd.Flags().String("capture", "", "Override runtime memory capture mode")
-	runtimeMemoryHookCmd.Flags().Int("max-items", 0, "Override maximum number of memory items")
-	runtimeMemoryHookCmd.Flags().Int("max-bytes", 0, "Override maximum serialized bytes")
-	runtimeMemoryCmd.AddCommand(runtimeMemoryHookCmd)
-	rootCmd.AddCommand(runtimeMemoryCmd)
+	// Discoverable path: `knowns runtime memory hook`, grouped under the noun
+	// it belongs to instead of sitting beside it as a second top-level command.
+	runtimeMemoryCmd := &cobra.Command{
+		Use:   "memory",
+		Short: "Manage runtime memory hook behavior",
+	}
+	runtimeMemoryCmd.AddCommand(newRuntimeMemoryHookCmd())
+	runtimeCmd.AddCommand(runtimeMemoryCmd)
+
+	// Compatibility path: `knowns runtime-memory hook`, kept runnable for hooks
+	// already installed. Its retirement schedule lives in lifecycle.go, which
+	// also hides it from help.
+	legacy := &cobra.Command{
+		Use:   "runtime-memory",
+		Short: "Manage runtime memory hook behavior (use \"knowns runtime memory\")",
+	}
+	legacy.AddCommand(newRuntimeMemoryHookCmd())
+	rootCmd.AddCommand(legacy)
 }

--- a/internal/cli/runtime_memory_compat_test.go
+++ b/internal/cli/runtime_memory_compat_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func find(root *cobra.Command, path ...string) *cobra.Command {
+	cur := root
+	for _, name := range path {
+		var next *cobra.Command
+		for _, c := range cur.Commands() {
+			if c.Name() == name {
+				next = c
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		cur = next
+	}
+	return cur
+}
+
+// TestRuntimeMemoryLegacyPathStillRuns guards the compatibility path. Every hook
+// script, OpenCode plugin, and Kiro hook file that runtimeinstall has written
+// invokes `knowns runtime-memory hook`, and doctor matches that exact string
+// (internal/runtimeinstall/runtimeinstall.go). Removing it silently breaks every
+// installation already in the field.
+func TestRuntimeMemoryLegacyPathStillRuns(t *testing.T) {
+	root := RootCommand()
+
+	legacy := find(root, "runtime-memory", "hook")
+	if legacy == nil {
+		t.Fatal("knowns runtime-memory hook must stay runnable for installed hooks")
+	}
+	if !legacy.Runnable() {
+		t.Error("legacy hook command must be runnable, not just present")
+	}
+	if parent := find(root, "runtime-memory"); parent != nil && !parent.Hidden {
+		t.Error("legacy runtime-memory should be hidden from help")
+	}
+
+	modern := find(root, "runtime", "memory", "hook")
+	if modern == nil {
+		t.Fatal("knowns runtime memory hook should be the discoverable path")
+	}
+
+	// Both paths must accept the same flags, or one of them silently diverges.
+	for _, name := range []string{"runtime", "event", "project", "cwd", "mode", "capture", "max-items", "max-bytes"} {
+		if legacy.Flags().Lookup(name) == nil {
+			t.Errorf("legacy hook missing --%s", name)
+		}
+		if modern.Flags().Lookup(name) == nil {
+			t.Errorf("runtime memory hook missing --%s", name)
+		}
+	}
+}
+
+// TestTopLevelCommandsAreGrouped keeps a second top-level command from
+// reappearing beside the noun it belongs under.
+func TestTopLevelCommandsAreGrouped(t *testing.T) {
+	for _, c := range RootCommand().Commands() {
+		if c.Hidden || !c.IsAvailableCommand() {
+			continue
+		}
+		if strings.Contains(c.Name(), "-") && strings.HasPrefix(c.Name(), "runtime") {
+			t.Errorf("%q should be a subcommand of runtime, not a top-level command", c.Name())
+		}
+	}
+}

--- a/internal/cli/setup_global.go
+++ b/internal/cli/setup_global.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/howznguyen/knowns/internal/models"
+	"github.com/howznguyen/knowns/internal/storage"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -63,7 +65,36 @@ func runGlobalSetup(cmd *cobra.Command, args []string, force bool) error {
 	}
 	fmt.Println()
 	fmt.Println(successStyle.Render("Global AI integration setup complete"))
+	recordGlobalSkillsScope()
 	return nil
+}
+
+// recordGlobalSkillsScope persists the choice this command just made, so a
+// later `knowns sync` does not undo it. Without this, global setup writes
+// skills to the home directory and nothing records it, so sync keeps
+// materializing a competing project copy that shadows the global one.
+//
+// It writes the global default in ~/.knowns/settings.json rather than one
+// project's config, because `--global` is a machine-wide action: every project
+// that has not set its own scope then honours it, including projects that
+// already exist. Best-effort, and never fails the command.
+func recordGlobalSkillsScope() {
+	store := storage.NewEmbeddingSettingsStore()
+	settings, err := store.Load()
+	if err != nil || settings == nil {
+		return
+	}
+	if settings.ProjectDefaults == nil {
+		settings.ProjectDefaults = &storage.ProjectDefaults{}
+	}
+	if settings.ProjectDefaults.Settings.SkillsScope == models.SkillsScopeGlobal {
+		return
+	}
+	settings.ProjectDefaults.Settings.SkillsScope = models.SkillsScopeGlobal
+	if err := store.Save(settings); err != nil {
+		return
+	}
+	fmt.Println(StyleDim.Render("Recorded global default skillsScope = \"global\"; knowns sync will no longer create project skill directories."))
 }
 
 func buildGlobalSetupSteps(force bool, platforms []string) []initStep {

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -105,6 +105,9 @@ var (
 
 // StatusStyle returns the appropriate style for a given status.
 func StatusStyle(status string) lipgloss.Style {
+	if plainOutput.Load() {
+		return lipgloss.NewStyle()
+	}
 	switch status {
 	case "done":
 		return lipgloss.NewStyle().Foreground(colorGreen)
@@ -125,6 +128,9 @@ func StatusStyle(status string) lipgloss.Style {
 
 // PriorityStyle returns the appropriate style for a given priority.
 func PriorityStyle(priority string) lipgloss.Style {
+	if plainOutput.Load() {
+		return lipgloss.NewStyle()
+	}
 	switch priority {
 	case "high":
 		return lipgloss.NewStyle().Foreground(colorRed)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -72,7 +72,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 
 	// 1. Skills
 	if syncSkills {
-		if err := runSyncSkillsForPlatforms(projectRoot, force, selectedPlatforms); err != nil {
+		if err := runSyncSkillsForScope(projectRoot, force, selectedPlatforms, resolveSkillsScope(cfg.Settings)); err != nil {
 			return fmt.Errorf("sync skills: %w", err)
 		}
 		fmt.Println()
@@ -311,6 +311,62 @@ func runSyncModelAPI(ss *models.SemanticSearchSettings) error {
 	fmt.Printf("%s Semantic search ready (api: %s, model: %s, %dd)\n",
 		StyleSuccess.Render("✓"), model.Provider, model.Model, model.Dimensions)
 	return nil
+}
+
+// resolveSkillsScope answers where sync should materialize skills. The project
+// setting wins; an unset project setting falls back to the global default in
+// ~/.knowns/settings.json; an unset global default means "project", which is
+// what every project did before the setting existed.
+//
+// The global fallback is the point: a user who keeps skills in ~/.claude/skills
+// sets the preference once instead of editing every repository they own, and
+// projects that predate the setting pick it up without being touched.
+func resolveSkillsScope(settings models.ProjectSettings) string {
+	if scope, err := models.NormalizeSkillsScope(settings.SkillsScope); err == nil && scope != "" {
+		return scope
+	}
+	defaults, err := loadGlobalProjectDefaults()
+	if err != nil || defaults == nil {
+		return models.SkillsScopeProject
+	}
+	if scope, err := models.NormalizeSkillsScope(defaults.Settings.SkillsScope); err == nil && scope != "" {
+		return scope
+	}
+	return models.SkillsScopeProject
+}
+
+// runSyncSkillsForScope routes skill materialization by the project's
+// settings.skillsScope. Before this existed, sync always created the project
+// skill directories, which silently shadowed a user's global install: a
+// project copy wins over ~/.claude/skills, and sync always overwrites, so
+// deleting the project copy never stuck.
+func runSyncSkillsForScope(projectRoot string, force bool, platforms []string, scope string) error {
+	switch scope {
+	case models.SkillsScopeNone:
+		fmt.Println(RenderInfo("Skills scope is \"none\": leaving skill directories untouched."))
+		return nil
+	case models.SkillsScopeGlobal:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("resolve home directory: %w", err)
+		}
+		count, err := codegen.BuiltInSkillCount()
+		if err != nil {
+			return fmt.Errorf("count built-in skills: %w", err)
+		}
+		if count == 0 {
+			fmt.Println(StyleDim.Render("No embedded built-in skills found. Skipping skill sync."))
+			return nil
+		}
+		fmt.Printf("%s\n", RenderInfo(fmt.Sprintf("Syncing %s skill(s) to global directories...", StyleBold.Render(fmt.Sprintf("%d", count)))))
+		if err := syncGlobalSkills(home, platforms); err != nil {
+			return err
+		}
+		fmt.Println(RenderSuccess(fmt.Sprintf("Synced %d skill(s) globally. Project skill directories were left untouched.", count)))
+		return nil
+	default:
+		return runSyncSkillsForPlatforms(projectRoot, force, platforms)
+	}
 }
 
 // runSyncSkillsForPlatforms copies embedded built-in skills to the platform dirs

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -313,26 +313,11 @@ func runSyncModelAPI(ss *models.SemanticSearchSettings) error {
 	return nil
 }
 
-// resolveSkillsScope answers where sync should materialize skills. The project
-// setting wins; an unset project setting falls back to the global default in
-// ~/.knowns/settings.json; an unset global default means "project", which is
-// what every project did before the setting existed.
-//
-// The global fallback is the point: a user who keeps skills in ~/.claude/skills
-// sets the preference once instead of editing every repository they own, and
-// projects that predate the setting pick it up without being touched.
+// resolveSkillsScope answers where sync should materialize skills, using the
+// shared chain so `knowns doctor` and `knowns sync` can never disagree about
+// which directories a project is supposed to have.
 func resolveSkillsScope(settings models.ProjectSettings) string {
-	if scope, err := models.NormalizeSkillsScope(settings.SkillsScope); err == nil && scope != "" {
-		return scope
-	}
-	defaults, err := loadGlobalProjectDefaults()
-	if err != nil || defaults == nil {
-		return models.SkillsScopeProject
-	}
-	if scope, err := models.NormalizeSkillsScope(defaults.Settings.SkillsScope); err == nil && scope != "" {
-		return scope
-	}
-	return models.SkillsScopeProject
+	return models.ResolveSkillsScope(settings.SkillsScope, storage.GlobalSkillsScopeDefault())
 }
 
 // runSyncSkillsForScope routes skill materialization by the project's

--- a/internal/cli/sync_skills_scope_test.go
+++ b/internal/cli/sync_skills_scope_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/howznguyen/knowns/internal/models"
+	"github.com/howznguyen/knowns/internal/storage"
+)
+
+// projectSkillDirsExist reports whether sync materialized skills into the
+// project. The bug this guards: sync always created these directories, so a
+// user who installed skills globally got a competing project copy that
+// shadowed the global one and came back on every sync.
+func projectSkillDirsExist(t *testing.T, root string) bool {
+	t.Helper()
+	for _, dir := range []string{".claude", ".agents", ".kiro"} {
+		if _, err := os.Stat(filepath.Join(root, dir, "skills")); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSyncSkillsScopeNoneLeavesProjectUntouched(t *testing.T) {
+	root := t.TempDir()
+	if err := runSyncSkillsForScope(root, true, []string{"claude-code"}, models.SkillsScopeNone); err != nil {
+		t.Fatalf("runSyncSkillsForScope: %v", err)
+	}
+	if projectSkillDirsExist(t, root) {
+		t.Fatal("scope \"none\" created project skill directories")
+	}
+}
+
+func TestSyncSkillsScopeGlobalLeavesProjectUntouched(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	if err := runSyncSkillsForScope(root, true, []string{"claude-code"}, models.SkillsScopeGlobal); err != nil {
+		t.Fatalf("runSyncSkillsForScope: %v", err)
+	}
+	if projectSkillDirsExist(t, root) {
+		t.Fatal("scope \"global\" created project skill directories, shadowing the global install")
+	}
+	home, _ := os.UserHomeDir()
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills")); err != nil {
+		t.Fatalf("scope \"global\" did not write skills to the home directory: %v", err)
+	}
+}
+
+func TestSyncSkillsScopeProjectStillMaterializes(t *testing.T) {
+	root := t.TempDir()
+	if err := runSyncSkillsForScope(root, true, []string{"claude-code"}, models.SkillsScopeProject); err != nil {
+		t.Fatalf("runSyncSkillsForScope: %v", err)
+	}
+	if !projectSkillDirsExist(t, root) {
+		t.Fatal("scope \"project\" must keep materializing skills, so a fresh clone still works")
+	}
+}
+
+func TestUnsetSkillsScopeResolvesToProject(t *testing.T) {
+	var settings models.ProjectSettings
+	if got := settings.SkillsScopeOrDefault(); got != models.SkillsScopeProject {
+		t.Fatalf("unset scope = %q, want %q so existing projects are unaffected", got, models.SkillsScopeProject)
+	}
+	settings.SkillsScope = "GLOBAL "
+	if got := settings.SkillsScopeOrDefault(); got != models.SkillsScopeGlobal {
+		t.Fatalf("scope %q resolved to %q", settings.SkillsScope, got)
+	}
+	settings.SkillsScope = "nonsense"
+	if err := settings.Normalize(); err == nil {
+		t.Fatal("Normalize accepted an unknown skills scope")
+	}
+}
+
+func TestGlobalDefaultAppliesToProjectsThatNeverSetTheScope(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".knowns"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	store := storage.NewEmbeddingSettingsStore()
+	settings, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.ProjectDefaults == nil {
+		settings.ProjectDefaults = &storage.ProjectDefaults{}
+	}
+	settings.ProjectDefaults.Settings.SkillsScope = models.SkillsScopeGlobal
+	if err := store.Save(settings); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// A project that never set the scope must inherit the global default,
+	// which is what makes existing repositories pick the fix up untouched.
+	if got := resolveSkillsScope(models.ProjectSettings{}); got != models.SkillsScopeGlobal {
+		t.Fatalf("unset project scope = %q, want the global default %q", got, models.SkillsScopeGlobal)
+	}
+
+	// An explicit project setting still wins over the global default.
+	explicit := models.ProjectSettings{SkillsScope: models.SkillsScopeProject}
+	if got := resolveSkillsScope(explicit); got != models.SkillsScopeProject {
+		t.Fatalf("explicit project scope = %q, want %q", got, models.SkillsScopeProject)
+	}
+}
+
+func TestNoGlobalDefaultStillMeansProject(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if got := resolveSkillsScope(models.ProjectSettings{}); got != models.SkillsScopeProject {
+		t.Fatalf("with no global default, scope = %q, want %q", got, models.SkillsScopeProject)
+	}
+}
+
+// TestEmptyScopeStaysEmpty guards the TUI trap: the settings form offers an
+// "inherit" option that maps to the empty string, and an empty string must
+// survive Normalize so stepping through the form never stamps an explicit
+// scope over the global default the user just set.
+func TestEmptyScopeStaysEmpty(t *testing.T) {
+	settings := models.ProjectSettings{SkillsScope: ""}
+	if err := settings.Normalize(); err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if settings.SkillsScope != "" {
+		t.Fatalf("empty scope became %q; an unset scope must stay unset", settings.SkillsScope)
+	}
+	scope, err := models.NormalizeSkillsScope("")
+	if err != nil || scope != "" {
+		t.Fatalf("NormalizeSkillsScope(\"\") = %q, %v; want \"\", nil", scope, err)
+	}
+}

--- a/internal/cli/sync_skills_scope_test.go
+++ b/internal/cli/sync_skills_scope_test.go
@@ -75,7 +75,7 @@ func TestUnsetSkillsScopeResolvesToProject(t *testing.T) {
 
 func TestGlobalDefaultAppliesToProjectsThatNeverSetTheScope(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	if err := os.MkdirAll(filepath.Join(home, ".knowns"), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestGlobalDefaultAppliesToProjectsThatNeverSetTheScope(t *testing.T) {
 }
 
 func TestNoGlobalDefaultStillMeansProject(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	if got := resolveSkillsScope(models.ProjectSettings{}); got != models.SkillsScopeProject {
 		t.Fatalf("with no global default, scope = %q, want %q", got, models.SkillsScopeProject)
 	}
@@ -128,4 +128,14 @@ func TestEmptyScopeStaysEmpty(t *testing.T) {
 	if err != nil || scope != "" {
 		t.Fatalf("NormalizeSkillsScope(\"\") = %q, %v; want \"\", nil", scope, err)
 	}
+}
+
+// setHome points the global settings store at dir. os.UserHomeDir reads
+// USERPROFILE on Windows and HOME elsewhere, so a test that sets only HOME
+// writes into the real home directory of whoever runs it — which is how one of
+// these tests came to read back a global default a sibling test had saved.
+func setHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 }

--- a/internal/cli/task_lifecycle_matrix_test.go
+++ b/internal/cli/task_lifecycle_matrix_test.go
@@ -432,7 +432,24 @@ func matrixMCPRunner(t *testing.T, store *storage.Store) func(tasklifecycle.Requ
 		if request.Operation == tasklifecycle.OperationReopen {
 			action = "unarchive"
 		}
-		args := map[string]any{"action": action, "taskId": request.TaskID, "ids": request.IDs, "execute": request.Execute, "confirmed": request.Confirmed, "reason": request.Reason}
+		// Send only what the action accepts. A uniform envelope used to be
+		// harmless because unrecognized arguments were dropped in silence,
+		// which is exactly how acceptance criteria passed to create were lost.
+		// The tool now rejects them, so this matrix must address each action
+		// with its own parameters.
+		args := map[string]any{"action": action}
+		switch action {
+		case "batch_archive", "batch_unarchive":
+			args["ids"] = request.IDs
+			args["execute"] = request.Execute
+		case "hard_delete":
+			args["taskId"] = request.TaskID
+			args["confirmed"] = request.Confirmed
+			args["reason"] = request.Reason
+		default:
+			args["taskId"] = request.TaskID
+			args["execute"] = request.Execute
+		}
 		message, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": map[string]any{"name": "tasks", "arguments": args}})
 		result := server.HandleMessage(t.Context(), message)
 		data, _ := json.Marshal(result)

--- a/internal/cli/task_prefix_test.go
+++ b/internal/cli/task_prefix_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/howznguyen/knowns/internal/models"
 	"github.com/howznguyen/knowns/internal/storage"
 	"github.com/spf13/cobra"
 )
@@ -106,7 +107,9 @@ func TestRunTaskCreateUsesDefaultAndCustomPrefixes(t *testing.T) {
 	}
 }
 
-func TestRunTaskCreateFallsBackToLegacyIDsWithoutPrefix(t *testing.T) {
+// Renamed from a test that asserted bare six-character IDs. Generation now
+// always adds a prefix; IDs written before this keep resolving unchanged.
+func TestRunTaskCreateDerivesAPrefixWithoutConfiguration(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	projectDir := t.TempDir()
 	store := storage.NewStore(filepath.Join(projectDir, ".knowns"))
@@ -133,7 +136,8 @@ func TestRunTaskCreateFallsBackToLegacyIDsWithoutPrefix(t *testing.T) {
 	if len(tasks) != 1 {
 		t.Fatalf("created %d tasks, want 1", len(tasks))
 	}
-	if id := tasks[0].ID; len(id) != 6 || strings.Contains(id, "-") {
-		t.Fatalf("task ID = %q, want legacy six-character base36 format", id)
+	want := models.DeriveTaskIDPrefix("task-legacy-cli")
+	if id := tasks[0].ID; !strings.HasPrefix(id, want+"-") {
+		t.Fatalf("task ID = %q, want the %q prefix derived from the project name", id, want)
 	}
 }

--- a/internal/cli/testdata/command-contract.txt
+++ b/internal/cli/testdata/command-contract.txt
@@ -1,0 +1,131 @@
+knowns	visible	runnable	--json:bool --no-pager:bool --page-size:int --page:int --plain:bool
+knowns __lsp-daemon	hidden	group
+knowns __lsp-daemon run	hidden	runnable	--project:string
+knowns __runtime	hidden	group
+knowns __runtime run	hidden	runnable
+knowns __runtime status	hidden	runnable
+knowns agents	visible	runnable
+knowns audit	visible	group
+knowns audit recent	visible	runnable	--limit:int --project:string --result:string --tool:string
+knowns audit stats	visible	runnable	--project:string --tool:string
+knowns board	visible	runnable
+knowns browser	visible	runnable	--allow-task-hard-delete:bool --dev:bool --no-open:bool --open:bool --password:string --port:int --project:string --restart:bool --scan:string --tunnel:bool --watch:bool
+knowns code	visible	group
+knowns code deps	visible	runnable	--limit:int --type:string
+knowns code search	visible	runnable	--limit:int --path:string
+knowns code symbols	visible	runnable	--kind:string --limit:int --path:string
+knowns config	visible	group
+knowns config get	visible	runnable
+knowns config list	visible	runnable
+knowns config reset	visible	runnable	--yes:bool
+knowns config set	visible	runnable
+knowns decision	visible	runnable
+knowns decision accept	visible	runnable	--supersede:stringArray
+knowns decision create	visible	runnable	--alternatives:string --body:string --consequences:string --context:string --decision:string --doc:stringArray --source:stringArray --status:string --tag:stringArray --task:stringArray
+knowns decision get	visible	runnable
+knowns decision inbox	visible	runnable
+knowns decision link	visible	runnable	--doc:stringArray --source:stringArray --task:stringArray
+knowns decision list	visible	runnable	--all-statuses:bool --status:string --tag:string
+knowns decision migrate	visible	group
+knowns decision migrate apply	visible	runnable	--accept-verified:bool --category:string --decision-id:string --doc:stringArray --memory:string --reason:string --resolution:string --target-memory:string --task:stringArray
+knowns decision migrate preview	visible	runnable
+knowns decision migrate rollback	visible	runnable
+knowns decision resolve	visible	runnable	--replacement-id:string --target:string
+knowns decision supersede	visible	runnable
+knowns doc	visible	runnable	--info:bool --line:string --section:string --smart:bool --toc:bool
+knowns doc create	visible	runnable	--content:string --description:string --folder:string --tag:stringArray
+knowns doc delete	visible	runnable	--dry-run:bool --expected-hash:string --force:bool
+knowns doc edit	visible	runnable	--append:string --content:string --description:string --expected-hash:string --path:string --section:string --tags:string --title:string
+knowns doc hard-delete	visible	runnable	--allow-hard-delete:bool --expected-hash:string --reason:string --yes:bool
+knowns doc history	visible	runnable	--limit:int --metadata:bool --offset:int --revision:string
+knowns doc list	visible	runnable	--tag:string
+knowns doc view	visible	runnable	--info:bool --line:string --section:string --smart:bool --toc:bool
+knowns doctor	visible	runnable	--scope:stringSlice --strict:bool --verbose:bool
+knowns eval	visible	group
+knowns eval retrieval	visible	runnable	--baseline:string --cases:string --mode:string --output:string --reason:string --runtime-id:string --update-baseline:bool
+knowns import	visible	group
+knowns import add	visible	runnable
+knowns import list	visible	runnable
+knowns import remove	visible	runnable
+knowns import status	visible	runnable
+knowns import sync	visible	runnable
+knowns init	visible	runnable	--force:bool --git-ignored:bool --git-tracked:bool --no-open:bool --no-wizard:bool --open:bool --task-prefix:string --wizard:bool
+knowns lsp	visible	group
+knowns lsp cleanup	visible	runnable
+knowns lsp install	visible	runnable	--latest:bool --version:string --yes:bool
+knowns lsp list	visible	runnable
+knowns mcp	visible	runnable	--project:string --stdio:bool
+knowns memory	visible	runnable
+knowns memory cleanup	visible	runnable	--layer:string --limit:int --older-than:int
+knowns memory create	visible	runnable	--category:string --content:string --create-anyway:bool --layer:string --status:string --tag:stringArray
+knowns memory delete	visible	runnable	--dry-run:bool --force:bool
+knowns memory demote	visible	runnable
+knowns memory edit	visible	runnable	--append:string --category:string --content:string --tag:stringArray --title:string
+knowns memory list	visible	runnable	--all-statuses:bool --category:string --layer:string --status:string --tag:string
+knowns memory promote	visible	runnable
+knowns memory view	visible	runnable
+knowns migrate	visible	runnable	--write:bool
+knowns provider	visible	group
+knowns provider add	visible	runnable	--api-base:string --api-key:string --id:string --name:string
+knowns provider list	visible	runnable
+knowns provider remove	visible	runnable
+knowns provider test	visible	runnable
+knowns qdrant	visible	group
+knowns qdrant cleanup	visible	runnable
+knowns qdrant install	visible	runnable
+knowns qdrant logs	visible	runnable	--tail:int
+knowns qdrant purge	visible	runnable
+knowns qdrant start	visible	runnable
+knowns qdrant status	visible	runnable
+knowns qdrant stop	visible	runnable
+knowns reconcile	visible	runnable	--execute:bool --wait:bool
+knowns resolve	visible	runnable	--depth:int --direction:string --relation:string --type:string
+knowns retrieve	visible	runnable	--assignee:string --expand-references:bool --include-historical:bool --keyword:bool --label:string --limit:int --priority:string --source-types:string --status:string --tag:string
+knowns runtime	visible	group
+knowns runtime install	visible	runnable
+knowns runtime logs	visible	runnable	--follow:bool --source:string --tail:int
+knowns runtime memory	visible	group
+knowns runtime memory hook	visible	runnable	--capture:string --cwd:string --event:string --max-bytes:int --max-items:int --mode:string --project:string --runtime:string
+knowns runtime ps	visible	runnable	--all:bool --clients:int --failed:bool --failures:int --interval:duration --jobs:bool --tail:int --watch:bool
+knowns runtime reload	visible	runnable	--timeout:duration --wait:bool
+knowns runtime status	visible	runnable
+knowns runtime stop	visible	runnable
+knowns runtime uninstall	visible	runnable
+knowns runtime-memory	hidden/deprecated	group
+knowns runtime-memory hook	visible	runnable	--capture:string --cwd:string --event:string --max-bytes:int --max-items:int --mode:string --project:string --runtime:string
+knowns search	visible	runnable	--assignee:string --include-historical:bool --keyword:bool --label:string --limit:int --priority:string --reindex:bool --setup:bool --status-check:bool --status:string --tag:string --type:string
+knowns search index	visible	runnable	--wait:bool
+knowns settings	visible	runnable	--global:bool
+knowns setup	visible	runnable	--force:bool --global:bool
+knowns status	visible	runnable
+knowns sync	visible	runnable	--force:bool --instructions:bool --model:bool --platform:string --skills:bool
+knowns task	visible	runnable
+knowns task archive	visible	runnable	--expected-hash:string --yes:bool
+knowns task batch-archive	visible	runnable	--yes:bool
+knowns task batch-unarchive	visible	runnable	--yes:bool
+knowns task create	visible	runnable	--ac:stringArray --assignee:string --description:string --fulfills:stringArray --label:stringArray --notes:string --parent:string --plan:string --prefix:string --priority:string --spec:string --status:string
+knowns task edit	visible	runnable	--ac:stringArray --append-notes:string --assignee:string --check-ac:intSlice --description:string --expected-hash:string --fulfills:stringArray --labels:string --notes:string --order:int --parent:string --plan:string --priority:string --remove-ac:intSlice --spec:string --status:string --title:string --uncheck-ac:intSlice
+knowns task hard-delete	visible	runnable	--allow-hard-delete:bool --reason:string --yes:bool
+knowns task history	visible	runnable	--limit:int --metadata:bool --offset:int --revision:string
+knowns task list	visible	runnable	--assignee:string --include-historical:bool --label:string --priority:string --status:string --tree:bool
+knowns task unarchive	visible	runnable	--expected-hash:string --yes:bool
+knowns task view	visible	runnable
+knowns template	visible	runnable
+knowns template create	visible	runnable	--description:string --doc:string
+knowns template list	visible	runnable	--imported:bool --local:bool
+knowns template run	visible	runnable	--dry-run:bool --var:stringArray
+knowns template view	visible	runnable
+knowns time	visible	group
+knowns time add	visible	runnable	--date:string --expected-hash:string --note:string
+knowns time log	visible	runnable
+knowns time pause	visible	runnable
+knowns time report	visible	runnable	--by-label:bool --by-status:bool --csv:bool --from:string --to:string
+knowns time resume	visible	runnable
+knowns time start	visible	runnable
+knowns time status	visible	runnable
+knowns time stop	visible	runnable	--expected-hash:string
+knowns tunnel	visible	group
+knowns tunnel status	visible	runnable	--port:int
+knowns tunnel stop	visible	runnable	--port:int
+knowns update	visible	runnable	--check:bool
+knowns validate	visible	runnable	--entity:string --fix:bool --scope:string --strict:bool

--- a/internal/decisionreview/review.go
+++ b/internal/decisionreview/review.go
@@ -92,6 +92,8 @@ type Match struct {
 	MatchedBy []string `json:"matchedBy,omitempty"`
 	Snippet   string   `json:"snippet,omitempty"`
 	Tags      []string `json:"tags,omitempty"`
+	// Hash pins the matched decision's content as the reviewer saw it.
+	Hash string `json:"hash,omitempty"`
 }
 
 func New(store *storage.Store) *Service {
@@ -299,6 +301,10 @@ func (s *Service) applyReviewMetadata(entry *models.DecisionEntry, matches []Mat
 	}
 	evaluatedAt := s.now().UTC()
 	entry.ReviewEvaluatedAt = &evaluatedAt
+	// Record which state was judged, not only when. The hash is taken after
+	// the review fields are set and deliberately excludes them, so writing the
+	// review cannot invalidate its own watermark.
+	entry.ReviewEvaluatedHash = storage.CanonicalDecisionHash(entry)
 }
 
 func candidateRepairGuidance(message string) string {
@@ -318,6 +324,7 @@ func persistedMatches(matches []Match) []models.DecisionReviewMatch {
 			Title:     match.Title,
 			Status:    match.Status,
 			Score:     match.Score,
+			Hash:      match.Hash,
 			Kind:      match.Kind,
 			MatchedBy: append([]string(nil), match.MatchedBy...),
 			Snippet:   strings.Join(strings.Fields(match.Snippet), " "),
@@ -956,6 +963,7 @@ func matchFromEntry(entry *models.DecisionEntry, score float64, kind string, mat
 		MatchedBy: matchedBy,
 		Snippet:   truncate(strings.TrimSpace(snippet), 220),
 		Tags:      append([]string(nil), entry.Tags...),
+		Hash:      storage.CanonicalDecisionHash(entry),
 	}
 }
 

--- a/internal/doctor/ai_checks.go
+++ b/internal/doctor/ai_checks.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"context"
 	"fmt"
+	"github.com/howznguyen/knowns/internal/models"
 	"os"
 	"path/filepath"
 	"sort"
@@ -327,9 +328,31 @@ func aiSkillsChecker(state *localState) Checker {
 			}
 			projectRoot := filepath.Dir(state.store.Root)
 			platforms := normalizedStrings(project.Settings.Platforms)
-			expected := skillDirsForPlatforms(platforms)
-			if len(platforms) == 0 {
-				expected = existingPaths(projectRoot, []string{
+			scope := models.ResolveSkillsScope(project.Settings.SkillsScope, state.deps.globalScope())
+
+			// A project whose scope is not "project" is not supposed to hold
+			// skill directories, so their absence is the configured state and
+			// never a fault. Reporting it as missing would produce a warning
+			// that `knowns sync --skills` can never clear.
+			var expected []string
+			if scope == models.SkillsScopeProject {
+				expected = skillDirsForPlatforms(platforms)
+				if len(platforms) == 0 {
+					expected = existingPaths(projectRoot, []string{
+						filepath.Join(".claude", "skills"),
+						filepath.Join(".agents", "skills"),
+						filepath.Join(".kiro", "skills"),
+					}, state.deps.exists)
+				}
+			}
+
+			// The state that motivated this check: skills live globally, yet a
+			// project copy is also present. The project copy wins at runtime,
+			// so the global install the user configured is silently overridden
+			// and neither directory looks wrong on its own.
+			shadowing := make([]string, 0)
+			if scope != models.SkillsScopeProject {
+				shadowing = existingPaths(projectRoot, []string{
 					filepath.Join(".claude", "skills"),
 					filepath.Join(".agents", "skills"),
 					filepath.Join(".kiro", "skills"),
@@ -341,7 +364,7 @@ func aiSkillsChecker(state *localState) Checker {
 			// They are checked even when this project syncs no skills of its own.
 			globalStale := homeRelativePaths(state.deps.globalSkills())
 
-			if len(expected) == 0 && len(globalStale) == 0 {
+			if len(expected) == 0 && len(globalStale) == 0 && len(shadowing) == 0 {
 				return subsystemDisabled("No configured AI platform requires synchronized skills", "not_applicable"), nil
 			}
 
@@ -365,6 +388,19 @@ func aiSkillsChecker(state *localState) Checker {
 			}
 			if len(globalStale) > 0 {
 				evidence["globalStalePaths"] = globalStale
+			}
+			evidence["skillsScope"] = scope
+			if len(shadowing) > 0 {
+				evidence["shadowingPaths"] = slashPaths(shadowing)
+				return CheckResult{
+					Status:  StatusWarn,
+					Summary: fmt.Sprintf("Project skill directories shadow the %s install", scope),
+					Remediation: &Remediation{
+						Description: fmt.Sprintf("settings.skillsScope is %q, but this project still holds skill directories. A project copy takes precedence over the global one, so the configured install is overridden.", scope),
+						Command:     "rm -rf " + strings.Join(slashPaths(shadowing), " "),
+					},
+					Evidence: evidence,
+				}, nil
 			}
 
 			projectNeedsSync := len(missing) > 0 || outOfSync

--- a/internal/doctor/local.go
+++ b/internal/doctor/local.go
@@ -28,6 +28,7 @@ type localDependencies struct {
 	runtimeHooks    func() ([]runtimeinstall.Status, error)
 	skillsOutOfSync func(string) bool
 	globalSkills    func() []string
+	globalScope     func() string
 	exists          func(string) bool
 	lookPath        func(string) (string, error)
 	readFile        func(string) ([]byte, error)
@@ -59,6 +60,7 @@ func defaultLocalDependencies() localDependencies {
 		},
 		skillsOutOfSync: codegen.SkillsOutOfSync,
 		globalSkills:    codegen.GlobalStaleSkillDirs,
+		globalScope:     storage.GlobalSkillsScopeDefault,
 		exists: func(path string) bool {
 			_, err := os.Stat(path)
 			return err == nil
@@ -141,6 +143,9 @@ func newLocalState(store *storage.Store, deps localDependencies) *localState {
 	}
 	if deps.globalSkills == nil {
 		deps.globalSkills = defaults.globalSkills
+	}
+	if deps.globalScope == nil {
+		deps.globalScope = defaults.globalScope
 	}
 	if deps.exists == nil {
 		deps.exists = defaults.exists

--- a/internal/doctor/local_test.go
+++ b/internal/doctor/local_test.go
@@ -826,3 +826,81 @@ func sameSnapshot(left, right map[string]string) bool {
 	}
 	return true
 }
+
+// TestAISkillsCheckStaysSilentWhenScopeIsGlobal guards against a warning no
+// remediation can clear. With settings.skillsScope "global" the project is not
+// supposed to hold skill directories, so their absence is the configured state.
+// Reporting it as missing would tell the user to run `knowns sync --skills`,
+// which deliberately creates nothing, leaving the warning permanently on.
+func TestAISkillsCheckStaysSilentWhenScopeIsGlobal(t *testing.T) {
+	store := newDoctorStore(t)
+	project, err := store.Config.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	project.Settings.Platforms = []string{"claude-code"}
+	project.Settings.SkillsScope = models.SkillsScopeGlobal
+	if err := store.Config.Save(project); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	deps := localDependencies{
+		skillsOutOfSync: func(string) bool { return false },
+		globalSkills:    func() []string { return nil },
+		globalScope:     func() string { return "" },
+		exists:          func(string) bool { return false },
+	}
+	result, err := Run(context.Background(), RunOptions{
+		Project: ProjectFromStore(store),
+		Scopes:  []Scope{ScopeAI},
+	}, localCheckersWithDependencies(store, deps))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if skills := findCheck(t, result, "ai.skills"); skills.Status == StatusWarn {
+		t.Fatalf("skills check warned about absent project dirs under global scope: %#v", skills)
+	}
+}
+
+// TestAISkillsCheckReportsProjectCopyShadowingGlobal covers the state that
+// produced the original report: skills configured globally, yet a project copy
+// present. The project copy wins at runtime, so the configured install is
+// silently overridden and neither directory looks wrong on its own.
+func TestAISkillsCheckReportsProjectCopyShadowingGlobal(t *testing.T) {
+	store := newDoctorStore(t)
+	project, err := store.Config.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	project.Settings.Platforms = []string{"claude-code"}
+	if err := store.Config.Save(project); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	root := filepath.Dir(store.Root)
+	existing := map[string]bool{filepath.Join(root, ".claude", "skills"): true}
+	deps := localDependencies{
+		skillsOutOfSync: func(string) bool { return false },
+		globalSkills:    func() []string { return nil },
+		// The scope comes from the machine-wide default, not this project, which
+		// is how an existing repository inherits the setting untouched.
+		globalScope: func() string { return models.SkillsScopeGlobal },
+		exists:      func(path string) bool { return existing[path] },
+	}
+	result, err := Run(context.Background(), RunOptions{
+		Project: ProjectFromStore(store),
+		Scopes:  []Scope{ScopeAI},
+	}, localCheckersWithDependencies(store, deps))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	skills := findCheck(t, result, "ai.skills")
+	if skills.Status != StatusWarn {
+		t.Fatalf("skills status = %v, want warn about shadowing", skills.Status)
+	}
+	shadowing, ok := skills.Evidence["shadowingPaths"].([]string)
+	if !ok || len(shadowing) != 1 {
+		t.Fatalf("shadowingPaths evidence = %#v", skills.Evidence["shadowingPaths"])
+	}
+	if skills.Remediation == nil || !strings.Contains(skills.Remediation.Command, ".claude/skills") {
+		t.Fatalf("remediation = %#v, want the shadowing directory removed", skills.Remediation)
+	}
+}

--- a/internal/instructions/guidelines/unified/commands-reference.md
+++ b/internal/instructions/guidelines/unified/commands-reference.md
@@ -383,7 +383,7 @@ knowns search "api" --type doc --plain
 ```bash
 knowns template list
 knowns template info <name>
-knowns template run <name> --name "X" --dry-run
+knowns template run <name> --var name=X --dry-run
 knowns template create <name>
 ```
 

--- a/internal/instructions/guidelines/unified/common-mistakes.md
+++ b/internal/instructions/guidelines/unified/common-mistakes.md
@@ -70,7 +70,6 @@ mcp__knowns__update_task({
 | `-a "criterion"` | `--ac "criterion"` |
 | `--parent task-KN-4F7Q2M` | `--parent KN-4F7Q2M` (the ID as printed) |
 | Stripping `KN-` from `KN-4F7Q2M` | The hyphen is part of the ID, not a `task-` ref |
-| `--plain` with create/edit | `--plain` only for view/list |
 | `--notes` for progress | `--append-notes` for progress |
 {{/if}}
 {{#if mcp}}

--- a/internal/instructions/guidelines/unified/core-rules.md
+++ b/internal/instructions/guidelines/unified/core-rules.md
@@ -78,13 +78,16 @@ knowns task edit KN-4F7Q2M --ac "Criterion text"
 
 ### --plain flag
 
-**Only for view/list/search commands:**
+**Global — every command accepts it.** It strips styling everywhere; on
+view/list/search it also selects the parseable plain format:
+
 ```bash
-knowns task <id> --plain      # ✓
-knowns task list --plain      # ✓
-knowns task create --plain    # ✗ ERROR
-knowns task edit --plain      # ✗ ERROR
+knowns task <id> --plain      # plain, parseable output
+knowns task list --plain      # plain, parseable output
+knowns task create --plain    # accepted; output is unstyled
 ```
+
+`NO_COLOR=1` strips styling without changing the format.
 
 ### Subtasks
 

--- a/internal/instructions/skills/kn-flow/SKILL.md
+++ b/internal/instructions/skills/kn-flow/SKILL.md
@@ -93,6 +93,7 @@ For each task or parallel-safe wave:
    - no durable guidance change → append `System Decision Impact: none — <reason>` and create no candidate
    - durable guidance added, changed, or removed → create a first-class draft Decision linked to the task, spec/doc, and readable sources; append `System Decision Impact: candidate @decision/<id> (added|changed|removed) — <summary>`
    - never auto-accept the candidate; unresolved evidence/conflicts stay in Review Inbox
+   - retire what the work replaced in the same change: delete a fully superseded spec/doc rather than leaving it resident under a `Superseded` banner; for a partially superseded one, keep it and name the void parts
 8. Append one structured task note before completion: `Spec Decision Compliance: D1=pass, D2=pass`. Use `D<N>=conflict: <reason>` for any conflict and do not mark the task done.
 
 Spec Decisions remain canonical execution rules in the spec's `Locked Decisions` section. Do not create System Decision ledger rows merely to mirror D-IDs. Never create Memory category `decision`; redirect legacy Decision Memory capture requests to the first-class Decision candidate flow.
@@ -187,6 +188,7 @@ Required order for the final user-facing response:
 - Skipping review before final verification
 - Marking the spec done while linked tasks remain unhandled
 - Marking work done without an explicit `System Decision Impact` marker
+- Leaving a fully superseded spec or doc resident under a `Superseded` banner instead of deleting it
 - Creating legacy Decision Memory instead of a first-class Decision candidate
 - Duplicating Spec Locked Decisions into the System Decision ledger
 - Committing or pushing without explicit user request

--- a/internal/instructions/skills/kn-implement/SKILL.md
+++ b/internal/instructions/skills/kn-implement/SKILL.md
@@ -134,6 +134,11 @@ mcp_knowns_decision({ "action": "create",
 Append the persisted candidate returned by the tool:
 `System Decision Impact: candidate @decision/<id> (added|changed|removed) — <short summary>`
 
+Retire what the work replaced, in the same change:
+
+- **Fully superseded** — delete the spec or doc. Do not leave it resident under a `Superseded` banner. A bannered document still returns in search and its body still reads as current instructions, so the banner hides the rot instead of removing it. Record the supersession in the Decision's `consequences`, not in the retired document.
+- **Partially superseded** — do not delete. Name the void parts explicitly (for example `FR-5`, `AC-6`, `Scenario 4`) and leave the rest live. Deleting a partially superseded document destroys guidance that is still in force.
+
 If review checks find missing evidence or a duplicate/conflict, leave the candidate unresolved in Review Inbox. Passing checks makes it ready for human review; it never makes the candidate current automatically.
 
 Resolving that candidate later — triaging the inbox, promoting it, or superseding what it replaces — is `/kn-decision`. Create the candidate here; settle it there.
@@ -293,6 +298,7 @@ Run: /kn-plan USER-4F7Q2M
 - [ ] Tests pass
 - [ ] **Validated (no broken refs)**
 - [ ] `System Decision Impact` marker recorded as `none` or a persisted candidate ref
+- [ ] Fully superseded specs/docs deleted in the same change; partially superseded ones kept with void parts named
 - [ ] Positive impact created a first-class draft Decision linked to task/spec/sources
 - [ ] Spec Decision Compliance marker recorded for every linked D-ID
 - [ ] Notes added
@@ -310,6 +316,7 @@ Run: /kn-plan USER-4F7Q2M
 - Using `notes` instead of `appendNotes`
 - Marking done without verification
 - Marking done without a `System Decision Impact` marker
+- Leaving a fully superseded spec or doc resident under a `Superseded` banner instead of deleting it
 - Creating Memory category `decision` instead of a first-class Decision candidate
 - Copying Spec Locked Decisions into the System Decision ledger
 - **Not checking sibling tasks when spec linked**

--- a/internal/instructions/skills/kn-verify/SKILL.md
+++ b/internal/instructions/skills/kn-verify/SKILL.md
@@ -33,7 +33,7 @@ Run validation with SDD-awareness to check spec coverage and task status.
 
 ### Via CLI
 ```bash
-knowns validate --sdd --plain
+knowns validate --scope sdd --plain
 ```
 
 ### Via MCP (if available)
@@ -155,7 +155,7 @@ When verification reveals a clear follow-up, include the best next command. If t
 
 ## Checklist
 
-- [ ] Ran validate --sdd
+- [ ] Ran validate --scope sdd
 - [ ] Presented status report
 - [ ] Reported Spec Decision compliance and validated every System Decision Impact marker/ref
 - [ ] Confirmed no Spec Decision ledger duplication or new Decision Memory capture

--- a/internal/mcp/handlers/task.go
+++ b/internal/mcp/handlers/task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -137,6 +138,9 @@ func RegisterTaskTool(s toolRegistrar, getStore func() *storage.Store) {
 			if err != nil {
 				return errResult("action is required")
 			}
+			if err := validateTaskArgs(action, req.GetArguments()); err != nil {
+				return errResult(err.Error())
+			}
 			switch action {
 			case "create":
 				return handleTaskCreate(getStore, req)
@@ -160,18 +164,18 @@ func RegisterTaskTool(s toolRegistrar, getStore func() *storage.Store) {
 		},
 	)
 
-	registerHelp(s, "tasks.create", HelpEntry{When: "Create a new task or subtask with title, context, ownership, labels, and optional spec links. Successful calls return a compact summary by default.", Params: map[string]string{"title": "required — task title", "description": "task context and goal", "status": "todo | in-progress | in-review | done | blocked | on-hold | urgent", "priority": "low | medium | high", "assignee": "person responsible for task", "labels": "task labels", "parent": "parent task ID for subtasks", "spec": "spec doc path this task implements", "fulfills": "spec AC IDs this task satisfies", "order": "display order", "prefix": "custom 2-8 character task ID prefix; overrides the project default for this task only", "return": "summary (default) | full legacy task payload"}, Examples: []string{`tasks({ action: "create", title: "Add auth", description: "...", priority: "high", prefix: "FR" })`}, Flow: "Create task, then update to in-progress and start time before implementation. Use return=full only when the complete created task is required."})
-	registerHelp(s, "tasks.get", HelpEntry{When: "Read full task details before planning, implementation, review, or status updates.", Params: map[string]string{"taskId": "required — task ID"}, Flow: "Use before update/history when you need current ACs, plan, notes, or spec links."})
-	registerHelp(s, "tasks.update", HelpEntry{When: "Modify task metadata, status, acceptance criteria, plan, or implementation notes. Successful calls return a compact summary by default.", Params: map[string]string{"taskId": "required — task ID", "title": "new task title", "description": "new task description", "status": "new task status", "priority": "low | medium | high", "assignee": "new assignee", "labels": "replacement label list", "spec": "spec doc path", "fulfills": "spec AC IDs this task satisfies", "order": "display order", "addAc": "new acceptance criteria", "checkAc": "1-based AC indexes to mark complete", "uncheckAc": "1-based AC indexes to mark incomplete", "removeAc": "1-based AC indexes to remove", "plan": "implementation plan", "notes": "replace all implementation notes", "appendNotes": "append to existing implementation notes", "clear": "string fields to clear", "return": "summary (default) | full legacy task payload"}, Why: "Use appendNotes for progress. notes replaces existing notes and can wipe history.", Examples: []string{`tasks({ action: "update", taskId: "abc123", appendNotes: "Done: added tests" })`, `tasks({ action: "update", taskId: "abc123", checkAc: [1, 2] })`}, Flow: "Only check AC after work is complete; stop time and set status done at finish. Use return=full only when the complete updated task is required."})
-	registerHelp(s, "tasks.delete", HelpEntry{When: "Preview or remove a task when it is obsolete or was created by mistake.", Params: map[string]string{"taskId": "required — task ID", "dryRun": "preview only without deleting; default true"}, Why: "Default dryRun protects against accidental deletion."})
-	registerHelp(s, "tasks.list", HelpEntry{When: "Find tasks by status, owner, priority, label, or spec before choosing work or checking remaining scope.", Params: map[string]string{"status": "filter by task status", "priority": "filter by low | medium | high", "assignee": "filter by assignee", "label": "filter by one label", "spec": "filter by linked spec doc path", "includeHistorical": "include archived Tasks in the result"}})
-	registerHelp(s, "tasks.history", HelpEntry{When: "Inspect chronological changes for audit, debugging, or understanding how a task evolved.", Params: map[string]string{"taskId": "required — task ID"}})
-	registerHelp(s, "tasks.board", HelpEntry{When: "Show task board grouped by status for planning or handoff overview.", Params: map[string]string{}})
-	registerHelp(s, "tasks.archive", HelpEntry{When: "Preview or archive one completed Task through the canonical lifecycle policy.", Params: map[string]string{"taskId": "required", "execute": "false previews; true mutates", "actor": "optional audit actor"}})
-	registerHelp(s, "tasks.unarchive", HelpEntry{When: "Preview or restore one done/archived Task.", Params: map[string]string{"taskId": "required", "execute": "false previews; true mutates"}})
-	registerHelp(s, "tasks.batch_archive", HelpEntry{When: "Preview or archive eligible Tasks with machine retry progress.", Params: map[string]string{"ids": "optional; omitted evaluates all Tasks", "execute": "false previews; true mutates"}})
-	registerHelp(s, "tasks.batch_unarchive", HelpEntry{When: "Preview or restore multiple Tasks.", Params: map[string]string{"ids": "required Task IDs", "execute": "false previews; true mutates"}})
-	registerHelp(s, "tasks.hard_delete", HelpEntry{When: "Permanently delete a Task only under a trusted project delete permission.", Params: map[string]string{"taskId": "required", "confirmed": "must be true", "reason": "required non-empty reason"}, Why: "Hard-delete is distinct from archive and leaves a content-free tombstone."})
+	registerHelp(s, "tasks.create", HelpEntry{When: "Create a new task or subtask with title, context, ownership, labels, and optional spec links. Successful calls return a compact summary by default.", Params: taskActionParams["create"], Examples: []string{`tasks({ action: "create", title: "Add auth", description: "...", priority: "high", prefix: "FR" })`}, Flow: "Create task, then update to in-progress and start time before implementation. Use return=full only when the complete created task is required."})
+	registerHelp(s, "tasks.get", HelpEntry{When: "Read full task details before planning, implementation, review, or status updates.", Params: taskActionParams["get"], Flow: "Use before update/history when you need current ACs, plan, notes, or spec links."})
+	registerHelp(s, "tasks.update", HelpEntry{When: "Modify task metadata, status, acceptance criteria, plan, or implementation notes. Successful calls return a compact summary by default.", Params: taskActionParams["update"], Why: "Use appendNotes for progress. notes replaces existing notes and can wipe history.", Examples: []string{`tasks({ action: "update", taskId: "abc123", appendNotes: "Done: added tests" })`, `tasks({ action: "update", taskId: "abc123", checkAc: [1, 2] })`}, Flow: "Only check AC after work is complete; stop time and set status done at finish. Use return=full only when the complete updated task is required."})
+	registerHelp(s, "tasks.delete", HelpEntry{When: "Preview or remove a task when it is obsolete or was created by mistake.", Params: taskActionParams["delete"], Why: "Default dryRun protects against accidental deletion."})
+	registerHelp(s, "tasks.list", HelpEntry{When: "Find tasks by status, owner, priority, label, or spec before choosing work or checking remaining scope.", Params: taskActionParams["list"]})
+	registerHelp(s, "tasks.history", HelpEntry{When: "Inspect chronological changes for audit, debugging, or understanding how a task evolved.", Params: taskActionParams["history"]})
+	registerHelp(s, "tasks.board", HelpEntry{When: "Show task board grouped by status for planning or handoff overview.", Params: taskActionParams["board"]})
+	registerHelp(s, "tasks.archive", HelpEntry{When: "Preview or archive one completed Task through the canonical lifecycle policy.", Params: taskActionParams["archive"]})
+	registerHelp(s, "tasks.unarchive", HelpEntry{When: "Preview or restore one done/archived Task.", Params: taskActionParams["unarchive"]})
+	registerHelp(s, "tasks.batch_archive", HelpEntry{When: "Preview or archive eligible Tasks with machine retry progress.", Params: taskActionParams["batch_archive"]})
+	registerHelp(s, "tasks.batch_unarchive", HelpEntry{When: "Preview or restore multiple Tasks.", Params: taskActionParams["batch_unarchive"]})
+	registerHelp(s, "tasks.hard_delete", HelpEntry{When: "Permanently delete a Task only under a trusted project delete permission.", Params: taskActionParams["hard_delete"], Why: "Hard-delete is distinct from archive and leaves a content-free tombstone."})
 }
 
 type taskMutationSummary struct {
@@ -198,6 +202,80 @@ func taskMutationResult(task *models.Task, returnMode string) *mcp.CallToolResul
 	}
 	out, _ := json.MarshalIndent(payload, "", "  ")
 	return mcp.NewToolResultText(string(out))
+}
+
+// taskActionParams declares the parameters each tasks action accepts. It is the
+// single source for both the help text and argument validation, so a parameter
+// cannot be documented without being accepted, or accepted without being
+// documented. A handler that reads a parameter absent from this map makes that
+// parameter an error, which is the intended direction: the caller is told,
+// rather than silently getting a different outcome than the one it asked for.
+var taskActionParams = map[string]map[string]string{
+	"create": {
+		"title": "required - task title", "description": "task context and goal",
+		"status":   "todo | in-progress | in-review | done | blocked | on-hold | urgent",
+		"priority": "low | medium | high", "assignee": "person responsible for task",
+		"labels": "task labels", "parent": "parent task ID for subtasks",
+		"spec": "spec doc path this task implements", "fulfills": "spec AC IDs this task satisfies",
+		"order": "display order", "prefix": "custom 2-8 character task ID prefix; overrides the project default for this task only",
+		"addAc": "acceptance criteria to create the task with",
+		"plan":  "implementation plan", "notes": "implementation notes",
+		"return": "summary (default) | full legacy task payload",
+	},
+	"get": {"taskId": "required - task ID"},
+	"update": {
+		"taskId": "required - task ID", "title": "new task title", "description": "new task description",
+		"status": "new task status", "priority": "low | medium | high", "assignee": "new assignee",
+		"labels": "replacement label list", "spec": "spec doc path", "fulfills": "spec AC IDs this task satisfies",
+		"order": "display order", "addAc": "new acceptance criteria",
+		"checkAc": "1-based AC indexes to mark complete", "uncheckAc": "1-based AC indexes to mark incomplete",
+		"removeAc": "1-based AC indexes to remove", "plan": "implementation plan",
+		"notes": "replace all implementation notes", "appendNotes": "append to existing implementation notes",
+		"clear": "string fields to clear", "expectedHash": "expected canonical hash for optimistic concurrency",
+		"return": "summary (default) | full legacy task payload",
+	},
+	"delete": {"taskId": "required - task ID", "dryRun": "preview only without deleting; default true"},
+	"list": {
+		"status": "filter by task status", "priority": "filter by low | medium | high",
+		"assignee": "filter by assignee", "label": "filter by one label",
+		"spec": "filter by linked spec doc path", "includeHistorical": "include archived Tasks in the result",
+	},
+	"history": {
+		"taskId": "required - task ID", "metadata": "payload-free paginated history metadata",
+		"limit": "history metadata page size", "offset": "history metadata offset, newest first",
+		"revision": "explicit revision detail (vN or numeric)",
+	},
+	"board":           {},
+	"archive":         {"taskId": "required", "execute": "false previews; true mutates", "actor": "optional audit actor", "expectedHash": "expected canonical hash"},
+	"unarchive":       {"taskId": "required", "execute": "false previews; true mutates", "actor": "optional audit actor", "expectedHash": "expected canonical hash"},
+	"batch_archive":   {"ids": "optional; omitted evaluates all Tasks", "execute": "false previews; true mutates", "actor": "optional audit actor", "expectedHashes": "per-Task expected canonical hashes"},
+	"batch_unarchive": {"ids": "required Task IDs", "execute": "false previews; true mutates", "actor": "optional audit actor", "expectedHashes": "per-Task expected canonical hashes"},
+	"hard_delete":     {"taskId": "required", "confirmed": "must be true", "reason": "required non-empty reason"},
+}
+
+// validateTaskArgs rejects a parameter the action does not accept instead of
+// ignoring it. Silently dropping an argument is how a caller working from a
+// stale picture of the schema receives a success it did not earn.
+func validateTaskArgs(action string, args map[string]any) error {
+	allowed, ok := taskActionParams[action]
+	if !ok {
+		return nil
+	}
+	unknown := make([]string, 0)
+	for key := range args {
+		if key == "action" {
+			continue
+		}
+		if _, valid := allowed[key]; !valid {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("tasks %s does not accept %s; call help(%q) for the parameters it takes",
+		action, strings.Join(unknown, ", "), "tasks."+action)
 }
 
 func handleTaskCreate(getStore func() *storage.Store, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -271,6 +349,15 @@ func handleTaskCreate(getStore func() *storage.Store, req mcp.CallToolRequest) (
 	}
 	if v, ok := stringArg(args, "notes"); ok {
 		task.ImplementationNotes = v
+	}
+
+	// Acceptance criteria used to be accepted only by update, so passing them
+	// here returned success and dropped them. A Task then reached done against
+	// criteria that were never recorded, and nothing in the response said so.
+	if v, ok := stringSliceArg(args, "addAc"); ok {
+		for _, text := range v {
+			task.AcceptanceCriteria = append(task.AcceptanceCriteria, models.AcceptanceCriterion{Text: text})
+		}
 	}
 
 	prefix, _ := stringArg(args, "prefix")

--- a/internal/mcp/handlers/task.go
+++ b/internal/mcp/handlers/task.go
@@ -386,20 +386,18 @@ func handleTaskUpdate(getStore func() *storage.Store, req mcp.CallToolRequest) (
 				})
 			}
 		}
+		// An out-of-range index used to be skipped in silence, so checking the
+		// criteria of a Task that has none reported success and changed
+		// nothing. That is how a Task reaches "done" with acceptance criteria
+		// nobody ever verified, which is the opposite of what the marker means.
 		if v, ok := intSliceArg(args, "checkAc"); ok {
-			for _, idx := range v {
-				i := idx - 1
-				if i >= 0 && i < len(task.AcceptanceCriteria) {
-					task.AcceptanceCriteria[i].Completed = true
-				}
+			if err := applyACCompletion(task, v, true); err != nil {
+				return err
 			}
 		}
 		if v, ok := intSliceArg(args, "uncheckAc"); ok {
-			for _, idx := range v {
-				i := idx - 1
-				if i >= 0 && i < len(task.AcceptanceCriteria) {
-					task.AcceptanceCriteria[i].Completed = false
-				}
+			if err := applyACCompletion(task, v, false); err != nil {
+				return err
 			}
 		}
 		if v, ok := intSliceArg(args, "removeAc"); ok {
@@ -745,4 +743,19 @@ func handleTaskBoard(getStore func() *storage.Store, req mcp.CallToolRequest) (*
 
 	out, _ := json.MarshalIndent(board, "", "  ")
 	return mcp.NewToolResultText(string(out)), nil
+}
+
+// applyACCompletion marks acceptance criteria complete or incomplete by
+// 1-based index, rejecting any index the Task does not have rather than
+// skipping it. A caller that names a criterion that is not there is working
+// from a stale picture, and silently doing nothing hides that.
+func applyACCompletion(task *models.Task, indexes []int, completed bool) error {
+	for _, idx := range indexes {
+		i := idx - 1
+		if i < 0 || i >= len(task.AcceptanceCriteria) {
+			return fmt.Errorf("acceptance criterion %d is out of range: task has %d", idx, len(task.AcceptanceCriteria))
+		}
+		task.AcceptanceCriteria[i].Completed = completed
+	}
+	return nil
 }

--- a/internal/mcp/handlers/task_ac_range_test.go
+++ b/internal/mcp/handlers/task_ac_range_test.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/howznguyen/knowns/internal/models"
+)
+
+// TestCheckACRejectsOutOfRange guards a silent data defect: checking criteria a
+// Task does not have used to report success and change nothing, so a Task could
+// be marked done against acceptance criteria that were never recorded.
+func TestCheckACRejectsOutOfRange(t *testing.T) {
+	task := &models.Task{}
+	err := applyACCompletion(task, []int{1, 2, 3}, true)
+	if err == nil {
+		t.Fatal("checking criteria on a task with none returned no error")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("error = %v, want it to name the range problem", err)
+	}
+}
+
+func TestCheckACAppliesInRangeIndexes(t *testing.T) {
+	task := &models.Task{AcceptanceCriteria: []models.AcceptanceCriterion{
+		{Text: "one"}, {Text: "two"}, {Text: "three"},
+	}}
+	if err := applyACCompletion(task, []int{1, 3}, true); err != nil {
+		t.Fatalf("applyACCompletion: %v", err)
+	}
+	if !task.AcceptanceCriteria[0].Completed || task.AcceptanceCriteria[2].Completed != true {
+		t.Fatal("in-range indexes were not applied")
+	}
+	if task.AcceptanceCriteria[1].Completed {
+		t.Fatal("an unnamed criterion was modified")
+	}
+	if err := applyACCompletion(task, []int{0}, true); err == nil {
+		t.Fatal("index 0 accepted; indexes are 1-based")
+	}
+}

--- a/internal/mcp/handlers/task_args_test.go
+++ b/internal/mcp/handlers/task_args_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUnknownTaskArgumentIsRejected covers what silent argument dropping cost.
+// `create` never accepted acceptance criteria, so passing them returned success
+// and discarded them, and the Task went on to be marked done against criteria
+// that were never recorded. An argument the action does not accept is now an
+// error naming the argument.
+func TestUnknownTaskArgumentIsRejected(t *testing.T) {
+	err := validateTaskArgs("create", map[string]any{"title": "t", "nonsense": 1})
+	if err == nil {
+		t.Fatal("an unknown argument was accepted")
+	}
+	if !strings.Contains(err.Error(), "nonsense") {
+		t.Fatalf("error = %v, want it to name the rejected argument", err)
+	}
+}
+
+// A privilege-shaped argument is refused before dispatch, so it can never reach
+// a handler that might be tempted to read it.
+func TestSpoofedAuthorizationArgumentIsRejected(t *testing.T) {
+	err := validateTaskArgs("hard_delete", map[string]any{
+		"taskId": "x", "confirmed": true, "reason": "spoof", "authorized": true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "authorized") {
+		t.Fatalf("error = %v, want the spoofed argument refused", err)
+	}
+}
+
+// A parameter valid on another action is still wrong here. This is the exact
+// shape of the original defect: addAc is real, but it was real only on update.
+func TestParameterValidOnAnotherActionIsRejected(t *testing.T) {
+	if err := validateTaskArgs("get", map[string]any{"taskId": "x", "addAc": []string{"a"}}); err == nil {
+		t.Fatal("addAc accepted on get")
+	}
+	if err := validateTaskArgs("create", map[string]any{"title": "t", "addAc": []string{"a"}}); err != nil {
+		t.Fatalf("create must now accept acceptance criteria: %v", err)
+	}
+}
+
+// Every action the tool dispatches must declare its parameters, or validation
+// silently passes everything through for that action.
+func TestEveryDispatchedActionDeclaresParams(t *testing.T) {
+	for _, action := range []string{
+		"create", "get", "update", "delete", "list", "history", "board",
+		"archive", "unarchive", "batch_archive", "batch_unarchive", "hard_delete",
+	} {
+		if _, ok := taskActionParams[action]; !ok {
+			t.Errorf("action %q has no declared parameters", action)
+		}
+	}
+}
+
+// TestCreatePersistsAcceptanceCriteria proves the handler stores the criteria
+// rather than merely accepting the argument. This is the defect that lost five
+// criteria on a real task: create returned success and wrote none of them.
+func TestCreatePersistsAcceptanceCriteria(t *testing.T) {
+	getStore := newMCPPrefixStore(t, "")
+	id := mcpCreatedTaskID(t, getStore, map[string]any{
+		"title": "Create with criteria",
+		"addAc": []any{"first criterion", "second criterion"},
+	})
+	task, err := getStore().Tasks.Get(id)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", id, err)
+	}
+	if len(task.AcceptanceCriteria) != 2 {
+		t.Fatalf("acceptance criteria = %#v, want the two passed to create", task.AcceptanceCriteria)
+	}
+	if task.AcceptanceCriteria[0].Text != "first criterion" || task.AcceptanceCriteria[1].Text != "second criterion" {
+		t.Fatalf("criteria text = %#v", task.AcceptanceCriteria)
+	}
+	if task.AcceptanceCriteria[0].Completed || task.AcceptanceCriteria[1].Completed {
+		t.Fatal("newly created criteria must start unchecked")
+	}
+}

--- a/internal/mcp/handlers/task_lifecycle_test.go
+++ b/internal/mcp/handlers/task_lifecycle_test.go
@@ -48,8 +48,12 @@ func TestTaskLifecycleMCPContractAndTrustedPermission(t *testing.T) {
 		t.Fatalf("empty batch-unarchive = %+v error=%t", empty, emptyError)
 	}
 
-	// A spoofed request argument cannot grant a permission absent from config.
-	denied, isError := callTaskLifecycleMCPAny(t, store, "hard_delete", map[string]any{"taskId": "mcp-life", "confirmed": true, "reason": "spoof", "authorized": true})
+	// A hard delete is denied by the permission layer, not by the arguments.
+	// The spoofed "authorized" argument that used to be passed here is now
+	// refused before dispatch by validateTaskArgs, which would hide whether the
+	// permission check itself still holds, so it is asserted separately in
+	// TestUnknownTaskArgumentIsRejected.
+	denied, isError := callTaskLifecycleMCPAny(t, store, "hard_delete", map[string]any{"taskId": "mcp-life", "confirmed": true, "reason": "spoof"})
 	if !isError {
 		t.Fatal("denied hard-delete must be an MCP error result")
 	}
@@ -337,7 +341,7 @@ func TestRegisteredTaskLifecycleMCPMiddlewarePreservesSharedResponse(t *testing.
 	RegisterTaskTool(registered, func() *storage.Store { return store })
 
 	denied, isError := callRegisteredTaskLifecycleMCP(t, registered.MCPServer, map[string]any{
-		"action": "hard_delete", "taskId": "registered-life", "confirmed": true, "reason": "spoof", "authorized": true,
+		"action": "hard_delete", "taskId": "registered-life", "confirmed": true, "reason": "spoof",
 	})
 	if !isError || denied.Items[0].Reasons[0].Code != tasklifecycle.ReasonPermissionRequired {
 		t.Fatalf("registered denial = %+v error=%t", denied, isError)

--- a/internal/mcp/handlers/task_prefix_test.go
+++ b/internal/mcp/handlers/task_prefix_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/howznguyen/knowns/internal/models"
 	"github.com/howznguyen/knowns/internal/storage"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -110,11 +111,21 @@ func TestMCPTaskCreateRejectsInvalidPrefix(t *testing.T) {
 	}
 }
 
-func TestMCPTaskCreateFallsBackToLegacyIDs(t *testing.T) {
+// TestMCPTaskCreateDerivesAPrefixWhenNoneIsConfigured replaces an older test
+// that asserted the opposite: that an unconfigured project minted bare
+// six-character IDs. Every new task now carries a prefix, derived from the
+// project name, so its file name says which project it belongs to. IDs already
+// written without one are left alone; only generation changed.
+func TestMCPTaskCreateDerivesAPrefixWhenNoneIsConfigured(t *testing.T) {
 	getStore := newMCPPrefixStore(t, "")
-	id := mcpCreatedTaskID(t, getStore, map[string]any{"title": "Legacy id"})
-	if !regexp.MustCompile(`^[0-9a-z]{6}$`).MatchString(id) {
-		t.Fatalf("task ID = %q, want legacy six-character base36 format", id)
+	id := mcpCreatedTaskID(t, getStore, map[string]any{"title": "Derived id"})
+
+	want := models.DeriveTaskIDPrefix("mcp-task-prefix")
+	if !strings.HasPrefix(id, want+"-") {
+		t.Fatalf("task ID = %q, want the %q prefix derived from the project name", id, want)
+	}
+	if !regexp.MustCompile(`^[A-Z][A-Z0-9]{1,7}-[0-9A-Z]{6}$`).MatchString(id) {
+		t.Fatalf("task ID = %q, want PREFIX-XXXXXX", id)
 	}
 }
 

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -139,8 +139,47 @@ type ProjectSettings struct {
 	// When nil, the implicit default preset (read-write-no-delete) is used.
 	Permissions *permissions.PermissionConfig `json:"permissions,omitempty"`
 
+	// SkillsScope controls where `knowns sync` materializes built-in skills.
+	// Allowed values: "project" (default), "global", "none". An unset value
+	// resolves to "project" so existing projects keep their behaviour.
+	SkillsScope string `json:"skillsScope,omitempty"`
+
 	// LSP configures language server enable/disable and binary overrides.
 	LSP *LSPSettings `json:"lsp,omitempty"`
+}
+
+// Skill materialization scopes for `knowns sync`.
+const (
+	SkillsScopeProject = "project"
+	SkillsScopeGlobal  = "global"
+	SkillsScopeNone    = "none"
+)
+
+// NormalizeSkillsScope canonicalizes a skills scope. An empty value is left
+// empty so an unset setting is never written back into config.json.
+func NormalizeSkillsScope(scope string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(scope)) {
+	case "":
+		return "", nil
+	case SkillsScopeProject:
+		return SkillsScopeProject, nil
+	case SkillsScopeGlobal:
+		return SkillsScopeGlobal, nil
+	case SkillsScopeNone:
+		return SkillsScopeNone, nil
+	default:
+		return "", fmt.Errorf("unknown scope %q, want %q, %q, or %q", scope, SkillsScopeProject, SkillsScopeGlobal, SkillsScopeNone)
+	}
+}
+
+// SkillsScopeOrDefault resolves the effective scope. Unset means "project",
+// which is what every project did before this setting existed.
+func (s *ProjectSettings) SkillsScopeOrDefault() string {
+	scope, err := NormalizeSkillsScope(s.SkillsScope)
+	if err != nil || scope == "" {
+		return SkillsScopeProject
+	}
+	return scope
 }
 
 // Normalize canonicalizes settings that accept human-friendly input.
@@ -150,6 +189,12 @@ func (s *ProjectSettings) Normalize() error {
 		return fmt.Errorf("settings.defaultTaskIdPrefix: %w", err)
 	}
 	s.DefaultTaskIDPrefix = prefix
+
+	scope, err := NormalizeSkillsScope(s.SkillsScope)
+	if err != nil {
+		return fmt.Errorf("settings.skillsScope: %w", err)
+	}
+	s.SkillsScope = scope
 	return nil
 }
 

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -172,6 +172,20 @@ func NormalizeSkillsScope(scope string) (string, error) {
 	}
 }
 
+// ResolveSkillsScope applies the resolution chain: the project's own scope
+// wins, then the global default from ~/.knowns/settings.json, then "project".
+// Callers supply both raw values so this stays a pure function that doctor and
+// the CLI can share without either importing the other.
+func ResolveSkillsScope(projectScope, globalScope string) string {
+	if scope, err := NormalizeSkillsScope(projectScope); err == nil && scope != "" {
+		return scope
+	}
+	if scope, err := NormalizeSkillsScope(globalScope); err == nil && scope != "" {
+		return scope
+	}
+	return SkillsScopeProject
+}
+
 // SkillsScopeOrDefault resolves the effective scope. Unset means "project",
 // which is what every project did before this setting existed.
 func (s *ProjectSettings) SkillsScopeOrDefault() string {

--- a/internal/models/decision.go
+++ b/internal/models/decision.go
@@ -35,6 +35,11 @@ type DecisionReviewMatch struct {
 	MatchedBy []string `json:"matchedBy,omitempty" yaml:"matchedBy,omitempty"`
 	Snippet   string   `json:"snippet,omitempty"   yaml:"snippet,omitempty"`
 	Tags      []string `json:"tags,omitempty"      yaml:"tags,omitempty"`
+
+	// Hash identifies the matched decision's content as the reviewer saw it.
+	// Without it a match records only that two decisions once looked alike,
+	// not which version of the other one was compared.
+	Hash string `json:"hash,omitempty" yaml:"hash,omitempty"`
 }
 
 // DecisionEntry represents a first-class architecture/product decision stored
@@ -56,8 +61,15 @@ type DecisionEntry struct {
 	ReviewMatches            []DecisionReviewMatch `json:"reviewMatches,omitempty"          yaml:"reviewMatches,omitempty"`
 	ReviewAllowedResolutions []string              `json:"reviewAllowedResolutions,omitempty" yaml:"reviewAllowedResolutions,omitempty"`
 	ReviewEvaluatedAt        *time.Time            `json:"reviewEvaluatedAt,omitempty"      yaml:"reviewEvaluatedAt,omitempty"`
-	CreatedAt                time.Time             `json:"createdAt"                        yaml:"createdAt"`
-	UpdatedAt                time.Time             `json:"updatedAt"                        yaml:"updatedAt"`
+	// ReviewEvaluatedHash is the content state the review was made against.
+	// ReviewEvaluatedAt says *when* a judgment happened; this says *which
+	// state* it judged, which is what tells a stale finding from a merely old
+	// one. Comparing it with the decision's current hash is exact, where
+	// comparing timestamps guesses and guesses wrong when two edits land close
+	// together.
+	ReviewEvaluatedHash string    `json:"reviewEvaluatedHash,omitempty" yaml:"reviewEvaluatedHash,omitempty"`
+	CreatedAt           time.Time `json:"createdAt"                        yaml:"createdAt"`
+	UpdatedAt           time.Time `json:"updatedAt"                        yaml:"updatedAt"`
 
 	Context                string `json:"context,omitempty"                 yaml:"-"`
 	Decision               string `json:"decision,omitempty"                yaml:"-"`

--- a/internal/models/id.go
+++ b/internal/models/id.go
@@ -5,6 +5,8 @@ import (
 	"math/rand/v2"
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 const (
@@ -50,6 +52,65 @@ func NormalizeTaskIDPrefix(prefix string) (string, error) {
 		return "", fmt.Errorf("task ID prefix must be 2-8 alphanumeric characters and start with a letter")
 	}
 	return normalized, nil
+}
+
+// FallbackTaskIDPrefix is used when a project name yields nothing that can be
+// a prefix, so that task IDs are prefixed even for a project named "42".
+const FallbackTaskIDPrefix = "TSK"
+
+// DeriveTaskIDPrefix produces a task ID prefix from a project name, for
+// projects that never configured one explicitly.
+//
+// A single word contributes its first two letters; several words contribute
+// their initials, up to four. The result is validated, so a name that cannot
+// produce a legal prefix falls back rather than minting an invalid ID.
+//
+//	DeriveTaskIDPrefix("Knowns")           →  "KN"
+//	DeriveTaskIDPrefix("My Cool Project")  →  "MCP"
+//	DeriveTaskIDPrefix("42")               →  "TSK"
+func DeriveTaskIDPrefix(projectName string) string {
+	words := strings.FieldsFunc(projectName, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+
+	var candidate string
+	switch {
+	case len(words) == 0:
+		candidate = ""
+	case len(words) == 1:
+		candidate = firstN(words[0], 2)
+	default:
+		var initials strings.Builder
+		for _, word := range words {
+			if initials.Len() == 4 {
+				break
+			}
+			initials.WriteString(firstN(word, 1))
+		}
+		candidate = initials.String()
+	}
+
+	if normalized, err := NormalizeTaskIDPrefix(candidate); err == nil && normalized != "" {
+		return normalized
+	}
+	return FallbackTaskIDPrefix
+}
+
+// firstN returns up to n characters from the front of s, uppercased, stopping
+// at the first character that cannot appear in a prefix. It stops rather than
+// skipping, so "Über" contributes nothing instead of quietly contributing "B".
+func firstN(s string, n int) string {
+	var b strings.Builder
+	for _, r := range s {
+		if b.Len() == n {
+			break
+		}
+		if r >= utf8.RuneSelf || !(unicode.IsLetter(r) || unicode.IsDigit(r)) {
+			break
+		}
+		b.WriteRune(unicode.ToUpper(r))
+	}
+	return b.String()
 }
 
 // NewPrefixedTaskID returns an ID in the form PREFIX-XXXXXX, where the suffix

--- a/internal/models/id.go
+++ b/internal/models/id.go
@@ -118,13 +118,23 @@ func SanitizeTitle(title string) string {
 	return clean
 }
 
-// TaskFileName returns the canonical file name for a task.
+// TaskFileName returns the canonical file name for a task: the ID and nothing
+// else.
 //
-// Format: "task-{id} - {sanitized-title}.md"
+// The title used to be part of the name. That made a directory listing
+// readable, but it put a copy of a mutable field into a path that is never
+// rewritten, so a renamed task advertised its old title for the rest of its
+// life. Readers that need the title read the frontmatter, which is always
+// current.
+//
+// Files written under the older forms, "task-{id} - {slug}.md" and
+// "task-{id}.md", are still located and read; see taskFileMatches in the
+// storage package.
 //
 // Example:
 //
-//	TaskFileName("abc123", "Fix login bug")  →  "task-abc123 - Fix-login-bug.md"
-func TaskFileName(id, title string) string {
-	return fmt.Sprintf("task-%s - %s.md", id, SanitizeTitle(title))
+//	TaskFileName("abc123")     →  "abc123.md"
+//	TaskFileName("KN-7F3K9M")  →  "KN-7F3K9M.md"
+func TaskFileName(id string) string {
+	return id + ".md"
 }

--- a/internal/models/id_test.go
+++ b/internal/models/id_test.go
@@ -68,9 +68,12 @@ func TestNewTaskIDKeepsLegacyBase36Format(t *testing.T) {
 }
 
 func TestTaskFileNameSupportsPrefixedIDs(t *testing.T) {
-	got := TaskFileName("KN-7F3K9M", "Add authentication")
-	want := "task-KN-7F3K9M - Add-authentication.md"
-	if got != want {
-		t.Fatalf("TaskFileName() = %q, want %q", got, want)
+	for _, tc := range []struct{ id, want string }{
+		{"KN-7F3K9M", "KN-7F3K9M.md"},
+		{"abc123", "abc123.md"},
+	} {
+		if got := TaskFileName(tc.id); got != tc.want {
+			t.Errorf("TaskFileName(%q) = %q, want %q", tc.id, got, tc.want)
+		}
 	}
 }

--- a/internal/models/id_test.go
+++ b/internal/models/id_test.go
@@ -77,3 +77,43 @@ func TestTaskFileNameSupportsPrefixedIDs(t *testing.T) {
 		}
 	}
 }
+
+func TestDeriveTaskIDPrefix(t *testing.T) {
+	cases := map[string]string{
+		"Knowns":          "KN",   // one word: first two letters
+		"knowns":          "KN",   // case is normalized
+		"My Cool Project": "MCP",  // several words: initials
+		"a b c d e f":     "ABCD", // initials are capped at four
+		"my-cool-project": "MCP",  // punctuation separates words
+		"42":              "TSK",  // cannot start with a digit
+		"":                "TSK",
+		"!!!":             "TSK",
+		"X":               "TSK", // a single letter is too short to be legal
+		// A word that does not start with an ASCII character contributes
+		// nothing, so only "Cool" is left, and one letter cannot be a prefix.
+		"Über Cool": "TSK",
+	}
+	for name, want := range cases {
+		got := DeriveTaskIDPrefix(name)
+		if got != want {
+			t.Errorf("DeriveTaskIDPrefix(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestDeriveTaskIDPrefixAlwaysReturnsALegalPrefix is the property that matters:
+// whatever a project is called, the result can be used to mint an ID.
+func TestDeriveTaskIDPrefixAlwaysReturnsALegalPrefix(t *testing.T) {
+	for _, name := range []string{
+		"Knowns", "", "42", "!!!", "x", "a very long project name indeed",
+		"日本語", "9lives", "A", "AB", "under_score", "  spaced  out  ",
+	} {
+		prefix := DeriveTaskIDPrefix(name)
+		if _, err := NormalizeTaskIDPrefix(prefix); err != nil {
+			t.Errorf("DeriveTaskIDPrefix(%q) = %q, which is not a legal prefix: %v", name, prefix, err)
+		}
+		if _, err := NewPrefixedTaskID(prefix); err != nil {
+			t.Errorf("DeriveTaskIDPrefix(%q) = %q, which cannot mint an ID: %v", name, prefix, err)
+		}
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -52,18 +52,37 @@ func (r *Registry) Load() error {
 	if err := json.Unmarshal(data, &r.Projects); err != nil {
 		return err
 	}
-	// Deduplicate by path (keep last occurrence so most recent wins)
+	// Rewrite stored paths to their on-disk spelling, then deduplicate on that
+	// canonical key (keep last occurrence so most recent wins). Registries
+	// written before paths were canonicalized can hold one folder twice under
+	// two spellings; this collapses them without hand-editing the file.
+	changed := false
 	seen := make(map[string]int)
 	deduped := r.Projects[:0]
 	for _, p := range r.Projects {
+		if canonical := util.CanonicalPath(p.Path); canonical != p.Path {
+			// Only refresh a name that was derived from the path, so a name
+			// set elsewhere survives the rewrite.
+			if p.Name == filepath.Base(p.Path) {
+				p.Name = filepath.Base(canonical)
+			}
+			p.Path = canonical
+			changed = true
+		}
 		if idx, exists := seen[p.Path]; exists {
 			deduped[idx] = p // overwrite with newer entry
+			changed = true
 		} else {
 			seen[p.Path] = len(deduped)
 			deduped = append(deduped, p)
 		}
 	}
 	r.Projects = deduped
+	if changed {
+		// The in-memory registry is already correct, so a registry that cannot
+		// be written (read-only home, for example) must not fail the read.
+		_ = r.Save()
+	}
 	return nil
 }
 
@@ -86,6 +105,9 @@ func (r *Registry) Add(projectPath string) (*Project, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve path: %w", err)
 	}
+	// Store the on-disk spelling so the same folder reached through a
+	// differently cased path resolves to one entry.
+	absPath = util.CanonicalPath(absPath)
 
 	// Check .knowns/ exists and has config.json (properly initialized project)
 	knDir := filepath.Join(absPath, ".knowns")
@@ -148,9 +170,12 @@ func (r *Registry) GetActive() *Project {
 }
 
 // FindByPath returns the project with the given absolute path, or nil.
+// The lookup compares on-disk spelling, so any casing that names the stored
+// folder finds it. Stored paths are canonicalized by Add and Load.
 func (r *Registry) FindByPath(absPath string) *Project {
+	canonical := util.CanonicalPath(absPath)
 	for i, p := range r.Projects {
-		if p.Path == absPath {
+		if p.Path == canonical {
 			return &r.Projects[i]
 		}
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -9,6 +9,22 @@ import (
 	"time"
 )
 
+// canonicalTempDir returns t.TempDir() spelled the way the OS itself reports
+// it. The Windows runners hand tests a TMP path holding the 8.3 short name
+// RUNNER~1, which is an alias rather than the directory's real name, so a test
+// comparing against the raw value asserts against exactly the spelling
+// CanonicalPath exists to collapse. EvalSymlinks reads the real name from the
+// OS, independently of the code under test.
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return dir
+	}
+	return resolved
+}
+
 // helper creates a temp dir with a .knowns/config.json to simulate an initialized project.
 func createFakeProject(t *testing.T, parent, name string) string {
 	t.Helper()
@@ -19,7 +35,7 @@ func createFakeProject(t *testing.T, parent, name string) string {
 }
 
 func TestRegistryAddAndLoad(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	regFile := filepath.Join(tmpDir, "registry.json")
 	projDir := createFakeProject(t, tmpDir, "my-project")
 
@@ -53,7 +69,7 @@ func TestRegistryAddAndLoad(t *testing.T) {
 }
 
 func TestRegistryRemove(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	regFile := filepath.Join(tmpDir, "registry.json")
 	projDir := createFakeProject(t, tmpDir, "to-remove")
 
@@ -70,7 +86,7 @@ func TestRegistryRemove(t *testing.T) {
 }
 
 func TestRegistrySetActiveAndGetActive(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	regFile := filepath.Join(tmpDir, "registry.json")
 	proj1 := createFakeProject(t, tmpDir, "proj-a")
 	proj2 := createFakeProject(t, tmpDir, "proj-b")
@@ -96,7 +112,7 @@ func TestRegistrySetActiveAndGetActive(t *testing.T) {
 }
 
 func TestRegistryAddDeduplicate(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	regFile := filepath.Join(tmpDir, "registry.json")
 	projDir := createFakeProject(t, tmpDir, "dup-project")
 
@@ -114,7 +130,7 @@ func TestRegistryAddDeduplicate(t *testing.T) {
 }
 
 func TestRegistryScan(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	regFile := filepath.Join(tmpDir, "registry.json")
 
 	// Create a parent dir with 3 subdirs, 2 of which have .knowns/
@@ -145,7 +161,7 @@ func TestRegistryScan(t *testing.T) {
 }
 
 func TestRegistryFindByPath(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	regFile := filepath.Join(tmpDir, "registry.json")
 	projDir := createFakeProject(t, tmpDir, "findme")
 
@@ -189,7 +205,7 @@ func caseInsensitiveFS(t *testing.T, dir string) bool {
 }
 
 func TestRegistryAddCollapsesCaseVariantPaths(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	if !caseInsensitiveFS(t, tmpDir) {
 		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
 	}
@@ -225,7 +241,7 @@ func TestRegistryAddCollapsesCaseVariantPaths(t *testing.T) {
 }
 
 func TestRegistryAddKeepsDistinctCaseSensitiveDirectories(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	if caseInsensitiveFS(t, tmpDir) {
 		t.Skip("filesystem is case-insensitive; both spellings name one folder")
 	}
@@ -248,7 +264,7 @@ func TestRegistryAddKeepsDistinctCaseSensitiveDirectories(t *testing.T) {
 }
 
 func TestRegistryLoadCollapsesCaseDuplicateRows(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	if !caseInsensitiveFS(t, tmpDir) {
 		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
 	}
@@ -291,7 +307,7 @@ func TestRegistryLoadCollapsesCaseDuplicateRows(t *testing.T) {
 }
 
 func TestRegistryLoadKeepsMissingPathsDistinct(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	regFile := filepath.Join(tmpDir, "registry.json")
 	gone := filepath.Join(tmpDir, "Deleted")
 
@@ -315,7 +331,7 @@ func TestRegistryLoadKeepsMissingPathsDistinct(t *testing.T) {
 }
 
 func TestRegistryFindByPathIgnoresCasing(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	if !caseInsensitiveFS(t, tmpDir) {
 		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -170,5 +172,168 @@ func TestRegistryGetActiveEmpty(t *testing.T) {
 	r.Load()
 	if r.GetActive() != nil {
 		t.Fatal("GetActive should return nil for empty registry")
+	}
+}
+
+// caseInsensitiveFS reports whether dir lives on a filesystem that treats two
+// spellings of one name as the same entry.
+func caseInsensitiveFS(t *testing.T, dir string) bool {
+	t.Helper()
+	probe := filepath.Join(dir, "CaseProbe")
+	if err := os.Mkdir(probe, 0755); err != nil {
+		t.Fatalf("create probe dir: %v", err)
+	}
+	defer os.RemoveAll(probe)
+	_, err := os.Stat(filepath.Join(dir, "caseprobe"))
+	return err == nil
+}
+
+func TestRegistryAddCollapsesCaseVariantPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	if !caseInsensitiveFS(t, tmpDir) {
+		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
+	}
+	regFile := filepath.Join(tmpDir, "registry.json")
+	projDir := createFakeProject(t, tmpDir, "Casing")
+
+	r := NewRegistryWithPath(regFile)
+	if err := r.Load(); err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	first, err := r.Add(projDir)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	second, err := r.Add(strings.ToLower(projDir))
+	if err != nil {
+		t.Fatalf("Add with lowercased path failed: %v", err)
+	}
+
+	if len(r.Projects) != 1 {
+		t.Fatalf("expected 1 project for one folder, got %d", len(r.Projects))
+	}
+	if second.ID != first.ID {
+		t.Fatalf("ID = %q, want the already registered %q", second.ID, first.ID)
+	}
+	if second.Path != projDir {
+		t.Fatalf("Path = %q, want the on-disk spelling %q", second.Path, projDir)
+	}
+	if second.Name != "Casing" {
+		t.Fatalf("Name = %q, want %q", second.Name, "Casing")
+	}
+}
+
+func TestRegistryAddKeepsDistinctCaseSensitiveDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+	if caseInsensitiveFS(t, tmpDir) {
+		t.Skip("filesystem is case-insensitive; both spellings name one folder")
+	}
+	regFile := filepath.Join(tmpDir, "registry.json")
+	upper := createFakeProject(t, tmpDir, "Casing")
+	lower := createFakeProject(t, tmpDir, "casing")
+
+	r := NewRegistryWithPath(regFile)
+	r.Load()
+	if _, err := r.Add(upper); err != nil {
+		t.Fatalf("Add(%q) failed: %v", upper, err)
+	}
+	if _, err := r.Add(lower); err != nil {
+		t.Fatalf("Add(%q) failed: %v", lower, err)
+	}
+
+	if len(r.Projects) != 2 {
+		t.Fatalf("expected 2 projects for 2 distinct folders, got %d", len(r.Projects))
+	}
+}
+
+func TestRegistryLoadCollapsesCaseDuplicateRows(t *testing.T) {
+	tmpDir := t.TempDir()
+	if !caseInsensitiveFS(t, tmpDir) {
+		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
+	}
+	regFile := filepath.Join(tmpDir, "registry.json")
+	projDir := createFakeProject(t, tmpDir, "Casing")
+
+	// A registry written before paths were canonicalized: one folder, two rows,
+	// disagreeing about both path spelling and name.
+	stale := `[
+	  {"id":"aaaaaa","name":"Casing","path":` + strconv.Quote(projDir) + `,"lastUsed":"2026-01-01T00:00:00Z"},
+	  {"id":"bbbbbb","name":"casing","path":` + strconv.Quote(strings.ToLower(projDir)) + `,"lastUsed":"2026-01-02T00:00:00Z"}
+	]`
+	if err := os.WriteFile(regFile, []byte(stale), 0644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+
+	r := NewRegistryWithPath(regFile)
+	if err := r.Load(); err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if len(r.Projects) != 1 {
+		t.Fatalf("expected duplicates to collapse to 1 project, got %d", len(r.Projects))
+	}
+	if r.Projects[0].Path != projDir {
+		t.Fatalf("Path = %q, want the on-disk spelling %q", r.Projects[0].Path, projDir)
+	}
+	if r.Projects[0].Name != "Casing" {
+		t.Fatalf("Name = %q, want %q", r.Projects[0].Name, "Casing")
+	}
+
+	// The collapse is persisted, so the duplicates do not come back on reload.
+	reloaded := NewRegistryWithPath(regFile)
+	if err := reloaded.Load(); err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+	if len(reloaded.Projects) != 1 {
+		t.Fatalf("expected 1 project after reload, got %d", len(reloaded.Projects))
+	}
+}
+
+func TestRegistryLoadKeepsMissingPathsDistinct(t *testing.T) {
+	tmpDir := t.TempDir()
+	regFile := filepath.Join(tmpDir, "registry.json")
+	gone := filepath.Join(tmpDir, "Deleted")
+
+	stale := `[
+	  {"id":"aaaaaa","name":"Deleted","path":` + strconv.Quote(gone) + `,"lastUsed":"2026-01-01T00:00:00Z"},
+	  {"id":"bbbbbb","name":"deleted","path":` + strconv.Quote(strings.ToLower(gone)) + `,"lastUsed":"2026-01-02T00:00:00Z"}
+	]`
+	if err := os.WriteFile(regFile, []byte(stale), 0644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+
+	r := NewRegistryWithPath(regFile)
+	if err := r.Load(); err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	// Neither path exists, so nothing proves they name one folder.
+	if len(r.Projects) != 2 {
+		t.Fatalf("expected unresolvable paths to stay distinct, got %d", len(r.Projects))
+	}
+}
+
+func TestRegistryFindByPathIgnoresCasing(t *testing.T) {
+	tmpDir := t.TempDir()
+	if !caseInsensitiveFS(t, tmpDir) {
+		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
+	}
+	regFile := filepath.Join(tmpDir, "registry.json")
+	projDir := createFakeProject(t, tmpDir, "Casing")
+
+	r := NewRegistryWithPath(regFile)
+	r.Load()
+	added, err := r.Add(projDir)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	found := r.FindByPath(strings.ToLower(projDir))
+	if found == nil {
+		t.Fatal("FindByPath with a differently cased path found nothing")
+	}
+	if found.ID != added.ID {
+		t.Fatalf("ID = %q, want %q", found.ID, added.ID)
 	}
 }

--- a/internal/runtimequeue/qdrant_deadletter_test.go
+++ b/internal/runtimequeue/qdrant_deadletter_test.go
@@ -1,0 +1,77 @@
+package runtimequeue
+
+import (
+	"testing"
+)
+
+// TestNewIntentRevivesDeadLetteredJob pins the defect that stranded eight
+// entities in a real project. A Qdrant outage exhausted the retry budget, every
+// pending job dead-lettered together, and nothing could ever run them again:
+// nextReadyJob skips a dead letter unconditionally and RetryJob, the only other
+// way to clear the flag, is wired to no command. Editing the entity afterwards
+// refreshed the job so it looked healthy while remaining unschedulable.
+func TestNewIntentRevivesDeadLetteredJob(t *testing.T) {
+	root := t.TempDir()
+	intent := QdrantIntent{EntityType: "task", EntityID: "abc123", Revision: 1, Operation: "update", Generation: 1}
+	if _, err := EnqueueQdrantIntent(root, intent); err != nil {
+		t.Fatalf("EnqueueQdrantIntent: %v", err)
+	}
+
+	// Simulate the outage outcome: the job burned its budget and dead-lettered.
+	if err := updateQueue(root, func(state *QueueState) error {
+		for _, job := range state.Jobs {
+			job.DeadLetter = true
+			job.Attempts = qdrantRetryLimit
+			job.LastError = "qdrant unreachable"
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed dead letter: %v", err)
+	}
+
+	// The entity is edited again, which is genuinely new work.
+	next := intent
+	next.Revision = 2
+	next.Generation = 2
+	revived, err := EnqueueQdrantIntent(root, next)
+	if err != nil {
+		t.Fatalf("re-enqueue: %v", err)
+	}
+	if revived.DeadLetter {
+		t.Fatal("a newer intent left the job dead-lettered, so it can never be scheduled again")
+	}
+	if revived.Attempts != 0 || revived.LastError != "" {
+		t.Fatalf("revived job kept prior failure state: attempts=%d lastError=%q", revived.Attempts, revived.LastError)
+	}
+}
+
+// TestStaleIntentDoesNotReviveDeadLetter is the other half. Only new work earns
+// a fresh attempt; a re-enqueue carrying the same or an older intent must not
+// resurrect a job that already failed, or a permanently broken backend would be
+// retried without end.
+func TestStaleIntentDoesNotReviveDeadLetter(t *testing.T) {
+	root := t.TempDir()
+	intent := QdrantIntent{EntityType: "task", EntityID: "abc123", Revision: 5, Operation: "update", Generation: 5}
+	if _, err := EnqueueQdrantIntent(root, intent); err != nil {
+		t.Fatalf("EnqueueQdrantIntent: %v", err)
+	}
+	if err := updateQueue(root, func(state *QueueState) error {
+		for _, job := range state.Jobs {
+			job.DeadLetter = true
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed dead letter: %v", err)
+	}
+
+	older := intent
+	older.Revision = 3
+	older.Generation = 3
+	got, err := EnqueueQdrantIntent(root, older)
+	if err != nil {
+		t.Fatalf("re-enqueue: %v", err)
+	}
+	if !got.DeadLetter {
+		t.Fatal("an older intent revived a dead letter; only newer work should")
+	}
+}

--- a/internal/runtimequeue/runtimequeue.go
+++ b/internal/runtimequeue/runtimequeue.go
@@ -938,6 +938,21 @@ func EnqueueQdrantIntent(storeRoot string, intent QdrantIntent) (Job, error) {
 			job.RequestedAt = now
 			job.RunAfter = now.Add(debounceFor(JobQdrantReconcile))
 			job.LastError = ""
+			// A newer intent is a new request, so it gets a fresh attempt
+			// budget. Clearing DeadLetter is part of that and not a separate
+			// policy: the two lines around it already discard the previous
+			// failure's error and attempt count. Leaving the flag set stranded
+			// the entity forever, because nextReadyJob skips a dead letter
+			// unconditionally and RetryJob, the only other way to clear it, is
+			// wired to no command. An outage long enough to exhaust the retry
+			// budget then orphaned every entity edited during it, and every
+			// later edit refreshed RequestedAt so the job never even aged out
+			// to be pruned and replaced.
+			//
+			// The generation guard above is what keeps this honest: a re-enqueue
+			// carrying the same or an older intent returns before this point, so
+			// only genuinely new work revives the job.
+			job.DeadLetter = false
 			// A running job keeps its StartedAt and is completed against its
 			// original generation; CompleteJob retains this newer successor.
 			if job.StartedAt == nil {

--- a/internal/search/evaluation_runtime.go
+++ b/internal/search/evaluation_runtime.go
@@ -9,7 +9,19 @@ import (
 
 // SemanticEvaluationRuntimeIdentity returns a stable, non-secret identity for
 // baseline attribution across machines.
+// MockEvaluationRuntimeIdentity is the runtime identity reported while the
+// deterministic embedder is active. It is deliberately unmistakable, so a
+// baseline recorded against the mock can never be confused with one recorded
+// against a real model.
+const MockEvaluationRuntimeIdentity = "mock/mock-deterministic@32"
+
 func SemanticEvaluationRuntimeIdentity(store *storage.Store) (string, error) {
+	// Under the deterministic embedder the runtime is the mock itself, so it
+	// reports a stable identity of its own. The pin still applies; CI pins to
+	// this value rather than to a provider that would have to be installed.
+	if MockEmbedderEnabled() {
+		return MockEvaluationRuntimeIdentity, nil
+	}
 	cfg, err := loadSemanticRuntimeConfig(store)
 	if err != nil {
 		return "", fmt.Errorf("load semantic evaluation runtime: %w", err)
@@ -37,6 +49,11 @@ func RequirePinnedSemanticEvaluationRuntime(
 			actualIdentity,
 			pinnedIdentity,
 		)
+	}
+	// The mock has no daemon to enable and no index to warm: it answers every
+	// embed call in process. Identity equality above is the whole check.
+	if MockEmbedderEnabled() {
+		return actualIdentity, nil
 	}
 	if !SemanticRuntimeEnabled() {
 		status := ObservedSemanticRuntimeStatus()

--- a/internal/search/init.go
+++ b/internal/search/init.go
@@ -53,6 +53,23 @@ func InitSemantic(store *storage.Store) (EmbedderProvider, VectorStore, error) {
 		return nil, nil, ErrSemanticNotConfigured
 	}
 
+	// The deterministic embedder replaces the API provider entirely, so a CI
+	// run can exercise the semantic and hybrid paths with no Ollama, no model
+	// download and no network. It is opt-in through an environment variable and
+	// never reached unless that variable is set.
+	if MockEmbedderEnabled() {
+		embedder := NewMockEmbedder()
+		// A distinct model name keeps the mock's vectors in their own store, so
+		// a CI run can never leave vectors behind that a real run would then
+		// read back as if a real model had produced them.
+		vecStore := NewSQLiteVectorStore(filepath.Join(store.Root, ".search"),
+			embedder.ModelConfig().Name, embedder.Dimensions())
+		if err := vecStore.Load(); err != nil {
+			return nil, nil, fmt.Errorf("load mock vector store: %w", err)
+		}
+		return embedder, vecStore, nil
+	}
+
 	return initSemanticAPI(store, ss)
 }
 

--- a/internal/search/mock_embedder.go
+++ b/internal/search/mock_embedder.go
@@ -1,0 +1,107 @@
+package search
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"os"
+	"strings"
+)
+
+// EnvMockEmbedder switches semantic search onto a deterministic in-process
+// embedder. It exists so CI can gate the semantic and hybrid retrieval paths
+// without an Ollama runtime, a model download, or a network call.
+const EnvMockEmbedder = "KNOWNS_EMBED_MOCK"
+
+// mockEmbedderDimensions is small enough to keep fixtures and baselines cheap
+// and large enough that unrelated texts do not collide into the same direction.
+const mockEmbedderDimensions = 32
+
+// MockEmbedderEnabled reports whether the deterministic embedder is requested.
+func MockEmbedderEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvMockEmbedder))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// mockEmbedder derives a vector from the text itself, so the same text always
+// embeds to the same direction and different texts embed to different ones.
+//
+// The distinction from the constant-vector stub used in unit tests matters. A
+// stub that answers every input with the same vector makes every document score
+// identically, so ranking becomes arbitrary and an evaluation over it measures
+// nothing. Deriving the vector from a hash of the text keeps ranking well
+// defined and reproducible on any machine.
+//
+// What this gates is behaviour, not quality. These vectors carry no meaning, so
+// "search quality improvements" and "improve search quality" point in unrelated
+// directions and human relevance judgements do not survive. A baseline recorded
+// against this embedder answers "does the ranking pipeline still behave the way
+// it did", which is what catches a change to the similarity threshold, the RRF
+// constant, the candidate window, or tie-breaking. It does not answer whether
+// retrieval is any good; that still needs real embeddings.
+type mockEmbedder struct{}
+
+// NewMockEmbedder returns the deterministic embedder used when EnvMockEmbedder
+// is set.
+func NewMockEmbedder() EmbedderProvider { return mockEmbedder{} }
+
+func (mockEmbedder) vector(text string) []float32 {
+	vec := make([]float32, mockEmbedderDimensions)
+	// One hash per block of 8 dimensions, chained so every dimension depends on
+	// the whole text rather than on a prefix of it.
+	sum := sha256.Sum256([]byte(text))
+	var norm float64
+	for i := 0; i < mockEmbedderDimensions; i++ {
+		if i > 0 && i%8 == 0 {
+			sum = sha256.Sum256(sum[:])
+		}
+		offset := (i % 8) * 4
+		bits := binary.BigEndian.Uint32(sum[offset : offset+4])
+		// Map into [-1, 1) so vectors spread across the sphere instead of
+		// crowding one octant, which would make every cosine similarity high.
+		v := float64(bits)/float64(math.MaxUint32)*2 - 1
+		vec[i] = float32(v)
+		norm += v * v
+	}
+	if norm == 0 {
+		vec[0] = 1
+		return vec
+	}
+	inv := float32(1 / math.Sqrt(norm))
+	for i := range vec {
+		vec[i] *= inv
+	}
+	return vec
+}
+
+func (m mockEmbedder) Embed(text string) ([]float32, error)         { return m.vector(text), nil }
+func (m mockEmbedder) EmbedDocument(text string) ([]float32, error) { return m.vector(text), nil }
+func (m mockEmbedder) EmbedQuery(text string) ([]float32, error)    { return m.vector(text), nil }
+
+func (m mockEmbedder) EmbedBatch(texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		out[i] = m.vector(t)
+	}
+	return out, nil
+}
+
+func (m mockEmbedder) EmbedDocumentBatch(texts []string) ([][]float32, error) {
+	return m.EmbedBatch(texts)
+}
+func (m mockEmbedder) EmbedQueryBatch(texts []string) ([][]float32, error) {
+	return m.EmbedBatch(texts)
+}
+
+func (mockEmbedder) Dimensions() int { return mockEmbedderDimensions }
+
+func (mockEmbedder) ModelConfig() EmbeddingModelConfig {
+	return EmbeddingModelConfig{Name: "mock-deterministic", Dimensions: mockEmbedderDimensions, MaxTokens: 8192}
+}
+
+func (mockEmbedder) GetTokenizer() Tokenizer { return nil }
+func (mockEmbedder) Close()                  {}

--- a/internal/search/mock_embedder_test.go
+++ b/internal/search/mock_embedder_test.go
@@ -1,0 +1,78 @@
+package search
+
+import (
+	"math"
+	"testing"
+)
+
+// TestMockEmbedderSeparatesDifferentTexts is the property that makes the mock
+// worth anything. The constant-vector stub used elsewhere in these tests gives
+// every document the same direction, so every similarity ties and a ranking
+// evaluation over it measures nothing at all.
+func TestMockEmbedderSeparatesDifferentTexts(t *testing.T) {
+	m := NewMockEmbedder()
+	a, err := m.EmbedDocument("retrieval evaluation gate")
+	if err != nil {
+		t.Fatalf("EmbedDocument: %v", err)
+	}
+	b, err := m.EmbedDocument("skills scope global install")
+	if err != nil {
+		t.Fatalf("EmbedDocument: %v", err)
+	}
+	if cosine(a, b) > 0.9 {
+		t.Fatalf("unrelated texts embed almost identically: cosine=%f", cosine(a, b))
+	}
+}
+
+// Determinism is what lets a baseline recorded on one machine hold on another.
+func TestMockEmbedderIsDeterministic(t *testing.T) {
+	m := NewMockEmbedder()
+	first, _ := m.EmbedDocument("same text")
+	second, _ := m.EmbedDocument("same text")
+	if cosine(first, second) < 0.999999 {
+		t.Fatal("the same text embedded to two different vectors")
+	}
+	// A query and a document of identical text must also agree, or the query
+	// leg and the index leg would never line up.
+	q, _ := m.EmbedQuery("same text")
+	if cosine(first, q) < 0.999999 {
+		t.Fatal("query and document embeddings of the same text disagree")
+	}
+}
+
+// Vectors must be unit length and spread across the sphere. Crowding one octant
+// would push every cosine similarity near 1 and make the threshold meaningless.
+func TestMockEmbedderVectorsAreNormalisedAndSigned(t *testing.T) {
+	m := NewMockEmbedder()
+	vec, _ := m.EmbedDocument("a document about nothing in particular")
+	if len(vec) != m.Dimensions() {
+		t.Fatalf("len = %d, want %d", len(vec), m.Dimensions())
+	}
+	var norm float64
+	negatives := 0
+	for _, v := range vec {
+		norm += float64(v) * float64(v)
+		if v < 0 {
+			negatives++
+		}
+	}
+	if math.Abs(math.Sqrt(norm)-1) > 1e-5 {
+		t.Fatalf("vector norm = %f, want 1", math.Sqrt(norm))
+	}
+	if negatives == 0 {
+		t.Fatal("no negative components; vectors are confined to one octant")
+	}
+}
+
+func cosine(a, b []float32) float64 {
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		na += float64(a[i]) * float64(a[i])
+		nb += float64(b[i]) * float64(b[i])
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}

--- a/internal/search/qdrant_generation.go
+++ b/internal/search/qdrant_generation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -125,6 +126,29 @@ func ReindexQdrantGeneration(ctx context.Context, store *storage.Store, embedder
 		return QdrantGenerationResult{}, fmt.Errorf("activate next Qdrant generation: %w", err)
 	}
 	activated = true
+
+	// The rebuild is the most authoritative moment to record what is indexed:
+	// the collection was just built from canonical sources, validated point by
+	// point, and made active. Stamping here is what lets `knowns search index`
+	// clear a `knowns doctor` warning, which it previously could never do
+	// because watermarks were written only by per-entity reconciliation.
+	//
+	// Only entities that actually produced points are stamped. Reindex swallows
+	// a per-entity embedding failure, so an entity it skipped has none and stays
+	// stale, which is the honest outcome.
+	indexedSourceIDs := make(map[string]bool, len(points))
+	for _, p := range points {
+		if id := payloadString(p.Payload, qdrantPayloadSourceID); id != "" {
+			indexedSourceIDs[id] = true
+		}
+	}
+	if _, err := StampWatermarksFromGeneration(store.Root, indexedSourceIDs, indexed); err != nil {
+		// The generation is live and correct; only the bookkeeping failed. Report
+		// it rather than failing the rebuild, so status stays wrong-but-visible
+		// instead of the rebuild appearing to have not happened.
+		log.Printf("[search] rebuilt generation but could not stamp index watermarks: %v", err)
+	}
+
 	result := QdrantGenerationResult{Pointer: next, Previous: previous}
 	records, historyErr := LoadQdrantGenerations(store.Root)
 	if historyErr != nil {

--- a/internal/search/qdrant_reconcile.go
+++ b/internal/search/qdrant_reconcile.go
@@ -124,6 +124,98 @@ func saveQdrantWatermarks(storeRoot string, values map[string]QdrantIndexWaterma
 	return nil
 }
 
+// StampWatermarksFromGeneration records that a full generation rebuild indexed
+// an entity, so `knowns search index` can finally clear what `knowns doctor`
+// reports.
+//
+// Until now the two halves were disjoint by construction. The bulk rebuild
+// (ReindexQdrantGeneration) repopulates the whole collection from canonical
+// sources but never wrote this file, while only per-entity reconciliation ever
+// did. A doctor warning could therefore survive its own advertised remediation
+// forever, which is exactly what happened to eight entities in this repository.
+//
+// Truth comes from the points that were actually built, validated and upserted,
+// not from the manifest. An entity the rebuild skipped - embedding failure is
+// swallowed per entity inside Reindex - has no point, so it is left stale and
+// keeps being reported. Claiming it indexed because the manifest lists it would
+// trade a visible wrong warning for an invisible wrong silence.
+func StampWatermarksFromGeneration(storeRoot string, indexedSourceIDs map[string]bool, at time.Time) (int, error) {
+	if len(indexedSourceIDs) == 0 {
+		return 0, nil
+	}
+	entries, err := manifestEntriesForStamping(storeRoot)
+	if err != nil {
+		return 0, err
+	}
+	values, err := loadQdrantWatermarks(storeRoot)
+	if err != nil {
+		return 0, err
+	}
+	if values == nil {
+		values = map[string]QdrantIndexWatermark{}
+	}
+	stamped := 0
+	for key, entry := range entries {
+		if !indexedSourceIDs[sourceIDForManifestEntry(entry)] {
+			continue
+		}
+		current := values[key]
+		if current.Removed || current.PendingRemoval {
+			continue
+		}
+		current.EntityType, current.EntityID = entry.EntityType, entry.EntityID
+		current.CanonicalHash, current.Revision, current.Path = entry.Hash, entry.Revision, entry.Path
+		current.IndexedHash, current.IndexedRevision, current.IndexedPath = entry.Hash, entry.Revision, entry.Path
+		current.IndexedAt, current.Stale = at.UTC(), false
+		values[key] = current
+		stamped++
+	}
+	if stamped == 0 {
+		return 0, nil
+	}
+	return stamped, saveQdrantWatermarks(storeRoot, values)
+}
+
+// sourceIDForManifestEntry mirrors how IndexService builds a chunk's source id:
+// tasks by ID, docs by their store-relative path with the docs/ prefix and .md
+// suffix removed.
+func sourceIDForManifestEntry(entry manifestStampEntry) string {
+	switch entry.EntityType {
+	case "task":
+		return "task:" + entry.EntityID
+	case "doc":
+		path := strings.TrimSuffix(strings.TrimPrefix(entry.Path, "docs/"), ".md")
+		return "doc:" + path
+	default:
+		return ""
+	}
+}
+
+type manifestStampEntry struct {
+	EntityType string `json:"entityType"`
+	EntityID   string `json:"entityId"`
+	Path       string `json:"path"`
+	Hash       string `json:"hash"`
+	Revision   int    `json:"revision"`
+}
+
+func manifestEntriesForStamping(storeRoot string) (map[string]manifestStampEntry, error) {
+	data, err := os.ReadFile(filepath.Join(storeRoot, "history", "state", "manifest.json"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var manifest struct {
+		Entries map[string]manifestStampEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+	return manifest.Entries, nil
+}
+
 // QdrantEntityReadinessForStore compares canonical manifest hashes and
 // durable public-hook intent watermarks with indexed watermarks without
 // loading entity content. Public hooks do not necessarily update the watcher

--- a/internal/search/watermark_stamp_test.go
+++ b/internal/search/watermark_stamp_test.go
@@ -1,0 +1,126 @@
+package search
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeStampFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "history", "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	manifest := map[string]any{"entries": map[string]any{
+		"task:indexed": map[string]any{
+			"entityType": "task", "entityId": "indexed",
+			"path": "tasks/task-indexed - A-real-filename.md", "hash": "hash-a", "revision": 6,
+		},
+		"task:skipped": map[string]any{
+			"entityType": "task", "entityId": "skipped",
+			"path": "tasks/task-skipped - Another-filename.md", "hash": "hash-b", "revision": 2,
+		},
+		"doc:doc-1": map[string]any{
+			"entityType": "doc", "entityId": "doc-1",
+			"path": "docs/guides/thing.md", "hash": "hash-c", "revision": 3,
+		},
+	}}
+	data, _ := json.Marshal(manifest)
+	if err := os.WriteFile(filepath.Join(stateDir, "manifest.json"), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return root
+}
+
+// TestStampClearsStaleForEntitiesTheRebuildCovered is the point of the change:
+// a full rebuild can now clear what doctor reports. Before this, watermarks were
+// written only by per-entity reconciliation, so a warning could outlive its own
+// advertised remediation indefinitely.
+func TestStampClearsStaleForEntitiesTheRebuildCovered(t *testing.T) {
+	root := writeStampFixture(t)
+	// Seed the two broken shapes seen in a real project: never indexed, and
+	// indexed once against a path spelled differently from the manifest.
+	if err := saveQdrantWatermarks(root, map[string]QdrantIndexWatermark{
+		"task:indexed": {EntityType: "task", EntityID: "indexed", CanonicalHash: "hash-a", Revision: 6,
+			Path: "tasks/indexed.md", Stale: true},
+		"doc:doc-1": {EntityType: "doc", EntityID: "doc-1", CanonicalHash: "hash-c", Revision: 3,
+			Path: "docs/guides/thing.md", IndexedHash: "old", IndexedPath: "docs/guides/thing.md", IndexedRevision: 2},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	stamped, err := StampWatermarksFromGeneration(root, map[string]bool{
+		"task:indexed":     true,
+		"doc:guides/thing": true,
+	}, now)
+	if err != nil {
+		t.Fatalf("StampWatermarksFromGeneration: %v", err)
+	}
+	if stamped != 2 {
+		t.Fatalf("stamped = %d, want 2", stamped)
+	}
+
+	values, err := loadQdrantWatermarks(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	task := values["task:indexed"]
+	if task.Stale {
+		t.Fatal("a rebuilt entity is still marked stale")
+	}
+	// The manifest spelling wins, which is what the readiness check compares against.
+	if task.IndexedPath != "tasks/task-indexed - A-real-filename.md" || task.IndexedHash != "hash-a" || task.IndexedRevision != 6 {
+		t.Fatalf("task watermark = %#v", task)
+	}
+	if !task.IndexedAt.Equal(now) {
+		t.Fatalf("indexedAt = %v, want %v", task.IndexedAt, now)
+	}
+	if doc := values["doc:doc-1"]; doc.IndexedHash != "hash-c" || doc.IndexedRevision != 3 {
+		t.Fatalf("doc watermark = %#v", doc)
+	}
+}
+
+// TestStampLeavesEntitiesTheRebuildSkipped guards the honesty of the change.
+// Reindex swallows a per-entity embedding failure, so an entity it dropped
+// produces no points. Stamping it from the manifest would replace a visible
+// wrong warning with an invisible wrong silence.
+func TestStampLeavesEntitiesTheRebuildSkipped(t *testing.T) {
+	root := writeStampFixture(t)
+	if err := saveQdrantWatermarks(root, map[string]QdrantIndexWatermark{
+		"task:skipped": {EntityType: "task", EntityID: "skipped", CanonicalHash: "hash-b", Revision: 2, Stale: true},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := StampWatermarksFromGeneration(root, map[string]bool{"task:indexed": true}, time.Now().UTC()); err != nil {
+		t.Fatalf("StampWatermarksFromGeneration: %v", err)
+	}
+	values, err := loadQdrantWatermarks(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if skipped := values["task:skipped"]; !skipped.Stale || skipped.IndexedHash != "" {
+		t.Fatalf("an entity the rebuild never covered was stamped indexed: %#v", skipped)
+	}
+}
+
+// A removal in flight must not be resurrected as indexed by a bulk rebuild.
+func TestStampSkipsEntitiesPendingRemoval(t *testing.T) {
+	root := writeStampFixture(t)
+	if err := saveQdrantWatermarks(root, map[string]QdrantIndexWatermark{
+		"task:indexed": {EntityType: "task", EntityID: "indexed", Stale: true, PendingRemoval: true},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := StampWatermarksFromGeneration(root, map[string]bool{"task:indexed": true}, time.Now().UTC()); err != nil {
+		t.Fatalf("StampWatermarksFromGeneration: %v", err)
+	}
+	values, _ := loadQdrantWatermarks(root)
+	if got := values["task:indexed"]; got.IndexedHash != "" || !got.PendingRemoval {
+		t.Fatalf("pending removal was stamped indexed: %#v", got)
+	}
+}

--- a/internal/server/routes/tasks_http_lifecycle_contract_test.go
+++ b/internal/server/routes/tasks_http_lifecycle_contract_test.go
@@ -170,7 +170,7 @@ func assertTaskMarkdownOmitsLifecycleState(t *testing.T, store *storage.Store, d
 		t.Fatal(err)
 	}
 	for _, entry := range entries {
-		if !entry.IsDir() && strings.HasPrefix(entry.Name(), "task-"+taskID) {
+		if !entry.IsDir() && storage.TaskFileMatches(entry.Name(), taskID) {
 			data, err := os.ReadFile(filepath.Join(store.Root, dir, entry.Name()))
 			if err != nil {
 				t.Fatal(err)

--- a/internal/server/routes/tasks_prefix_test.go
+++ b/internal/server/routes/tasks_prefix_test.go
@@ -92,11 +92,15 @@ func TestTaskPOSTRejectsInvalidPrefix(t *testing.T) {
 	}
 }
 
-func TestTaskPOSTFallsBackToLegacyIDs(t *testing.T) {
+// TestTaskPOSTDerivesAPrefixWhenNoneIsConfigured replaces an older test that
+// asserted bare six-character IDs for an unconfigured project. Generation now
+// always produces PREFIX-XXXXXX; IDs already written without a prefix keep
+// resolving under their original names.
+func TestTaskPOSTDerivesAPrefixWhenNoneIsConfigured(t *testing.T) {
 	store := newTaskLifecycleRouteStore(t)
-	id := createdTaskID(t, postTaskPrefix(t, store, `{"title":"Legacy id"}`))
-	if !regexp.MustCompile(`^[0-9a-z]{6}$`).MatchString(id) {
-		t.Fatalf("task ID = %q, want legacy six-character base36 format", id)
+	id := createdTaskID(t, postTaskPrefix(t, store, `{"title":"Derived id"}`))
+	if !regexp.MustCompile(`^[A-Z][A-Z0-9]{1,7}-[0-9A-Z]{6}$`).MatchString(id) {
+		t.Fatalf("task ID = %q, want PREFIX-XXXXXX", id)
 	}
 }
 

--- a/internal/server/routes/workspace.go
+++ b/internal/server/routes/workspace.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/howznguyen/knowns/internal/storage"
+	"github.com/howznguyen/knowns/internal/util"
 )
 
 // WorkspaceRoutes handles /api/workspaces endpoints for multi-project management.
@@ -109,8 +110,6 @@ func (wr *WorkspaceRoutes) browse(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, http.StatusOK, result)
 }
 
-
-//
 // GET /api/workspaces
 func (wr *WorkspaceRoutes) list(w http.ResponseWriter, r *http.Request) {
 	reg := wr.manager.GetRegistry()
@@ -189,9 +188,11 @@ func (wr *WorkspaceRoutes) switchWorkspace(w http.ResponseWriter, r *http.Reques
 		Data: map[string]string{"reason": "workspace-switch"},
 	})
 
-	// Return the active project info.
+	// Return the active project info. Registry paths carry their on-disk
+	// spelling, so compare against the canonical form of what was requested.
+	canonicalPath := util.CanonicalPath(projectPath)
 	for _, p := range reg.Projects {
-		if p.Path == projectPath {
+		if p.Path == canonicalPath {
 			respondJSON(w, http.StatusOK, p)
 			return
 		}
@@ -247,7 +248,35 @@ func (wr *WorkspaceRoutes) autoScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Common project directories to scan
+	dirs := scanCandidates(home)
+
+	added, err := reg.Scan(dirs)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if added == nil {
+		respondJSON(w, http.StatusOK, []struct{}{})
+		return
+	}
+	respondJSON(w, http.StatusOK, added)
+}
+
+// scanCandidates returns the directories auto-scan walks for the given home
+// directory: the well-known project folders that exist, collapsed onto their
+// on-disk spelling.
+//
+// Unlike browse, this does not filter the macOS /private tree. Every candidate
+// is the home directory or one of its immediate children, so the filter never
+// protected anything on a real machine, while it silently emptied the scan for
+// any home that resolves under /private, such as root's /var/root.
+//
+// The candidate list deliberately carries several casings of the same folder
+// (Projects and projects, Code and code) because either spelling can be the
+// real one. On a case-insensitive filesystem both spellings stat successfully
+// and name one directory, so without the collapse every scan would register
+// that project twice.
+func scanCandidates(home string) []string {
 	candidates := []string{
 		home,
 		filepath.Join(home, "Projects"),
@@ -267,33 +296,21 @@ func (wr *WorkspaceRoutes) autoScan(w http.ResponseWriter, r *http.Request) {
 		filepath.Join(home, "Dev"),
 	}
 
-	// Filter to only existing directories, excluding /private (macOS symlink target)
 	var dirs []string
+	seen := make(map[string]bool)
 	for _, d := range candidates {
 		info, err := os.Stat(d)
 		if err != nil || !info.IsDir() {
 			continue
 		}
-		resolved, err := filepath.EvalSymlinks(d)
-		if err != nil {
-			resolved = d
-		}
-		if strings.HasPrefix(resolved, "/private") {
+		canonical := util.CanonicalPath(d)
+		if seen[canonical] {
 			continue
 		}
-		dirs = append(dirs, d)
+		seen[canonical] = true
+		dirs = append(dirs, canonical)
 	}
-
-	added, err := reg.Scan(dirs)
-	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	if added == nil {
-		respondJSON(w, http.StatusOK, []struct{}{})
-		return
-	}
-	respondJSON(w, http.StatusOK, added)
+	return dirs
 }
 
 // remove deletes a project from the registry.

--- a/internal/server/routes/workspace_test.go
+++ b/internal/server/routes/workspace_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -153,5 +154,109 @@ func TestWorkspaceDelete(t *testing.T) {
 	// Verify removed
 	if len(reg.Projects) != 0 {
 		t.Fatalf("expected 0 projects after delete, got %d", len(reg.Projects))
+	}
+}
+
+// caseInsensitiveFS reports whether dir lives on a filesystem that treats two
+// spellings of one name as the same entry.
+func caseInsensitiveFS(t *testing.T, dir string) bool {
+	t.Helper()
+	probe := filepath.Join(dir, "CaseProbe")
+	if err := os.Mkdir(probe, 0755); err != nil {
+		t.Fatalf("create probe dir: %v", err)
+	}
+	defer os.RemoveAll(probe)
+	_, err := os.Stat(filepath.Join(dir, "caseprobe"))
+	return err == nil
+}
+
+func TestScanCandidatesCollapsesCaseVariantDirectories(t *testing.T) {
+	home := t.TempDir()
+	if !caseInsensitiveFS(t, home) {
+		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
+	}
+	// Only one of the two spellings the candidate list carries exists on disk.
+	projects := filepath.Join(home, "Projects")
+	if err := os.Mkdir(projects, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	dirs := scanCandidates(home)
+
+	seen := make(map[string]int)
+	for _, d := range dirs {
+		seen[d]++
+		if seen[d] > 1 {
+			t.Fatalf("candidate %q returned more than once", d)
+		}
+	}
+	matches := 0
+	for _, d := range dirs {
+		if strings.EqualFold(filepath.Base(d), "projects") {
+			matches++
+			if d != projects {
+				t.Fatalf("candidate = %q, want the on-disk spelling %q", d, projects)
+			}
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("projects directory appeared %d times, want 1", matches)
+	}
+}
+
+func TestScanCandidatesKeepsDistinctCaseSensitiveDirectories(t *testing.T) {
+	home := t.TempDir()
+	if caseInsensitiveFS(t, home) {
+		t.Skip("filesystem is case-insensitive; both spellings name one folder")
+	}
+	for _, name := range []string{"Projects", "projects"} {
+		if err := os.Mkdir(filepath.Join(home, name), 0755); err != nil {
+			t.Fatalf("mkdir %q: %v", name, err)
+		}
+	}
+
+	dirs := scanCandidates(home)
+
+	matches := 0
+	for _, d := range dirs {
+		if strings.EqualFold(filepath.Base(d), "projects") {
+			matches++
+		}
+	}
+	if matches != 2 {
+		t.Fatalf("distinct projects directories appeared %d times, want 2", matches)
+	}
+}
+
+func TestWorkspaceSwitchByCaseVariantPath(t *testing.T) {
+	r, _, mgr, tmpDir := setupWorkspaceTest(t)
+	if !caseInsensitiveFS(t, tmpDir) {
+		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
+	}
+	projDir := filepath.Join(tmpDir, "test-project")
+	registered := mgr.GetRegistry().FindByPath(projDir)
+	if registered == nil {
+		t.Fatal("test project was not registered")
+	}
+
+	body, _ := json.Marshal(map[string]string{"path": strings.ToLower(projDir)})
+	req := httptest.NewRequest("POST", "/workspaces/switch", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /workspaces/switch status = %d, want 200", w.Code)
+	}
+
+	var got registry.Project
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.ID != registered.ID {
+		t.Fatalf("ID = %q, want the already registered %q", got.ID, registered.ID)
+	}
+	if len(mgr.GetRegistry().Projects) != 1 {
+		t.Fatalf("expected 1 project after switching by another spelling, got %d",
+			len(mgr.GetRegistry().Projects))
 	}
 }

--- a/internal/server/routes/workspace_test.go
+++ b/internal/server/routes/workspace_test.go
@@ -15,6 +15,22 @@ import (
 	"github.com/howznguyen/knowns/internal/storage"
 )
 
+// canonicalTempDir returns t.TempDir() spelled the way the OS itself reports
+// it. The Windows runners hand tests a TMP path holding the 8.3 short name
+// RUNNER~1, which is an alias rather than the directory's real name, so a test
+// comparing against the raw value asserts against exactly the spelling
+// CanonicalPath exists to collapse. EvalSymlinks reads the real name from the
+// OS, independently of the code under test.
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return dir
+	}
+	return resolved
+}
+
 // fakeBroadcaster records broadcast calls for assertions.
 type fakeBroadcaster struct {
 	events []SSEEvent
@@ -27,7 +43,7 @@ func (fb *fakeBroadcaster) Broadcast(e SSEEvent) {
 // setupWorkspaceTest creates a test environment with registry, manager, and router.
 func setupWorkspaceTest(t *testing.T) (*chi.Mux, *fakeBroadcaster, *storage.Manager, string) {
 	t.Helper()
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 
 	// Create a fake project with .knowns/config.json
 	projDir := filepath.Join(tmpDir, "test-project")
@@ -171,7 +187,7 @@ func caseInsensitiveFS(t *testing.T, dir string) bool {
 }
 
 func TestScanCandidatesCollapsesCaseVariantDirectories(t *testing.T) {
-	home := t.TempDir()
+	home := canonicalTempDir(t)
 	if !caseInsensitiveFS(t, home) {
 		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
 	}
@@ -205,7 +221,7 @@ func TestScanCandidatesCollapsesCaseVariantDirectories(t *testing.T) {
 }
 
 func TestScanCandidatesKeepsDistinctCaseSensitiveDirectories(t *testing.T) {
-	home := t.TempDir()
+	home := canonicalTempDir(t)
 	if caseInsensitiveFS(t, home) {
 		t.Skip("filesystem is case-insensitive; both spellings name one folder")
 	}

--- a/internal/server/server_picker_test.go
+++ b/internal/server/server_picker_test.go
@@ -13,6 +13,22 @@ import (
 	"github.com/howznguyen/knowns/internal/storage"
 )
 
+// canonicalTempDir returns t.TempDir() spelled the way the OS itself reports
+// it. The Windows runners hand tests a TMP path holding the 8.3 short name
+// RUNNER~1, which is an alias rather than the directory's real name, so a test
+// comparing against the raw value asserts against exactly the spelling
+// CanonicalPath exists to collapse. EvalSymlinks reads the real name from the
+// OS, independently of the code under test.
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return dir
+	}
+	return resolved
+}
+
 // newPickerServer creates a Server in picker mode (nil store).
 func newPickerServer(t *testing.T) *Server {
 	t.Helper()
@@ -30,7 +46,7 @@ func newPickerServer(t *testing.T) *Server {
 // newActiveServer creates a Server with a real project store.
 func newActiveServer(t *testing.T) (*Server, string) {
 	t.Helper()
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	projDir := filepath.Join(tmpDir, "my-project")
 	os.MkdirAll(filepath.Join(projDir, ".knowns"), 0755)
 	os.WriteFile(filepath.Join(projDir, ".knowns", "config.json"), []byte(`{"name":"my-project"}`), 0644)
@@ -148,7 +164,7 @@ func TestWorkspaceRoutes_AvailableInPickerMode(t *testing.T) {
 
 func TestWorkspaceSwitch_UpdatesActiveStore(t *testing.T) {
 	t.Parallel()
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 
 	// Start in picker mode (nil store)
 	proj := filepath.Join(tmpDir, "proj-a")

--- a/internal/storage/decision_review_watermark_test.go
+++ b/internal/storage/decision_review_watermark_test.go
@@ -1,0 +1,151 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/howznguyen/knowns/internal/models"
+)
+
+func reviewedDecision() *models.DecisionEntry {
+	at := time.Date(2026, 9, 3, 10, 0, 0, 0, time.UTC)
+	entry := &models.DecisionEntry{
+		ID:          "d-1",
+		Title:       "Store vectors in SQLite",
+		Status:      "accepted",
+		Decision:    "The derived index lives in .knowns/.search/index.db.",
+		ReviewState: models.DecisionReviewStateReadyForReview,
+	}
+	entry.ReviewEvaluatedAt = &at
+	entry.ReviewEvaluatedHash = CanonicalDecisionHash(entry)
+	return entry
+}
+
+// TestReviewWatermarkIgnoresReviewFields is the property the whole watermark
+// depends on: recording a review must not change the hash the review was taken
+// against, or every review would be stale the instant it was written.
+func TestReviewWatermarkIgnoresReviewFields(t *testing.T) {
+	entry := reviewedDecision()
+	before := CanonicalDecisionHash(entry)
+
+	entry.ReviewState = models.DecisionReviewStateNeedsResolution
+	entry.ReviewBlockers = []string{"missing evidence"}
+	entry.ReviewMatches = []models.DecisionReviewMatch{{ID: "d-2", Score: 0.91}}
+	entry.ReviewAllowedResolutions = []string{"supersede"}
+	later := time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC)
+	entry.ReviewEvaluatedAt = &later
+
+	if got := CanonicalDecisionHash(entry); got != before {
+		t.Error("review fields must not feed the hash; a review would invalidate itself")
+	}
+	if DecisionReviewIsStale(entry) {
+		t.Error("recording a review must not make that review stale")
+	}
+}
+
+func TestReviewWatermarkDetectsContentChange(t *testing.T) {
+	entry := reviewedDecision()
+	if DecisionReviewIsStale(entry) {
+		t.Fatal("a freshly reviewed decision is not stale")
+	}
+
+	entry.Decision = "The derived index moved to Qdrant."
+	if !DecisionReviewIsStale(entry) {
+		t.Error("changing the decision's substance must strand the review")
+	}
+}
+
+// TestReviewWatermarkCatchesWhatATimestampCannot is the case that motivated the
+// field. Two edits landing inside the same clock reading leave ReviewEvaluatedAt
+// unable to say whether the review saw the current text; the hash still can.
+func TestReviewWatermarkCatchesWhatATimestampCannot(t *testing.T) {
+	entry := reviewedDecision()
+	sameInstant := *entry.ReviewEvaluatedAt
+
+	entry.Decision = "Edited without advancing any clock."
+	entry.UpdatedAt = sameInstant
+
+	if entry.ReviewEvaluatedAt.Before(entry.UpdatedAt) {
+		t.Fatal("this test is only meaningful when the timestamps cannot be ordered")
+	}
+	if !DecisionReviewIsStale(entry) {
+		t.Error("the hash must detect an edit that the timestamps cannot distinguish")
+	}
+}
+
+// TestReviewWatermarkAbsentIsNotStale keeps decisions written before the field
+// existed from being reported as stale, which would be a false accusation
+// rather than a finding.
+func TestReviewWatermarkAbsentIsNotStale(t *testing.T) {
+	entry := reviewedDecision()
+	entry.ReviewEvaluatedHash = ""
+	if DecisionReviewIsStale(entry) {
+		t.Error("a decision predating the watermark is unverifiable, not stale")
+	}
+	if DecisionReviewIsStale(nil) {
+		t.Error("nil must not be reported as stale")
+	}
+}
+
+// TestReviewWatermarkSurvivesPersistReload is the test whose absence let two
+// bugs through. Both were round-trip failures invisible to an in-memory check:
+// the hash mixed the section fields with Content (empty on write, populated on
+// read), and empty slices hashed differently from the nil slices the YAML
+// reader produces. Either one made every freshly created decision report its
+// own review as stale.
+func TestReviewWatermarkSurvivesPersistReload(t *testing.T) {
+	store := setupDecisionStore(t)
+	createdAt := time.Date(2026, 9, 3, 10, 0, 0, 0, time.UTC)
+
+	draft := &models.DecisionEntry{
+		Title:    "Keep markdown as the record",
+		Context:  "Three audiences read the store and share no client.",
+		Decision: "Markdown stays the source of truth.",
+	}
+	if err := store.Decisions.Create(draft, DecisionCreateOptions{Now: createdAt}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Stamp the watermark the way the review service does, then persist.
+	draft.ReviewState = models.DecisionReviewStateReadyForReview
+	draft.ReviewEvaluatedAt = &createdAt
+	draft.ReviewEvaluatedHash = CanonicalDecisionHash(draft)
+	if err := store.Decisions.Update(draft); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	loaded, err := store.Decisions.Get(draft.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if loaded.ReviewEvaluatedHash != draft.ReviewEvaluatedHash {
+		t.Fatalf("watermark did not persist: got %q, want %q", loaded.ReviewEvaluatedHash, draft.ReviewEvaluatedHash)
+	}
+	if got := CanonicalDecisionHash(loaded); got != draft.ReviewEvaluatedHash {
+		t.Errorf("hash is not stable across persist/reload:\n  wrote %s\n  read  %s", draft.ReviewEvaluatedHash, got)
+	}
+	if DecisionReviewIsStale(loaded) {
+		t.Error("a decision reported its own review as stale immediately after reload")
+	}
+
+	// After a load, Content holds the authoritative body and the section
+	// fields are derived views of it, so an edit is a change to Content. This
+	// mirrors the real case the watermark exists for: something rewrote the
+	// markdown outside the review.
+	edited := *loaded
+	edited.Content = strings.Replace(loaded.Content, "source of truth", "cache", 1)
+	if edited.Content == loaded.Content {
+		t.Fatal("test setup failed to change the body")
+	}
+	if !DecisionReviewIsStale(&edited) {
+		t.Error("a rewritten body must strand the review")
+	}
+
+	// A frontmatter change counts too, and does not depend on body semantics.
+	tagged := *loaded
+	tagged.Tags = []string{"storage"}
+	if !DecisionReviewIsStale(&tagged) {
+		t.Error("a frontmatter change must strand the review")
+	}
+}

--- a/internal/storage/decision_store.go
+++ b/internal/storage/decision_store.go
@@ -20,6 +20,55 @@ type DecisionStore struct {
 	writeFile     func(string, []byte) error
 }
 
+// CanonicalDecisionHash identifies the substance a reviewer judged: the
+// decision's own content and relationships, with every review field and
+// timestamp excluded. Excluding them is what makes the hash usable as a review
+// watermark; if writing the review changed the hash, the review would be stale
+// the instant it was recorded.
+func CanonicalDecisionHash(entry *models.DecisionEntry) string {
+	if entry == nil {
+		return ""
+	}
+	// ID is deliberately absent. It is assigned inside Create, after the review
+	// that records this hash has already run, so including it guaranteed a
+	// mismatch on every freshly created decision. It also never changes, so it
+	// tells a change detector nothing.
+	return hashSnapshot(map[string]any{
+		"title": entry.Title, "status": entry.Status,
+		"supersedes": canonicalList(entry.Supersedes), "supersededBy": canonicalList(entry.SupersededBy),
+		"tags": canonicalList(entry.Tags), "sources": canonicalList(entry.Sources),
+		"relatedDocs": canonicalList(entry.RelatedDocs), "relatedTasks": canonicalList(entry.RelatedTasks),
+		"verification": canonicalList(entry.Verification), "verifiedAt": entry.VerifiedAt,
+		// The body is hashed in its canonical rendered form, the same one the
+		// store writes. Hashing the section fields and Content separately does
+		// not round-trip: on write the sections are set and Content is empty,
+		// while on read Content holds the rendered body. It also loses body
+		// text that lives outside the four known sections.
+		"body": renderDecisionBody(entry),
+	})
+}
+
+// canonicalList collapses an empty slice and a nil slice to one value. The
+// write path builds empty slices while the YAML reader leaves them nil, and
+// without this every freshly created decision hashed differently on reload and
+// reported its own review as stale.
+func canonicalList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
+// DecisionReviewIsStale reports whether a recorded review was made against a
+// state the decision has since left. A review with no recorded state is not
+// stale, only unverifiable: it predates the watermark.
+func DecisionReviewIsStale(entry *models.DecisionEntry) bool {
+	if entry == nil || entry.ReviewEvaluatedHash == "" {
+		return false
+	}
+	return entry.ReviewEvaluatedHash != CanonicalDecisionHash(entry)
+}
+
 func (ds *DecisionStore) decisionsDir() string { return filepath.Join(ds.root, "decisions") }
 
 type decisionFrontmatter struct {
@@ -39,6 +88,7 @@ type decisionFrontmatter struct {
 	ReviewMatches            []models.DecisionReviewMatch `yaml:"reviewMatches,omitempty"`
 	ReviewAllowedResolutions []string                     `yaml:"reviewAllowedResolutions,omitempty"`
 	ReviewEvaluatedAt        string                       `yaml:"reviewEvaluatedAt,omitempty"`
+	ReviewEvaluatedHash      string                       `yaml:"reviewEvaluatedHash,omitempty"`
 	CreatedAt                string                       `yaml:"createdAt"`
 	UpdatedAt                string                       `yaml:"updatedAt"`
 }
@@ -391,6 +441,7 @@ func (ds *DecisionStore) Accept(id string, verification []string, supersedes []s
 		decision.ReviewMatches = nil
 		decision.ReviewAllowedResolutions = nil
 		decision.ReviewEvaluatedAt = nil
+		decision.ReviewEvaluatedHash = ""
 		decision.UpdatedAt = verifiedAt
 
 		seen := map[string]bool{}
@@ -607,6 +658,7 @@ func parseDecisionContent(content string) (*models.DecisionEntry, error) {
 			decision.VerifiedAt = &parsed
 		}
 	}
+	decision.ReviewEvaluatedHash = fm.ReviewEvaluatedHash
 	if fm.ReviewEvaluatedAt != "" {
 		if parsed, err := parseISO(fm.ReviewEvaluatedAt); err == nil {
 			decision.ReviewEvaluatedAt = &parsed
@@ -696,11 +748,15 @@ func renderDecision(decision *models.DecisionEntry) string {
 		len(decision.ReviewBlockers) > 0 ||
 		len(decision.ReviewMatches) > 0 ||
 		len(decision.ReviewAllowedResolutions) > 0 ||
+		decision.ReviewEvaluatedHash != "" ||
 		decision.ReviewEvaluatedAt != nil {
 		fmt.Fprintf(&b, "reviewState: %s\n", yamlScalar(decision.ReviewState))
 		writeYAMLStringList(&b, "reviewBlockers", decision.ReviewBlockers)
 		writeDecisionReviewMatches(&b, decision.ReviewMatches)
 		writeYAMLStringList(&b, "reviewAllowedResolutions", decision.ReviewAllowedResolutions)
+		if decision.ReviewEvaluatedHash != "" {
+			fmt.Fprintf(&b, "reviewEvaluatedHash: '%s'\n", decision.ReviewEvaluatedHash)
+		}
 		if decision.ReviewEvaluatedAt != nil {
 			fmt.Fprintf(&b, "reviewEvaluatedAt: '%s'\n", formatISO(*decision.ReviewEvaluatedAt))
 		}
@@ -730,6 +786,9 @@ func writeDecisionReviewMatches(b *strings.Builder, matches []models.DecisionRev
 		fmt.Fprintf(b, "    score: %.6f\n", match.Score)
 		if match.Kind != "" {
 			fmt.Fprintf(b, "    kind: %s\n", yamlScalar(match.Kind))
+		}
+		if match.Hash != "" {
+			fmt.Fprintf(b, "    hash: %s\n", yamlScalar(match.Hash))
 		}
 		writeIndentedYAMLStringList(b, "matchedBy", match.MatchedBy, 4)
 		if match.Snippet != "" {

--- a/internal/storage/embedding_settings_store.go
+++ b/internal/storage/embedding_settings_store.go
@@ -240,6 +240,17 @@ type EmbeddingSettingsStore struct {
 	filePath string
 }
 
+// GlobalSkillsScopeDefault returns the machine-wide skills scope recorded in
+// ~/.knowns/settings.json, or "" when none is set. Errors are reported as ""
+// so a missing or unreadable global file simply means "no default".
+func GlobalSkillsScopeDefault() string {
+	settings, err := NewEmbeddingSettingsStore().Load()
+	if err != nil || settings == nil || settings.ProjectDefaults == nil {
+		return ""
+	}
+	return settings.ProjectDefaults.Settings.SkillsScope
+}
+
 // NewEmbeddingSettingsStore creates a store with the default path (~/.knowns/settings.json).
 func NewEmbeddingSettingsStore() *EmbeddingSettingsStore {
 	home, _ := os.UserHomeDir()

--- a/internal/storage/history_jsonl.go
+++ b/internal/storage/history_jsonl.go
@@ -538,12 +538,11 @@ func metadataRecord(raw map[string]json.RawMessage) (models.HistoryRecord, error
 
 func validateMetadataRecord(raw map[string]json.RawMessage, record models.HistoryRecord, expected int, previous []models.HistoryRecord, entityType, entityID string) error {
 	recordHash := record.RecordHash
-	data, err := marshalMetadataForHash(raw)
+	computed, err := metadataRecordHash(raw)
 	if err != nil {
 		return err
 	}
-	hash := sha256.Sum256(data)
-	if recordHash == "" || recordHash != hex.EncodeToString(hash[:]) {
+	if recordHash == "" || recordHash != computed {
 		return fmt.Errorf("%w: record hash mismatch at revision %d", ErrHistoryCorrupt, expected)
 	}
 	return validateHistoryEnvelope(record, expected, previous, entityType, entityID, rawCheckpointPayloadPresent(raw), true)
@@ -589,17 +588,27 @@ type historyRecordWire struct {
 	CheckpointPayload json.RawMessage        `json:"checkpointPayload,omitempty"`
 }
 
-func marshalMetadataForHash(raw map[string]json.RawMessage) ([]byte, error) {
+// metadataRecordHash recomputes a record hash from the raw line so the metadata
+// reader validates with exactly the function that wrote the hash.
+//
+// It must not hash the file's bytes directly. `historyRecordHash` normalizes a
+// record through `models.HistoryRecord`, where `TaskChange.OldValue` and
+// `NewValue` are `any` and therefore become `map[string]any`, whose keys Go
+// marshals in sorted order. On disk the same values keep the field order of the
+// struct they were written from. Any record whose changes carry a nested object
+// - an acceptance criterion, for instance - therefore hashes one way when
+// written and another when read back verbatim, and a perfectly intact history
+// gets reported as corrupt.
+func metadataRecordHash(raw map[string]json.RawMessage) (string, error) {
 	data, err := json.Marshal(raw)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	var wire historyRecordWire
-	if err := json.Unmarshal(data, &wire); err != nil {
-		return nil, err
+	var record models.HistoryRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return "", err
 	}
-	wire.RecordHash = ""
-	return json.Marshal(wire)
+	return historyRecordHash(record), nil
 }
 
 // FindEntityByPath locates a Doc history by its current or historical path.

--- a/internal/storage/history_metadata_hash_test.go
+++ b/internal/storage/history_metadata_hash_test.go
@@ -1,0 +1,85 @@
+package storage
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/howznguyen/knowns/internal/models"
+)
+
+// TestMetadataHashMatchesWriterForNestedChangeValues pins the defect that made
+// an intact history read as corrupt.
+//
+// `TaskChange.OldValue` and `NewValue` are `any`, so a nested object round-trips
+// as `map[string]any`, whose keys Go marshals sorted. On disk the same value
+// keeps the field order of the struct it was written from. Hashing the file's
+// bytes verbatim therefore disagrees with the hash the writer computed, and
+// only for records whose changes carry a nested object - which is why records
+// holding nothing but scalar changes validated fine and hid this for weeks.
+func TestMetadataHashMatchesWriterForNestedChangeValues(t *testing.T) {
+	record := models.HistoryRecord{
+		SchemaVersion: 1,
+		EntityType:    "task",
+		EntityID:      "abc123",
+		Revision:      1,
+		TaskChanges: []models.TaskChange{{
+			Field:    "acceptanceCriteria",
+			OldValue: nil,
+			// Text is declared before Completed, so the on-disk bytes read
+			// {"text":...,"completed":...} while a map re-marshal sorts them
+			// the other way round.
+			NewValue: []models.AcceptanceCriterion{{Text: "criterion", Completed: false}},
+		}},
+	}
+	record.RecordHash = historyRecordHash(record)
+
+	line, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(line, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+
+	computed, err := metadataRecordHash(raw)
+	if err != nil {
+		t.Fatalf("metadataRecordHash: %v", err)
+	}
+	if computed != record.RecordHash {
+		t.Fatalf("metadata hash = %s, writer hash = %s; the reader must use the writer's normalization", computed, record.RecordHash)
+	}
+}
+
+// TestMetadataHashStillDetectsTampering makes sure the fix did not turn the
+// integrity check into a formality that accepts anything.
+func TestMetadataHashStillDetectsTampering(t *testing.T) {
+	record := models.HistoryRecord{
+		SchemaVersion: 1,
+		EntityType:    "task",
+		EntityID:      "abc123",
+		Revision:      1,
+		TaskChanges: []models.TaskChange{{
+			Field:    "acceptanceCriteria",
+			NewValue: []models.AcceptanceCriterion{{Text: "criterion"}},
+		}},
+	}
+	record.RecordHash = historyRecordHash(record)
+
+	record.TaskChanges[0].NewValue = []models.AcceptanceCriterion{{Text: "tampered"}}
+	line, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(line, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	computed, err := metadataRecordHash(raw)
+	if err != nil {
+		t.Fatalf("metadataRecordHash: %v", err)
+	}
+	if computed == record.RecordHash {
+		t.Fatal("a tampered payload produced the stored hash")
+	}
+}

--- a/internal/storage/mutation_transaction.go
+++ b/internal/storage/mutation_transaction.go
@@ -212,6 +212,13 @@ func (s *Store) CreateTaskWithHistoryPrefixed(ctx context.Context, task *models.
 					return fmt.Errorf("resolve default task ID prefix: %w", err)
 				}
 				effectivePrefix = project.Settings.DefaultTaskIDPrefix
+				if effectivePrefix == "" {
+					// Every new task gets a prefix, so its file name carries
+					// the project it belongs to. Existing unprefixed IDs are
+					// left alone: an ID is an identity, and rewriting one
+					// breaks every @task- reference already pointing at it.
+					effectivePrefix = models.DeriveTaskIDPrefix(project.Name)
+				}
 			}
 			id, err := s.Tasks.allocateTaskIDUnlocked(effectivePrefix)
 			if err != nil {

--- a/internal/storage/task_filename_test.go
+++ b/internal/storage/task_filename_test.go
@@ -1,0 +1,63 @@
+package storage
+
+import "testing"
+
+// TestTaskFileMatchesEveryWrittenForm is the compatibility contract. Projects
+// in the field hold files written under all three names, and a store that
+// stopped resolving any of them would lose those tasks silently rather than
+// loudly.
+func TestTaskFileMatchesEveryWrittenForm(t *testing.T) {
+	cases := []struct {
+		name, id string
+		want     bool
+	}{
+		{"abc123.md", "abc123", true},                       // canonical
+		{"task-abc123.md", "abc123", true},                  // legacy, untitled
+		{"task-abc123 - Fix login bug.md", "abc123", true},  // legacy, titled
+		{"KN-7F3K9M.md", "KN-7F3K9M", true},                 // prefixed, canonical
+		{"task-KN-7F3K9M - Add auth.md", "KN-7F3K9M", true}, // prefixed, legacy
+
+		{"abc124.md", "abc123", false},
+		{"task-abc1234.md", "abc123", false},
+		{"abc123.txt", "abc123", false},
+		{"notes-abc123.md", "abc123", false},
+	}
+
+	for _, tc := range cases {
+		if got := TaskFileMatches(tc.name, tc.id); got != tc.want {
+			t.Errorf("TaskFileMatches(%q, %q) = %v, want %v", tc.name, tc.id, got, tc.want)
+		}
+	}
+}
+
+// TestTaskFileMatchesPrefersCanonicalOverLegacyShape guards the one collision
+// the two naming schemes can produce: a project whose configured prefix is
+// "TASK" writes "TASK-ABC123.md", which on a case-insensitive filesystem also
+// reads as the legacy "task-<id>.md" shape for some other id.
+func TestTaskFileMatchesPrefersCanonicalOverLegacyShape(t *testing.T) {
+	if !TaskFileMatches("TASK-ABC123.md", "TASK-ABC123") {
+		t.Error("a task whose ID begins with a TASK prefix must match its own canonical file")
+	}
+	if TaskFileMatches("TASK-ABC123.md", "ABC123") {
+		t.Error("the canonical file of one task must not be claimed by another id")
+	}
+}
+
+// TestIDFromFilenameReadsEveryForm covers the bug the old regexp carried: for
+// "task-abc123.md" it captured "abc123.md", extension included. It had no
+// callers, so nothing failed; changing the written format would have woken it.
+func TestIDFromFilenameReadsEveryForm(t *testing.T) {
+	cases := map[string]string{
+		"abc123.md":                      "abc123",
+		"task-abc123.md":                 "abc123",
+		"task-abc123 - Fix login bug.md": "abc123",
+		"KN-7F3K9M.md":                   "KN-7F3K9M",
+		"task-KN-7F3K9M - Add auth.md":   "KN-7F3K9M",
+		"":                               "",
+	}
+	for name, want := range cases {
+		if got := IDFromFilename(name); got != want {
+			t.Errorf("IDFromFilename(%q) = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/internal/storage/task_id_prefix_default_test.go
+++ b/internal/storage/task_id_prefix_default_test.go
@@ -1,0 +1,86 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/howznguyen/knowns/internal/models"
+)
+
+func setupPrefixStore(t *testing.T, projectName string) *Store {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	store := NewStore(filepath.Join(t.TempDir(), ".knowns"))
+	if err := store.Init(projectName); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	return store
+}
+
+func createTaskWithGeneratedID(t *testing.T, store *Store, title string) *models.Task {
+	t.Helper()
+	task := &models.Task{Title: title, Status: "todo", Priority: "medium"}
+	if err := store.CreateTaskWithHistory(context.Background(), task, models.TaskVersion{}); err != nil {
+		t.Fatalf("create %q: %v", title, err)
+	}
+	return task
+}
+
+// TestGeneratedTaskIDsCarryADerivedPrefix covers the case that used to produce
+// a bare ID: a project that never configured defaultTaskIdPrefix. The prefix
+// now comes from the project name, so a task file names the project it belongs
+// to instead of being six anonymous characters.
+func TestGeneratedTaskIDsCarryADerivedPrefix(t *testing.T) {
+	store := setupPrefixStore(t, "Knowns")
+	task := createTaskWithGeneratedID(t, store, "First task")
+
+	if !strings.HasPrefix(task.ID, "KN-") {
+		t.Errorf("generated ID = %q, want a KN- prefix derived from the project name", task.ID)
+	}
+	if _, err := store.Tasks.Get(task.ID); err != nil {
+		t.Errorf("the generated task must be readable back: %v", err)
+	}
+}
+
+// TestConfiguredPrefixWinsOverDerivation keeps derivation as a fallback rather
+// than an override.
+func TestConfiguredPrefixWinsOverDerivation(t *testing.T) {
+	store := setupPrefixStore(t, "Knowns")
+	project, err := store.Config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	project.Settings.DefaultTaskIDPrefix = "OPS"
+	if err := store.Config.Save(project); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	task := createTaskWithGeneratedID(t, store, "Configured")
+	if !strings.HasPrefix(task.ID, "OPS-") {
+		t.Errorf("generated ID = %q, want the configured OPS- prefix", task.ID)
+	}
+}
+
+// TestExistingUnprefixedIDsAreLeftAlone is the promise made when prefixes
+// became automatic. An ID is an identity: rewriting one breaks every
+// @task-<id> reference already pointing at it, so old tasks keep their names.
+func TestExistingUnprefixedIDsAreLeftAlone(t *testing.T) {
+	store := setupPrefixStore(t, "Knowns")
+
+	legacy := &models.Task{ID: "abc123", Title: "Written before prefixes", Status: "todo", Priority: "medium"}
+	if err := store.Tasks.Create(legacy); err != nil {
+		t.Fatalf("Create legacy: %v", err)
+	}
+
+	createTaskWithGeneratedID(t, store, "Written after prefixes")
+
+	loaded, err := store.Tasks.Get("abc123")
+	if err != nil {
+		t.Fatalf("legacy task must still resolve by its original ID: %v", err)
+	}
+	if loaded.ID != "abc123" {
+		t.Errorf("legacy ID = %q, want it untouched", loaded.ID)
+	}
+}

--- a/internal/storage/task_id_prefix_test.go
+++ b/internal/storage/task_id_prefix_test.go
@@ -29,14 +29,19 @@ func newPrefixTestStore(t *testing.T, name, defaultPrefix string) *Store {
 	return store
 }
 
-func TestCreateTaskWithHistoryUsesCustomDefaultAndLegacyIDFormats(t *testing.T) {
+// The "derived fallback" row used to be a "legacy fallback" asserting a bare
+// six-character ID for an unconfigured project. Generation now always produces
+// PREFIX-XXXXXX, deriving the prefix from the project name when nothing is
+// configured. IDs already written without a prefix are untouched and still
+// resolve; see TestExistingUnprefixedIDsAreLeftAlone.
+func TestCreateTaskWithHistoryUsesCustomDefaultAndDerivedIDFormats(t *testing.T) {
 	tests := []struct {
 		name          string
 		defaultPrefix string
 		customPrefix  string
 		pattern       string
 	}{
-		{name: "legacy fallback", pattern: `^[0-9a-z]{6}$`},
+		{name: "derived fallback", pattern: `^CTIT-[0-9A-HJKMNP-TV-Z]{6}$`},
 		{name: "project default", defaultPrefix: "KN", pattern: `^KN-[0-9A-HJKMNP-TV-Z]{6}$`},
 		{name: "custom override", defaultPrefix: "KN", customPrefix: "fr", pattern: `^FR-[0-9A-HJKMNP-TV-Z]{6}$`},
 		// A custom prefix equal to the default must still be honored explicitly.

--- a/internal/storage/task_store.go
+++ b/internal/storage/task_store.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -189,15 +188,12 @@ func (ts *TaskStore) scanForID(dir, id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	prefix := "task-" + id + " - "
-	exact := "task-" + id + ".md"
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
-		n := e.Name()
-		if n == exact || strings.HasPrefix(n, prefix) {
-			return filepath.Join(dir, n), nil
+		if TaskFileMatches(e.Name(), id) {
+			return filepath.Join(dir, e.Name()), nil
 		}
 	}
 	return "", fmt.Errorf("task %q not found in %s", id, dir)
@@ -296,7 +292,7 @@ func (ts *TaskStore) createUnlocked(task *models.Task) error {
 	if err := os.MkdirAll(ts.tasksDir(), 0755); err != nil {
 		return fmt.Errorf("create task dir: %w", err)
 	}
-	path := filepath.Join(ts.tasksDir(), taskFilename(task.ID, task.Title))
+	path := filepath.Join(ts.tasksDir(), taskFilename(task.ID))
 	return ts.writeFile(path, task)
 }
 
@@ -343,10 +339,8 @@ func (ts *TaskStore) deleteAllUnlocked(id string) (int, error) {
 		if err != nil {
 			return removed, err
 		}
-		prefix := "task-" + id + " - "
-		exact := "task-" + id + ".md"
 		for _, entry := range entries {
-			if entry.IsDir() || (entry.Name() != exact && !strings.HasPrefix(entry.Name(), prefix)) {
+			if entry.IsDir() || !TaskFileMatches(entry.Name(), id) {
 				continue
 			}
 			if err := os.Remove(filepath.Join(dir, entry.Name())); err != nil && !os.IsNotExist(err) {
@@ -840,13 +834,20 @@ func formatISO(t time.Time) string {
 }
 
 // taskIDPattern extracts the ID from a task filename.
-var taskIDPattern = regexp.MustCompile(`^task-([^ ]+)`)
-
-// IDFromFilename extracts a task ID from a filename like "task-abc123 - My Task.md".
+// IDFromFilename extracts a task ID from any filename this store has written:
+// "abc123.md", "task-abc123.md", or "task-abc123 - My Task.md". The legacy
+// untitled form is why the extension has to be trimmed explicitly; the old
+// pattern captured "abc123.md" for it and no caller noticed.
 func IDFromFilename(filename string) string {
-	m := taskIDPattern.FindStringSubmatch(filename)
-	if len(m) < 2 {
+	name := strings.TrimSuffix(filename, ".md")
+	if name == "" {
 		return ""
 	}
-	return m[1]
+	if rest, ok := strings.CutPrefix(name, "task-"); ok {
+		name = rest
+	}
+	if before, _, found := strings.Cut(name, " - "); found {
+		name = before
+	}
+	return strings.TrimSpace(name)
 }

--- a/internal/storage/util.go
+++ b/internal/storage/util.go
@@ -81,8 +81,28 @@ func sanitizeTitle(title string) string {
 }
 
 // taskFilename returns the canonical filename for a task.
-func taskFilename(id, title string) string {
-	return "task-" + id + " - " + sanitizeTitle(title) + ".md"
+// taskFilename delegates so that the canonical name has exactly one definition.
+// It previously had three, in three packages, which is how two of them came to
+// describe a format the store no longer wrote.
+func taskFilename(id string) string {
+	return models.TaskFileName(id)
+}
+
+// TaskFileMatches reports whether name is the file for id, in any of the three
+// forms this store has written. The canonical form is checked first, so an ID
+// that itself begins with "task-" can never be mistaken for a legacy name.
+//
+// It is exported because tests outside this package need the same answer, and
+// each hand-rolled copy of this rule is a place the naming change can be missed.
+//
+//	<id>.md                     canonical
+//	task-<id>.md                legacy, untitled
+//	task-<id> - <slug>.md       legacy, titled
+func TaskFileMatches(name, id string) bool {
+	if name == id+".md" {
+		return true
+	}
+	return name == "task-"+id+".md" || strings.HasPrefix(name, "task-"+id+" - ")
 }
 
 // extractSection returns the content between <!-- SECTION:TYPE:BEGIN --> /

--- a/internal/tasklifecycle/service_test.go
+++ b/internal/tasklifecycle/service_test.go
@@ -1334,11 +1334,23 @@ func countID(tasks []*models.Task, id string) int {
 	return count
 }
 
+// taskFilePath finds a task file under any name the store has written, using
+// the store's own matcher so this helper cannot drift from it.
 func taskFilePath(t *testing.T, root, directory, id string) string {
 	t.Helper()
-	matches, err := filepath.Glob(filepath.Join(root, directory, "task-"+id+"*.md"))
-	if err != nil || len(matches) != 1 {
-		t.Fatalf("find Task %s in %s: matches=%v err=%v", id, directory, matches, err)
+	dir := filepath.Join(root, directory)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("find Task %s in %s: %v", id, directory, err)
+	}
+	var matches []string
+	for _, entry := range entries {
+		if !entry.IsDir() && storage.TaskFileMatches(entry.Name(), id) {
+			matches = append(matches, filepath.Join(dir, entry.Name()))
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("find Task %s in %s: matches=%v", id, directory, matches)
 	}
 	return matches[0]
 }

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -45,11 +45,6 @@ func SanitizeTitle(title string) string {
 	return s
 }
 
-// TaskFileName returns the filename for a task: task-{id} - {sanitized-title}.md
-func TaskFileName(id, title string) string {
-	return fmt.Sprintf("task-%s - %s.md", id, SanitizeTitle(title))
-}
-
 // ParseDuration parses duration strings like "2h", "30m", "1h30m" into seconds.
 func ParseDuration(s string) (int, error) {
 	s = strings.TrimSpace(strings.ToLower(s))

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -17,9 +17,13 @@ import (
 // case-sensitive the exact spelling matches first, so two genuinely distinct
 // directories keep their own paths.
 //
-// Components that do not exist on disk keep the caller's spelling, and any
-// error while resolving leaves the remainder of the path untouched, so the
-// result is always usable as a path.
+// A component that cannot be resolved keeps the caller's spelling and the walk
+// carries on into the components below it. Resolution reads a parent's
+// directory listing, so a component the listing never names — a Windows 8.3
+// short name such as RUNNER~1, which the filesystem still opens — must not
+// stop the deeper components from being canonicalized. Where the directory is
+// genuinely absent the components below it fail to resolve too and keep their
+// own spelling, so the result is always usable as a path.
 func CanonicalPath(path string) string {
 	if path == "" {
 		return path
@@ -37,12 +41,12 @@ func CanonicalPath(path string) string {
 		return current
 	}
 
-	components := strings.Split(rest, string(filepath.Separator))
-	for i, component := range components {
+	for _, component := range strings.Split(rest, string(filepath.Separator)) {
 		match, ok := onDiskName(current, component)
 		if !ok {
-			// Unresolvable from here down; keep what the caller spelled.
-			return filepath.Join(append([]string{current}, components[i:]...)...)
+			// Not in the parent's listing: keep what the caller spelled and
+			// keep walking, since the directory may still open under that name.
+			match = component
 		}
 		current = filepath.Join(current, match)
 	}

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -18,12 +18,14 @@ import (
 // directories keep their own paths.
 //
 // A component that cannot be resolved keeps the caller's spelling and the walk
-// carries on into the components below it. Resolution reads a parent's
-// directory listing, so a component the listing never names — a Windows 8.3
-// short name such as RUNNER~1, which the filesystem still opens — must not
-// stop the deeper components from being canonicalized. Where the directory is
-// genuinely absent the components below it fail to resolve too and keep their
-// own spelling, so the result is always usable as a path.
+// carries on into the components below it, so a directory that is absent or
+// unreadable never strands the rest of the path.
+//
+// Resolution reads a parent's directory listing, and a component the listing
+// never names still has to collapse: a Windows 8.3 short name such as RUNNER~1
+// opens fine but is not enumerated, so keeping the caller's spelling there
+// would let RUNNER~1 and runner~1 canonicalize to two different strings for
+// one directory.
 func CanonicalPath(path string) string {
 	if path == "" {
 		return path
@@ -54,10 +56,9 @@ func CanonicalPath(path string) string {
 }
 
 // onDiskName resolves name against the entries of dir, returning the spelling
-// stored on disk. An exact match always wins. A case-insensitive match is only
-// accepted when the filesystem itself treats both spellings as the same
-// directory, so on a case-sensitive filesystem a missing name never silently
-// resolves to a differently cased sibling.
+// stored on disk. An exact match always wins. Any other match has to be proved
+// with os.SameFile, so on a case-sensitive filesystem a missing name never
+// silently resolves to a differently cased sibling.
 func onDiskName(dir, name string) (string, bool) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -73,22 +74,44 @@ func onDiskName(dir, name string) (string, bool) {
 			folded = entry.Name()
 		}
 	}
-	if folded == "" {
-		return "", false
-	}
 
+	// Everything below has to open the requested name. When it does not exist
+	// there is nothing to resolve, and this also keeps the scan further down
+	// off the common path.
 	requested, err := os.Lstat(filepath.Join(dir, name))
 	if err != nil {
 		return "", false
 	}
-	existing, err := os.Lstat(filepath.Join(dir, folded))
-	if err != nil {
-		return "", false
+
+	if folded != "" {
+		existing, err := os.Lstat(filepath.Join(dir, folded))
+		if err != nil || !os.SameFile(requested, existing) {
+			return "", false
+		}
+		return folded, true
 	}
-	if !os.SameFile(requested, existing) {
-		return "", false
+
+	// The listing never names it, yet it opens: an alias the directory does not
+	// enumerate, such as a Windows 8.3 short name. Reading the spelling back is
+	// impossible, so find the entry it refers to instead. Without this,
+	// C:\Users\RUNNER~1 and C:\Users\runner~1 each keep the caller's spelling
+	// and one directory canonicalizes to two different strings.
+	return nameOfSameFile(dir, entries, requested)
+}
+
+// nameOfSameFile returns the entry of dir that names the same file as
+// requested, identifying it by the file itself rather than by its spelling.
+func nameOfSameFile(dir string, entries []os.DirEntry, requested os.FileInfo) (string, bool) {
+	for _, entry := range entries {
+		existing, err := os.Lstat(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		if os.SameFile(requested, existing) {
+			return entry.Name(), true
+		}
 	}
-	return folded, true
+	return "", false
 }
 
 // canonicalVolume normalizes a Windows drive letter, which is case-insensitive

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -1,0 +1,98 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CanonicalPath returns path with every component rewritten to the spelling
+// that actually exists on disk.
+//
+// Windows and the default macOS filesystem are case-insensitive, so
+// C:\Users\me\Projects\app and C:\Users\me\projects\app name one directory
+// while comparing as two different strings. Resolving each component against
+// its parent's directory listing collapses those spellings onto a single key
+// without branching on the operating system: where a filesystem is
+// case-sensitive the exact spelling matches first, so two genuinely distinct
+// directories keep their own paths.
+//
+// Components that do not exist on disk keep the caller's spelling, and any
+// error while resolving leaves the remainder of the path untouched, so the
+// result is always usable as a path.
+func CanonicalPath(path string) string {
+	if path == "" {
+		return path
+	}
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+
+	volume := filepath.VolumeName(abs)
+	current := canonicalVolume(volume) + string(filepath.Separator)
+	rest := strings.Trim(strings.TrimPrefix(abs, volume), string(filepath.Separator))
+	if rest == "" {
+		return current
+	}
+
+	components := strings.Split(rest, string(filepath.Separator))
+	for i, component := range components {
+		match, ok := onDiskName(current, component)
+		if !ok {
+			// Unresolvable from here down; keep what the caller spelled.
+			return filepath.Join(append([]string{current}, components[i:]...)...)
+		}
+		current = filepath.Join(current, match)
+	}
+	return current
+}
+
+// onDiskName resolves name against the entries of dir, returning the spelling
+// stored on disk. An exact match always wins. A case-insensitive match is only
+// accepted when the filesystem itself treats both spellings as the same
+// directory, so on a case-sensitive filesystem a missing name never silently
+// resolves to a differently cased sibling.
+func onDiskName(dir, name string) (string, bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false
+	}
+
+	folded := ""
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return name, true
+		}
+		if folded == "" && strings.EqualFold(entry.Name(), name) {
+			folded = entry.Name()
+		}
+	}
+	if folded == "" {
+		return "", false
+	}
+
+	requested, err := os.Lstat(filepath.Join(dir, name))
+	if err != nil {
+		return "", false
+	}
+	existing, err := os.Lstat(filepath.Join(dir, folded))
+	if err != nil {
+		return "", false
+	}
+	if !os.SameFile(requested, existing) {
+		return "", false
+	}
+	return folded, true
+}
+
+// canonicalVolume normalizes a Windows drive letter, which is case-insensitive
+// and carries no on-disk casing to read back. UNC volumes and the empty Unix
+// volume keep the caller's spelling.
+func canonicalVolume(volume string) string {
+	if len(volume) == 2 && volume[1] == ':' {
+		return strings.ToUpper(volume)
+	}
+	return volume
+}

--- a/internal/util/path_test.go
+++ b/internal/util/path_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -86,5 +87,46 @@ func TestCanonicalPathKeepsMissingComponents(t *testing.T) {
 func TestCanonicalPathEmptyInput(t *testing.T) {
 	if got := CanonicalPath(""); got != "" {
 		t.Fatalf("CanonicalPath(\"\") = %q, want empty", got)
+	}
+}
+
+// TestCanonicalPathResolvesPastAnUnlistableComponent locks the behaviour that
+// broke on Windows CI, where TMP arrives as a path containing the 8.3 short
+// name RUNNER~1: the component opens fine but never appears in its parent's
+// directory listing, so resolution has to carry on past it instead of leaving
+// the whole remainder of the path as the caller spelled it.
+//
+// An execute-only directory reproduces the same shape portably: it can be
+// traversed but not listed.
+func TestCanonicalPathResolvesPastAnUnlistableComponent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not gate listing on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root reads a directory regardless of its mode")
+	}
+
+	tmpDir := t.TempDir()
+	if !caseInsensitiveFS(t, tmpDir) {
+		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
+	}
+
+	// "inner" cannot be found in opaque's listing, standing in for RUNNER~1;
+	// the component below it still has to resolve.
+	opaque := filepath.Join(tmpDir, "opaque")
+	inner := filepath.Join(opaque, "inner")
+	dir := filepath.Join(inner, "Projects")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Execute-only: traversable, unlistable. Restored so t.TempDir can clean up.
+	if err := os.Chmod(opaque, 0111); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(opaque, 0755) })
+
+	lower := filepath.Join(inner, "projects")
+	if got := CanonicalPath(lower); got != dir {
+		t.Fatalf("CanonicalPath(%q) = %q, want %q", lower, got, dir)
 	}
 }

--- a/internal/util/path_test.go
+++ b/internal/util/path_test.go
@@ -1,0 +1,90 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// caseInsensitiveFS reports whether dir lives on a filesystem that treats two
+// spellings of one name as the same entry.
+func caseInsensitiveFS(t *testing.T, dir string) bool {
+	t.Helper()
+	probe := filepath.Join(dir, "CaseProbe")
+	if err := os.Mkdir(probe, 0755); err != nil {
+		t.Fatalf("create probe dir: %v", err)
+	}
+	defer os.RemoveAll(probe)
+	_, err := os.Stat(filepath.Join(dir, "caseprobe"))
+	return err == nil
+}
+
+func TestCanonicalPathKeepsExistingSpelling(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, "Projects")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if got := CanonicalPath(dir); got != dir {
+		t.Fatalf("CanonicalPath(%q) = %q, want unchanged", dir, got)
+	}
+}
+
+func TestCanonicalPathResolvesOnDiskCasing(t *testing.T) {
+	tmpDir := t.TempDir()
+	if !caseInsensitiveFS(t, tmpDir) {
+		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
+	}
+
+	dir := filepath.Join(tmpDir, "Projects")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	lower := filepath.Join(tmpDir, "projects")
+	if got := CanonicalPath(lower); got != dir {
+		t.Fatalf("CanonicalPath(%q) = %q, want %q", lower, got, dir)
+	}
+}
+
+func TestCanonicalPathKeepsDistinctDirectoriesApart(t *testing.T) {
+	tmpDir := t.TempDir()
+	if caseInsensitiveFS(t, tmpDir) {
+		t.Skip("filesystem is case-insensitive; both spellings name one folder")
+	}
+
+	upper := filepath.Join(tmpDir, "Projects")
+	lower := filepath.Join(tmpDir, "projects")
+	for _, dir := range []string{upper, lower} {
+		if err := os.Mkdir(dir, 0755); err != nil {
+			t.Fatalf("mkdir %q: %v", dir, err)
+		}
+	}
+
+	if got := CanonicalPath(upper); got != upper {
+		t.Fatalf("CanonicalPath(%q) = %q, want unchanged", upper, got)
+	}
+	if got := CanonicalPath(lower); got != lower {
+		t.Fatalf("CanonicalPath(%q) = %q, want unchanged", lower, got)
+	}
+}
+
+func TestCanonicalPathKeepsMissingComponents(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, "Projects")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	missing := filepath.Join(dir, "not-there", "deeper")
+	if got := CanonicalPath(missing); got != missing {
+		t.Fatalf("CanonicalPath(%q) = %q, want unchanged", missing, got)
+	}
+}
+
+func TestCanonicalPathEmptyInput(t *testing.T) {
+	if got := CanonicalPath(""); got != "" {
+		t.Fatalf("CanonicalPath(\"\") = %q, want empty", got)
+	}
+}

--- a/internal/util/path_test.go
+++ b/internal/util/path_test.go
@@ -130,3 +130,74 @@ func TestCanonicalPathResolvesPastAnUnlistableComponent(t *testing.T) {
 		t.Fatalf("CanonicalPath(%q) = %q, want %q", lower, got, dir)
 	}
 }
+
+// TestNameOfSameFileResolvesAnUnlistedSpelling covers the branch that RUNNER~1
+// takes on Windows: a name the parent's listing never enumerates, which the
+// filesystem still opens. No portable filesystem creates such an alias, so the
+// listing is narrowed by hand and a hard link supplies the second spelling of
+// one file. The real 8.3 shape is only exercised on the Windows runners.
+func TestNameOfSameFileResolvesAnUnlistedSpelling(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "Target")
+	if err := os.WriteFile(target, []byte("x"), 0644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	alias := filepath.Join(dir, "alias-not-in-listing")
+	if err := os.Link(target, alias); err != nil {
+		t.Skipf("filesystem does not support hard links: %v", err)
+	}
+
+	all, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	// Drop the alias, leaving the listing the walk would see for a name the
+	// directory does not enumerate.
+	var listed []os.DirEntry
+	for _, entry := range all {
+		if entry.Name() != filepath.Base(alias) {
+			listed = append(listed, entry)
+		}
+	}
+
+	requested, err := os.Lstat(alias)
+	if err != nil {
+		t.Fatalf("lstat alias: %v", err)
+	}
+	got, ok := nameOfSameFile(dir, listed, requested)
+	if !ok {
+		t.Fatal("nameOfSameFile found no entry naming the same file")
+	}
+	if got != "Target" {
+		t.Fatalf("nameOfSameFile = %q, want %q", got, "Target")
+	}
+}
+
+// TestNameOfSameFileRejectsAnUnrelatedEntry keeps the scan from resolving a
+// name onto whatever sibling happens to be listed.
+func TestNameOfSameFileRejectsAnUnrelatedEntry(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"one", "two"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(name), 0644); err != nil {
+			t.Fatalf("write %q: %v", name, err)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	requested, err := os.Lstat(filepath.Join(dir, "one"))
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+
+	var others []os.DirEntry
+	for _, entry := range entries {
+		if entry.Name() == "two" {
+			others = append(others, entry)
+		}
+	}
+	if got, ok := nameOfSameFile(dir, others, requested); ok {
+		t.Fatalf("nameOfSameFile = %q, want no match", got)
+	}
+}

--- a/internal/util/path_test.go
+++ b/internal/util/path_test.go
@@ -7,6 +7,22 @@ import (
 	"testing"
 )
 
+// canonicalTempDir returns t.TempDir() spelled the way the OS itself reports
+// it. The Windows runners hand tests a TMP path holding the 8.3 short name
+// RUNNER~1, which is an alias rather than the directory's real name, so a test
+// comparing against the raw value asserts against exactly the spelling
+// CanonicalPath exists to collapse. EvalSymlinks reads the real name from the
+// OS, independently of the code under test.
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return dir
+	}
+	return resolved
+}
+
 // caseInsensitiveFS reports whether dir lives on a filesystem that treats two
 // spellings of one name as the same entry.
 func caseInsensitiveFS(t *testing.T, dir string) bool {
@@ -21,7 +37,7 @@ func caseInsensitiveFS(t *testing.T, dir string) bool {
 }
 
 func TestCanonicalPathKeepsExistingSpelling(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	dir := filepath.Join(tmpDir, "Projects")
 	if err := os.Mkdir(dir, 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -33,7 +49,7 @@ func TestCanonicalPathKeepsExistingSpelling(t *testing.T) {
 }
 
 func TestCanonicalPathResolvesOnDiskCasing(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	if !caseInsensitiveFS(t, tmpDir) {
 		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
 	}
@@ -50,7 +66,7 @@ func TestCanonicalPathResolvesOnDiskCasing(t *testing.T) {
 }
 
 func TestCanonicalPathKeepsDistinctDirectoriesApart(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	if caseInsensitiveFS(t, tmpDir) {
 		t.Skip("filesystem is case-insensitive; both spellings name one folder")
 	}
@@ -72,7 +88,7 @@ func TestCanonicalPathKeepsDistinctDirectoriesApart(t *testing.T) {
 }
 
 func TestCanonicalPathKeepsMissingComponents(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	dir := filepath.Join(tmpDir, "Projects")
 	if err := os.Mkdir(dir, 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -106,7 +122,7 @@ func TestCanonicalPathResolvesPastAnUnlistableComponent(t *testing.T) {
 		t.Skip("root reads a directory regardless of its mode")
 	}
 
-	tmpDir := t.TempDir()
+	tmpDir := canonicalTempDir(t)
 	if !caseInsensitiveFS(t, tmpDir) {
 		t.Skip("filesystem is case-sensitive; the two spellings are different folders")
 	}
@@ -137,7 +153,7 @@ func TestCanonicalPathResolvesPastAnUnlistableComponent(t *testing.T) {
 // listing is narrowed by hand and a hard link supplies the second spelling of
 // one file. The real 8.3 shape is only exercised on the Windows runners.
 func TestNameOfSameFileResolvesAnUnlistedSpelling(t *testing.T) {
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	target := filepath.Join(dir, "Target")
 	if err := os.WriteFile(target, []byte("x"), 0644); err != nil {
 		t.Fatalf("write target: %v", err)
@@ -176,7 +192,7 @@ func TestNameOfSameFileResolvesAnUnlistedSpelling(t *testing.T) {
 // TestNameOfSameFileRejectsAnUnrelatedEntry keeps the scan from resolving a
 // name onto whatever sibling happens to be listed.
 func TestNameOfSameFileRejectsAnUnrelatedEntry(t *testing.T) {
-	dir := t.TempDir()
+	dir := canonicalTempDir(t)
 	for _, name := range []string{"one", "two"} {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(name), 0644); err != nil {
 			t.Fatalf("write %q: %v", name, err)

--- a/tests/deadcode_test.go
+++ b/tests/deadcode_test.go
@@ -13,19 +13,32 @@ import (
 // TestDeadCode_UnusedFunctions parses internal/cli/*.go using AST and detects
 // unexported functions that are defined but never referenced anywhere in the package.
 // Interface method implementations and init() are excluded.
+//
+// Declarations are collected from production files only, but references are
+// counted across the test files too: a helper the package's own tests exercise
+// is reachable code, and reporting it as dead would push authors to delete the
+// thing under test or to bolt on a fake production caller.
 func TestDeadCode_UnusedFunctions(t *testing.T) {
 	cliDir := filepath.Join(getProjectRoot(t), "internal", "cli")
 
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, cliDir, func(fi os.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, parser.ParseComments)
+	pkgs, err := parser.ParseDir(fset, cliDir, nil, parser.ParseComments)
 	if err != nil {
 		t.Fatalf("failed to parse cli package: %v", err)
 	}
 
-	pkg, ok := pkgs["cli"]
-	if !ok {
+	// Test files may sit in "cli" or in the external "cli_test" package; both
+	// reference the same identifiers.
+	var files []*ast.File
+	for name, pkg := range pkgs {
+		if name != "cli" && name != "cli_test" {
+			continue
+		}
+		for _, file := range pkg.Files {
+			files = append(files, file)
+		}
+	}
+	if _, ok := pkgs["cli"]; !ok {
 		t.Fatal("package 'cli' not found in internal/cli")
 	}
 
@@ -34,9 +47,12 @@ func TestDeadCode_UnusedFunctions(t *testing.T) {
 		pos  token.Position
 	}
 
-	// Collect all unexported top-level function declarations.
+	// Collect all unexported top-level function declarations, production only.
 	funcDefs := make(map[string]funcInfo)
-	for _, file := range pkg.Files {
+	for name, file := range pkgs["cli"].Files {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
 		for _, decl := range file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
 			if !ok || fn.Recv != nil {
@@ -55,7 +71,7 @@ func TestDeadCode_UnusedFunctions(t *testing.T) {
 
 	// Count all identifier usages across the package (excluding the func declaration itself).
 	usages := make(map[string]int)
-	for _, file := range pkg.Files {
+	for _, file := range files {
 		ast.Inspect(file, func(n ast.Node) bool {
 			ident, ok := n.(*ast.Ident)
 			if !ok {

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -161,11 +161,14 @@ func runCliWithTimeout(t *testing.T, dir string, timeout time.Duration, args ...
 	}
 }
 
-// taskIDRegex matches "task-<id>" format (e.g., "task-abc123").
-var taskIDRegex = regexp.MustCompile(`task-([a-z0-9]+)`)
+// taskIDRegex matches the "@task-<id>" reference format. The id half accepts
+// uppercase and a hyphen because generated IDs are prefixed (KN-A1B2C3); the
+// older unprefixed ids (abc123) still match.
+var taskIDRegex = regexp.MustCompile(`task-([A-Za-z0-9]+(?:-[A-Za-z0-9]+)?)`)
 
-// createdTaskRegex matches the Go CLI create output: "Created task <id>:" (with optional ANSI codes).
-var createdTaskRegex = regexp.MustCompile(`(?i)created\s+task\s+([a-z0-9]+)`)
+// createdTaskRegex matches the CLI create output: "Created task <id>:" (with
+// optional ANSI codes), for both prefixed and unprefixed ids.
+var createdTaskRegex = regexp.MustCompile(`(?i)created\s+task\s+([A-Za-z0-9]+(?:-[A-Za-z0-9]+)?)`)
 
 // extractTaskID extracts the first task-<id> from the given text (e.g. "task-abc123").
 func extractTaskID(output string) string {

--- a/tools/gendocs/lint.go
+++ b/tools/gendocs/lint.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Hand-written docs drift from the binary in a way generated pages cannot: they
+// show commands and flags a reader is meant to type. Before this check the repo
+// documented `knowns memory add --category` (add is not a subcommand), `template
+// run --name` (the flag is --var), and, in a skill embedded in the binary,
+// `validate --sdd` (now --scope sdd) - so every agent running kn-verify hit an
+// error the repo could not see.
+//
+// Only fenced code is linted. Prose deliberately names commands that do not
+// exist ("There is no `knowns model` command"), and treating that as drift
+// would train people to ignore the check.
+var docRoots = []string{
+	"README.md", "README.vi.md", "ARCHITECTURE.md", "PHILOSOPHY.md",
+	"AGENTS.md", "CLAUDE.md", "GEMINI.md", "OPENCODE.md",
+	"docs", "internal/instructions",
+}
+
+// Source files tell users what to run too: doctor remediations, error hints,
+// and a UI alert saying "Run 'knowns init' in your terminal". A rename rots
+// those strings exactly like a stale README, and nothing was checking them.
+// Every line counts here; unlike markdown there is no fence to be inside of.
+var srcRoots = []string{"internal", "cmd", "ui/src"}
+
+func isSourceFile(path string) bool {
+	switch filepath.Ext(path) {
+	case ".go", ".ts", ".tsx":
+		return !strings.Contains(path, "/cli-reference/")
+	}
+	return false
+}
+
+var (
+	invocationRE = regexp.MustCompile(`\bknowns\s+((?:[a-z][a-z0-9_-]*\s*)+)`)
+	flagTokenRE  = regexp.MustCompile(`--([a-z][a-z0-9-]*)`)
+	fenceRE      = regexp.MustCompile("^\\s*```")
+)
+
+type docFinding struct {
+	file, line string
+	detail     string
+}
+
+// lintDocs reports every fenced `knowns ...` invocation whose flags the command
+// no longer accepts. Returns the findings and how many invocations were checked.
+func lintDocs(root *cobra.Command) ([]docFinding, int) {
+	var findings []docFinding
+	checked := 0
+
+	scan := func(roots []string, want func(string) bool, fenced bool) {
+		for _, r := range roots {
+			_ = filepath.Walk(r, func(path string, info os.FileInfo, err error) error {
+				if err != nil || info.IsDir() || !want(path) {
+					return nil
+				}
+				if strings.Contains(path, "node_modules") {
+					return nil
+				}
+				body, readErr := os.ReadFile(path)
+				if readErr != nil {
+					return nil
+				}
+				inFence := !fenced
+				for n, line := range strings.Split(string(body), "\n") {
+					if fenced && fenceRE.MatchString(line) {
+						inFence = !inFence
+						continue
+					}
+					if !inFence {
+						continue
+					}
+					for _, detail := range lintLine(root, line) {
+						checked++
+						if detail != "" {
+							findings = append(findings, docFinding{path, fmt.Sprint(n + 1), detail})
+						}
+					}
+				}
+				return nil
+			})
+		}
+	}
+
+	// Markdown: only fenced code, because prose deliberately names commands
+	// that do not exist ("There is no `knowns model` command").
+	scan(docRoots, func(p string) bool {
+		return strings.HasSuffix(p, ".md") && !strings.Contains(p, "cli-reference")
+	}, true)
+	scan(srcRoots, isSourceFile, false)
+
+	return findings, checked
+}
+
+// lintLine assigns each flag to the invocation that precedes it, the way a
+// shell does. A line often mentions two commands, and attributing every flag to
+// the first one reports drift that is not there.
+func lintLine(root *cobra.Command, line string) []string {
+	locs := invocationRE.FindAllStringSubmatchIndex(line, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(locs))
+	for i, loc := range locs {
+		cmd, path := resolvePath(root, strings.Fields(line[loc[2]:loc[3]]))
+		if cmd == nil {
+			out = append(out, "")
+			continue
+		}
+		end := len(line)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+
+		problem := ""
+		for _, m := range flagTokenRE.FindAllStringSubmatch(line[loc[1]:end], -1) {
+			if cmd.Flags().Lookup(m[1]) == nil && cmd.InheritedFlags().Lookup(m[1]) == nil {
+				problem = fmt.Sprintf("knowns %s does not accept --%s", strings.Join(path, " "), m[1])
+			}
+		}
+		out = append(out, problem)
+	}
+	return out
+}
+
+// resolvePath consumes as many subcommand words as resolve, stopping at the
+// first token that is not a subcommand (a placeholder like <name>, or an arg).
+func resolvePath(root *cobra.Command, words []string) (*cobra.Command, []string) {
+	cur := root
+	var path []string
+	for _, w := range words {
+		next := childNamed(cur, w)
+		if next == nil {
+			break
+		}
+		cur = next
+		path = append(path, w)
+	}
+	if len(path) == 0 {
+		return nil, nil
+	}
+	return cur, path
+}
+
+func childNamed(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}

--- a/tools/gendocs/lint_test.go
+++ b/tools/gendocs/lint_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// tree builds a small command tree so these tests do not depend on the real
+// CLI surface, which changes for unrelated reasons.
+func tree() *cobra.Command {
+	root := &cobra.Command{Use: "knowns"}
+
+	setup := &cobra.Command{Use: "setup", Short: "Configure integrations", Run: func(*cobra.Command, []string) {}}
+	setup.Flags().Bool("global", false, "Install to user-level paths")
+
+	initCmd := &cobra.Command{Use: "init", Short: "Initialize", Run: func(*cobra.Command, []string) {}}
+	initCmd.Flags().Bool("force", false, "Force")
+
+	memory := &cobra.Command{Use: "memory", Short: "Manage memory"}
+	create := &cobra.Command{Use: "create <title>", Short: "Create a memory", Run: func(*cobra.Command, []string) {}}
+	create.Flags().String("category", "", "Memory category")
+	memory.AddCommand(create)
+
+	root.AddCommand(setup, initCmd, memory)
+	return root
+}
+
+// TestLintLineAttributesFlagsToNearestCommand covers the bug that made the
+// first version of this check useless: a line often names two commands, and
+// giving every flag to the first one reported drift that was not there. The
+// real line below is from quick-start.md, where --global belongs to `setup`
+// even though `knowns init` appears earlier in the sentence.
+func TestLintLineAttributesFlagsToNearestCommand(t *testing.T) {
+	root := tree()
+
+	cases := []struct {
+		name string
+		line string
+		want string // "" means no finding
+	}{
+		{
+			name: "flag belongs to the second command on the line",
+			line: "`knowns init` creates the store; integrations use `knowns setup <target> --global`.",
+			want: "",
+		},
+		{
+			name: "flag genuinely missing",
+			line: "knowns init --global",
+			want: "knowns init does not accept --global",
+		},
+		{
+			name: "subcommand flag resolves through the path",
+			line: `knowns memory create "x" --category pattern`,
+			want: "",
+		},
+		{
+			name: "flag on the group, not the subcommand",
+			line: `knowns memory --category pattern`,
+			want: "knowns memory does not accept --category",
+		},
+		{
+			name: "placeholder stops path resolution without a false finding",
+			line: "knowns setup <target> --global",
+			want: "",
+		},
+		{
+			name: "unknown command yields no finding, since it may not be ours",
+			line: "knowns notacommand --whatever",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []string
+			for _, f := range lintLine(root, tc.line) {
+				if f != "" {
+					got = append(got, f)
+				}
+			}
+			if tc.want == "" {
+				if len(got) > 0 {
+					t.Errorf("expected no finding, got %q", got)
+				}
+				return
+			}
+			if len(got) != 1 || got[0] != tc.want {
+				t.Errorf("got %q, want [%q]", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSourceFilesAreScanned covers the surface markdown-only linting missed:
+// a Go remediation string or a UI alert naming a command the binary lacks.
+// internal/cli/agents.go told users to run `knowns agents --sync`, which has
+// never been a flag, and nothing noticed until source files were included.
+func TestSourceFilesAreScanned(t *testing.T) {
+	for _, path := range []string{"internal/cli/agents.go", "ui/src/pages/WelcomePage.tsx", "cmd/knowns/main.go"} {
+		if !isSourceFile(path) {
+			t.Errorf("%s should be scanned for command references", path)
+		}
+	}
+	for _, path := range []string{"README.md", "docs/en/cli-reference/knowns_task.md", "ui/src/styles.css"} {
+		if isSourceFile(path) {
+			t.Errorf("%s should not be scanned as source", path)
+		}
+	}
+}
+
+// TestUnfencedLineIsLintedLikeSource is the behavioural half: source has no
+// code fence to be inside of, so every line must be considered.
+func TestUnfencedLineIsLintedLikeSource(t *testing.T) {
+	root := tree()
+	line := `fmt.Println("Use 'knowns init --global' to set up")`
+
+	var got []string
+	for _, f := range lintLine(root, line) {
+		if f != "" {
+			got = append(got, f)
+		}
+	}
+	if len(got) != 1 || got[0] != "knowns init does not accept --global" {
+		t.Errorf("got %q, want one finding about --global", got)
+	}
+}
+
+func TestResolvePathStopsAtNonSubcommand(t *testing.T) {
+	root := tree()
+
+	cmd, path := resolvePath(root, strings.Fields("memory create x"))
+	if cmd == nil || strings.Join(path, " ") != "memory create" {
+		t.Errorf("got path %q, want \"memory create\"", strings.Join(path, " "))
+	}
+
+	if cmd, _ := resolvePath(root, strings.Fields("nope")); cmd != nil {
+		t.Error("an unknown first word should resolve to nothing")
+	}
+}
+
+// TestRenderPageOmitsVersion guards the property that keeps the drift gate
+// usable: a generated page must not embed anything that changes on its own,
+// or every release produces a diff nobody asked for.
+func TestRenderPageOmitsVersion(t *testing.T) {
+	root := tree()
+	root.Version = "9.9.9"
+
+	page := renderPage(root)
+	if strings.Contains(page, "9.9.9") {
+		t.Error("generated page embeds the version; every release would look like drift")
+	}
+	if !strings.Contains(page, "Do not edit by hand") {
+		t.Error("generated page should say it is generated")
+	}
+}
+
+func TestRenderTreeSkipsHiddenAndHelp(t *testing.T) {
+	root := tree()
+	hidden := &cobra.Command{Use: "__daemon", Hidden: true, Run: func(*cobra.Command, []string) {}}
+	root.AddCommand(hidden)
+
+	pages := renderTree(root)
+	if _, ok := pages["knowns___daemon.md"]; ok {
+		t.Error("hidden commands must not get a human reference page")
+	}
+	if _, ok := pages["knowns_memory_create.md"]; !ok {
+		t.Error("nested visible commands must get a page")
+	}
+}

--- a/tools/gendocs/main.go
+++ b/tools/gendocs/main.go
@@ -1,0 +1,177 @@
+// Command gendocs renders the CLI reference straight from the cobra command
+// tree, and can verify that the committed copy still matches.
+//
+// The point is not the docs themselves but the gate: without it, a reference
+// page can describe a command the binary never had (docs/en/reference had
+// `knowns model`) or miss eight that it does. Run with --check in CI.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/howznguyen/knowns/internal/cli"
+)
+
+const defaultOutDir = "docs/en/cli-reference"
+
+func main() {
+	out := flag.String("out", defaultOutDir, "directory to write the CLI reference into")
+	check := flag.Bool("check", false, "verify the committed reference matches the command tree; write nothing")
+	lint := flag.Bool("lint", false, "verify hand-written docs only use commands and flags that exist")
+	flag.Parse()
+
+	if *lint {
+		// Both checks always run. Exiting inside the first would hide every
+		// broken file reference until the last broken flag was fixed.
+		bad := runLint()
+		if runPathLint() {
+			bad = true
+		}
+		if bad {
+			os.Exit(1)
+		}
+		return
+	}
+
+	generated := renderTree(cli.RootCommand())
+	if len(generated) == 0 {
+		fail(fmt.Errorf("command tree produced no pages"))
+	}
+
+	if *check {
+		if err := verify(*out, generated); err != nil {
+			fail(err)
+		}
+		fmt.Printf("CLI reference is up to date (%d pages).\n", len(generated))
+		return
+	}
+
+	if err := write(*out, generated); err != nil {
+		fail(err)
+	}
+	fmt.Printf("Wrote %d pages to %s.\n", len(generated), *out)
+}
+
+func write(dir string, pages map[string][]byte) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+	// Drop pages for commands that no longer exist, so a removed command cannot
+	// leave a stale page behind.
+	existing, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", dir, err)
+	}
+	for _, e := range existing {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		if _, keep := pages[e.Name()]; !keep {
+			if err := os.Remove(filepath.Join(dir, e.Name())); err != nil {
+				return fmt.Errorf("remove stale %s: %w", e.Name(), err)
+			}
+		}
+	}
+	for name, body := range pages {
+		if err := os.WriteFile(filepath.Join(dir, name), body, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func verify(dir string, pages map[string][]byte) error {
+	var missing, stale, changed []string
+
+	for name, want := range pages {
+		got, err := os.ReadFile(filepath.Join(dir, name))
+		if os.IsNotExist(err) {
+			missing = append(missing, name)
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if string(got) != string(want) {
+			changed = append(changed, name)
+		}
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", dir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		if _, ok := pages[e.Name()]; !ok {
+			stale = append(stale, e.Name())
+		}
+	}
+
+	if len(missing)+len(stale)+len(changed) == 0 {
+		return nil
+	}
+
+	var b strings.Builder
+	b.WriteString("CLI reference is out of date. Run: make cli-docs\n")
+	report(&b, "missing (command exists, page does not)", missing)
+	report(&b, "stale (page exists, command does not)", stale)
+	report(&b, "changed (flags or help text differ)", changed)
+	return fmt.Errorf("%s", b.String())
+}
+
+func report(b *strings.Builder, label string, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	sort.Strings(names)
+	fmt.Fprintf(b, "\n  %s:\n", label)
+	for _, n := range names {
+		fmt.Fprintf(b, "    %s\n", n)
+	}
+}
+
+// runLint reports command and flag drift in hand-written docs.
+// It returns whether anything was wrong.
+func runLint() bool {
+	findings, checked := lintDocs(cli.RootCommand())
+	if len(findings) == 0 {
+		fmt.Printf("Docs are consistent with the command tree (%d invocations checked).\n", checked)
+		return false
+	}
+	fmt.Fprintf(os.Stderr, "Docs reference commands or flags that do not exist:\n\n")
+	for _, f := range findings {
+		fmt.Fprintf(os.Stderr, "  %s:%s  %s\n", f.file, f.line, f.detail)
+	}
+	fmt.Fprintf(os.Stderr, "\n%d of %d fenced invocations are broken.\n", len(findings), checked)
+	return true
+}
+
+// runPathLint reports file references that point at nothing.
+// It returns whether anything was wrong.
+func runPathLint() bool {
+	findings, checked := lintPaths()
+	if len(findings) == 0 {
+		fmt.Printf("Docs reference %d files, all of which exist.\n", checked)
+		return false
+	}
+	fmt.Fprintf(os.Stderr, "\nDocs reference files that do not exist:\n\n")
+	for _, f := range findings {
+		fmt.Fprintf(os.Stderr, "  %s:%s  %s\n", f.file, f.line, f.token)
+	}
+	fmt.Fprintf(os.Stderr, "\n%d of %d file references are broken.\n"+
+		"Fix the reference, or add it to %s with a reason.\n", len(findings), checked, allowFile)
+	return true
+}
+
+func fail(err error) {
+	fmt.Fprintf(os.Stderr, "gendocs: %v\n", err)
+	os.Exit(1)
+}

--- a/tools/gendocs/paths.go
+++ b/tools/gendocs/paths.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// A doc that names a file which does not exist is the failure that produced the
+// old ARCHITECTURE.md: it described task.ts, file-store.ts, and src/index.ts in
+// a repository that has never contained a line of TypeScript outside ui/. The
+// command lint cannot see that class, because none of it is a command.
+//
+// Precision matters more than recall here. A check that cries wolf gets
+// disabled, so this only considers tokens that are unambiguously meant as a
+// path in this repository, and everything else needs an explicit allow entry.
+
+const allowFile = "docs/allowed-missing-paths.txt"
+
+var (
+	// Source extensions only, and backticked. Config and markdown names in docs
+	// are overwhelmingly artifacts Knowns writes into a *user's* project
+	// (KNOWNS.md, .cursor/mcp.json, requirements.md), which cannot be resolved
+	// here; including them made every finding a false positive. A .go or .ts
+	// name, by contrast, can only mean a file in this repository.
+	pathTokenRE = regexp.MustCompile("`([A-Za-z0-9_./-]+\\.(?:go|ts|tsx|js|jsx))`")
+
+	// Directory-tree blocks name files without backticks, and that is exactly
+	// where the old ARCHITECTURE.md listed eleven TypeScript files this
+	// repository has never had.
+	fencedPathRE = regexp.MustCompile(`\b([A-Za-z0-9_./-]+\.(?:go|ts|tsx|js|jsx))\b`)
+	placeholder  = regexp.MustCompile(`[<>*$]|\.\.\.`)
+)
+
+type pathFinding struct {
+	file, line, token string
+}
+
+// lintPaths reports backticked file references that resolve to nothing.
+func lintPaths() ([]pathFinding, int) {
+	allow := loadAllowList()
+	index := buildBasenameIndex()
+
+	var findings []pathFinding
+	checked := 0
+
+	for _, r := range docRoots {
+		_ = filepath.Walk(r, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() || !strings.HasSuffix(path, ".md") {
+				return nil
+			}
+			if strings.Contains(path, "cli-reference") {
+				return nil
+			}
+			body, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return nil
+			}
+			inFence := false
+			for n, line := range strings.Split(string(body), "\n") {
+				if fenceRE.MatchString(line) {
+					inFence = !inFence
+					continue
+				}
+				re := pathTokenRE
+				if inFence {
+					re = fencedPathRE
+				}
+				for _, m := range re.FindAllStringSubmatch(line, -1) {
+					token := m[1]
+					if placeholder.MatchString(token) || allow[token] {
+						continue
+					}
+					checked++
+					if !pathExists(token, index) {
+						findings = append(findings, pathFinding{path, itoa(n + 1), token})
+					}
+				}
+			}
+			return nil
+		})
+	}
+	return findings, checked
+}
+
+// pathExists accepts a repo-relative path, or - for a bare filename - any file
+// in the tree with that basename. Docs legitimately say "storage/store.go" or
+// just "store.go" depending on how much context the sentence already carries.
+func pathExists(token string, index map[string]bool) bool {
+	for _, candidate := range []string{token, filepath.Join("internal", token)} {
+		if _, err := os.Stat(candidate); err == nil {
+			return true
+		}
+	}
+	if !strings.Contains(token, "/") {
+		return index[token]
+	}
+	// A partial path like "handlers/task.go": accept it if some real file ends
+	// with it, so docs can name the meaningful tail instead of the full path.
+	return index["suffix:"+token]
+}
+
+func buildBasenameIndex() map[string]bool {
+	index := map[string]bool{}
+	_ = filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case "node_modules", ".git", "dist", "bin":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		index[info.Name()] = true
+		parts := strings.Split(filepath.ToSlash(path), "/")
+		for i := range parts {
+			index["suffix:"+strings.Join(parts[i:], "/")] = true
+		}
+		return nil
+	})
+	return index
+}
+
+func loadAllowList() map[string]bool {
+	allow := map[string]bool{}
+	body, err := os.ReadFile(allowFile)
+	if err != nil {
+		return allow
+	}
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		allow[line] = true
+	}
+	return allow
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/tools/gendocs/render.go
+++ b/tools/gendocs/render.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// pageName is the file a command's page lives in: `knowns task create` becomes
+// knowns_task_create.md, matching the command path so a reader can guess it.
+func pageName(c *cobra.Command) string {
+	return strings.ReplaceAll(c.CommandPath(), " ", "_") + ".md"
+}
+
+// renderTree walks every visible command and returns filename -> contents.
+func renderTree(root *cobra.Command) map[string][]byte {
+	pages := map[string][]byte{}
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		if !c.IsAvailableCommand() && c != root {
+			return
+		}
+		if c.Name() == "help" {
+			return
+		}
+		pages[pageName(c)] = []byte(renderPage(c))
+		for _, sub := range c.Commands() {
+			walk(sub)
+		}
+	}
+	walk(root)
+	return pages
+}
+
+// renderPage renders one command. The version is deliberately left out: it
+// changes every release and would turn the drift gate into noise.
+func renderPage(c *cobra.Command) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "# %s\n\n", c.CommandPath())
+	if s := strings.TrimSpace(c.Short); s != "" {
+		fmt.Fprintf(&b, "%s\n\n", s)
+	}
+	if l := strings.TrimSpace(c.Long); l != "" && l != strings.TrimSpace(c.Short) {
+		fmt.Fprintf(&b, "%s\n\n", l)
+	}
+
+	if c.Runnable() {
+		b.WriteString("## Usage\n\n```\n" + c.UseLine() + "\n```\n\n")
+	}
+	if e := strings.TrimSpace(c.Example); e != "" {
+		b.WriteString("## Examples\n\n```bash\n" + e + "\n```\n\n")
+	}
+
+	writeFlags(&b, "Flags", c.NonInheritedFlags())
+	writeFlags(&b, "Inherited flags", c.InheritedFlags())
+
+	var subs []*cobra.Command
+	for _, sub := range c.Commands() {
+		if sub.IsAvailableCommand() && sub.Name() != "help" {
+			subs = append(subs, sub)
+		}
+	}
+	if len(subs) > 0 {
+		sort.Slice(subs, func(i, j int) bool { return subs[i].Name() < subs[j].Name() })
+		b.WriteString("## Subcommands\n\n")
+		for _, sub := range subs {
+			fmt.Fprintf(&b, "- [`%s`](%s) — %s\n", sub.CommandPath(), pageName(sub), strings.TrimSpace(sub.Short))
+		}
+		b.WriteString("\n")
+	}
+
+	if p := c.Parent(); p != nil {
+		fmt.Fprintf(&b, "## See also\n\n- [`%s`](%s) — %s\n\n", p.CommandPath(), pageName(p), strings.TrimSpace(p.Short))
+	}
+
+	b.WriteString("---\n\nGenerated from the command tree by `make cli-docs`. Do not edit by hand.\n")
+	return b.String()
+}
+
+func writeFlags(b *strings.Builder, heading string, fs *pflag.FlagSet) {
+	if !fs.HasAvailableFlags() {
+		return
+	}
+	fmt.Fprintf(b, "## %s\n\n| Flag | Type | Default | Description |\n|---|---|---|---|\n", heading)
+	fs.VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		name := "`--" + f.Name + "`"
+		if f.Shorthand != "" {
+			name = "`-" + f.Shorthand + ", --" + f.Name + "`"
+		}
+		def := "—"
+		if f.DefValue != "" && f.DefValue != "false" && f.DefValue != "[]" {
+			def = "`" + f.DefValue + "`"
+		}
+		fmt.Fprintf(b, "| %s | `%s` | %s | %s |\n", name, f.Value.Type(), def, escapePipes(strings.TrimSpace(f.Usage)))
+	})
+	b.WriteString("\n")
+}
+
+// escapePipes keeps a flag description with a literal | from breaking the table.
+func escapePipes(s string) string { return strings.ReplaceAll(s, "|", `\|`) }

--- a/ui/e2e/darkmode.spec.ts
+++ b/ui/e2e/darkmode.spec.ts
@@ -277,7 +277,7 @@ test.describe("Dark Mode with Mentions", () => {
 
 		await test.step("Create task with mentions", async () => {
 			const output = server.cli('task create "Mentioned Task" -d "Referenced by another"');
-			const match = output.match(/Created task\s+([a-z0-9]+)/i);
+			const match = output.match(/Created task\s+([a-z0-9-]+)/i);
 			taskId = match?.[1] || "";
 			server.cli(`task create "Mentioner" -d "See @task-${taskId} for details"`);
 		});

--- a/ui/e2e/dashboard-extended.spec.ts
+++ b/ui/e2e/dashboard-extended.spec.ts
@@ -7,10 +7,10 @@ test.beforeAll(async () => {
 	server = await startServer();
 	server.cli('task create "Dashboard High Priority" -d "Needs attention" --priority high -l "ui"');
 	const progressOutput = server.cli('task create "Dashboard Current Focus" -d "Current focus" --priority medium -l "ui"');
-	const progressId = progressOutput.match(/Created task\s+([a-z0-9.]+)/i)?.[1];
+	const progressId = progressOutput.match(/Created task\s+([a-z0-9.-]+)/i)?.[1];
 	if (progressId) server.cli(`task edit ${progressId} -s in-progress`);
 	const holdOutput = server.cli('task create "Dashboard On Hold" -d "Custom status coverage" --priority low -l "ops"');
-	const holdId = holdOutput.match(/Created task\s+([a-z0-9.]+)/i)?.[1];
+	const holdId = holdOutput.match(/Created task\s+([a-z0-9.-]+)/i)?.[1];
 	if (holdId) server.cli(`task edit ${holdId} -s on-hold`);
 });
 

--- a/ui/e2e/decision.spec.ts
+++ b/ui/e2e/decision.spec.ts
@@ -264,7 +264,7 @@ function seedDecisionEvidence(label: string): DecisionEvidence {
 	const docPath = stripAnsi(docOutput).match(/Created doc:\s+(\S+)/)?.[1];
 	expect(docPath, `could not parse doc path from: ${docOutput}`).toBeTruthy();
 	const taskOutput = server.cli(`task create "Verify Decisions ${label}" --status done`);
-	const taskID = taskOutput.match(/Created task\s+([a-z0-9]+):/)?.[1];
+	const taskID = taskOutput.match(/Created task\s+([a-z0-9-]+):/i)?.[1];
 	expect(taskID, `could not parse task ID from: ${taskOutput}`).toBeTruthy();
 	return {
 		sources: [`@doc/${docPath!}`],

--- a/ui/e2e/error-handling.spec.ts
+++ b/ui/e2e/error-handling.spec.ts
@@ -145,7 +145,7 @@ test.describe("Rapid Operations", () => {
 
 		await test.step("Create task", async () => {
 			const output = server.cli('task create "Status Flipper" -d "Changes status rapidly"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 		});
 
 		await test.step("Change status rapidly via CLI", async () => {
@@ -200,7 +200,7 @@ test.describe("Long Content Handling", () => {
 
 		await test.step("Create task with long description", async () => {
 			const output = server.cli(`task create "Long Desc Task" -d "${longDesc}"`);
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 		});
 
 		await test.step("Open task detail", async () => {

--- a/ui/e2e/full-interactions.spec.ts
+++ b/ui/e2e/full-interactions.spec.ts
@@ -220,7 +220,7 @@ test.describe("Task Detail Editing", () => {
 		let taskId = "";
 		await test.step("Create task and open detail", async () => {
 			const output = server.cli('task create "Done Task" -d "Mark done"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			// Navigate directly to task detail to avoid pagination issues
 			await page.goto(`${server.baseURL}/kanban/${taskId}`);
 			await expect(page.getByRole("heading", { name: "Done Task", exact: true })).toBeVisible();
@@ -457,7 +457,7 @@ test.describe("Kanban Drag and Drop", () => {
 
 		await test.step("Create task in To Do", async () => {
 			const output = server.cli('task create "Column Move" -d "Move via status change"');
-			const match = output.match(/Created task\s+([a-z0-9]+)/i);
+			const match = output.match(/Created task\s+([a-z0-9-]+)/i);
 			taskId = match?.[1] || "";
 		});
 
@@ -534,11 +534,11 @@ test.describe("Kanban Drag and Drop", () => {
 
 		await test.step("Create 3 tasks in To Do", async () => {
 			const out1 = server.cli('task create "Order First" -d "First task"');
-			taskId1 = out1.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId1 = out1.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			const out2 = server.cli('task create "Order Second" -d "Second task"');
-			taskId2 = out2.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId2 = out2.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			const out3 = server.cli('task create "Order Third" -d "Third task"');
-			taskId3 = out3.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId3 = out3.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 		});
 
 		await test.step("Move middle task to in-progress via CLI", async () => {
@@ -581,7 +581,7 @@ test.describe("Kanban Drag and Drop", () => {
 
 		await test.step("Create task and change status", async () => {
 			const output = server.cli('task create "Persist Status" -d "Should persist"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`task edit ${taskId} -s done`);
 		});
 

--- a/ui/e2e/mentions.spec.ts
+++ b/ui/e2e/mentions.spec.ts
@@ -19,7 +19,7 @@ test.describe("Task → Task Mentions", () => {
 
 		await test.step("Create target task", async () => {
 			const output = server.cli('task create "Login Feature" -d "Implement login"');
-			const match = output.match(/Created task\s+([a-z0-9]+)/i);
+			const match = output.match(/Created task\s+([a-z0-9-]+)/i);
 			targetId = match?.[1] || "";
 			expect(targetId).toBeTruthy();
 		});
@@ -50,7 +50,7 @@ test.describe("Task → Task Mentions", () => {
 
 		await test.step("Create two tasks with mention", async () => {
 			const output = server.cli('task create "Target Task" -d "The target"');
-			const match = output.match(/Created task\s+([a-z0-9]+)/i);
+			const match = output.match(/Created task\s+([a-z0-9-]+)/i);
 			targetId = match?.[1] || "";
 			server.cli(`task create "Referencing Task" -d "See @task-${targetId} for details"`);
 		});
@@ -164,7 +164,7 @@ test.describe("Semantic Reference Badges", () => {
 
 		await test.step("Create target task and doc", async () => {
 			const output = server.cli('task create "Runtime API" -d "Implement runtime API"');
-			const match = output.match(/Created task\s+([a-z0-9]+)/i);
+			const match = output.match(/Created task\s+([a-z0-9-]+)/i);
 			taskId = match?.[1] || "";
 			expect(taskId).toBeTruthy();
 			server.cli('doc create "Semantic Runtime" -d "Semantic runtime guide" -t "guide"');
@@ -217,7 +217,7 @@ test.describe("Semantic Reference Badges", () => {
 
 		await test.step("Create canonical ref targets", async () => {
 			const taskOutput = server.cli('task create "Canonical Target" -d "Target task"');
-			taskId = taskOutput.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = taskOutput.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			expect(taskId).toBeTruthy();
 
 			server.cli('memory create "Canonical Memory" --layer project --category pattern -c "Remember canonical refs"');
@@ -289,7 +289,7 @@ test.describe("Doc → Task Mentions", () => {
 
 		await test.step("Create a task", async () => {
 			const output = server.cli('task create "Important Bug" -d "Critical bug to fix"');
-			const match = output.match(/Created task\s+([a-z0-9]+)/i);
+			const match = output.match(/Created task\s+([a-z0-9-]+)/i);
 			taskId = match?.[1] || "";
 		});
 
@@ -352,11 +352,11 @@ test.describe("Multiple Mentions", () => {
 
 		await test.step("Create tasks and docs", async () => {
 			const out1 = server.cli('task create "Backend API" -d "Build backend"');
-			const match1 = out1.match(/Created task\s+([a-z0-9]+)/i);
+			const match1 = out1.match(/Created task\s+([a-z0-9-]+)/i);
 			taskId1 = match1?.[1] || "";
 
 			const out2 = server.cli('task create "Frontend UI" -d "Build frontend"');
-			const match2 = out2.match(/Created task\s+([a-z0-9]+)/i);
+			const match2 = out2.match(/Created task\s+([a-z0-9-]+)/i);
 			taskId2 = match2?.[1] || "";
 
 			server.cli('doc create "Design Spec" -d "Design specifications" -t "spec"');

--- a/ui/e2e/task-archive.spec.ts
+++ b/ui/e2e/task-archive.spec.ts
@@ -17,7 +17,7 @@ test.describe("Task Archive", () => {
 
 		await test.step("Create task", async () => {
 			const output = server.cli('task create "Archive Target" -d "Task to be archived" --priority low');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 		});
 
 		await test.step("Open task detail", async () => {
@@ -37,7 +37,7 @@ test.describe("Task Archive", () => {
 
 		await test.step("Create task", async () => {
 			const output = server.cli('task create "Soon Archived" -d "Will be archived" --status done');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 		});
 
 		await test.step("Verify task visible on kanban", async () => {
@@ -62,7 +62,7 @@ test.describe("Task Archive", () => {
 
 		await test.step("Create and archive task", async () => {
 			const output = server.cli('task create "Revived Task" -d "Will be unarchived" --status done');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`task archive ${taskId} --yes`);
 		});
 
@@ -89,7 +89,7 @@ test.describe("Task Archive", () => {
 
 		await test.step("Create task", async () => {
 			const output = server.cli('task create "Hidden Task" -d "Should not appear after archive" --status done');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 		});
 
 		await test.step("Verify task on tasks page", async () => {
@@ -116,7 +116,7 @@ test.describe("Task Delete", () => {
 
 		await test.step("Create task", async () => {
 			const output = server.cli('task create "Delete Me" -d "Permanent removal"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 		});
 
 		await test.step("Verify task on kanban", async () => {

--- a/ui/e2e/task-detail.spec.ts
+++ b/ui/e2e/task-detail.spec.ts
@@ -81,7 +81,7 @@ test.describe("Task Detail Sheet", () => {
 	test("shows implementation plan", async ({ page }) => {
 		await test.step("Create task with plan", async () => {
 			const output = server.cli('task create "Planned Task" -d "Has a plan"');
-			const idMatch = output.match(/Created task\s+([a-z0-9]+)/i);
+			const idMatch = output.match(/Created task\s+([a-z0-9-]+)/i);
 			if (idMatch?.[1]) {
 				server.cli(`task edit ${idMatch[1]} --plan "1. Design the feature\n2. Implement it\n3. Write tests"`);
 			}

--- a/ui/e2e/task-history.spec.ts
+++ b/ui/e2e/task-history.spec.ts
@@ -34,7 +34,7 @@ test.describe("Task History Panel", () => {
 
 		await test.step("Create and edit task to generate history", async () => {
 			const output = server.cli('task create "History Task" -d "Track changes" --priority low');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`task edit ${taskId} -s in-progress`);
 			server.cli(`task edit ${taskId} --priority high`);
 			server.cli(`task edit ${taskId} -d "Updated description"`);
@@ -59,7 +59,7 @@ test.describe("Task History Panel", () => {
 
 		await test.step("Create task with several edits", async () => {
 			const output = server.cli('task create "Version Task" -d "Original description"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`task edit ${taskId} -s in-progress`);
 			server.cli(`task edit ${taskId} -t "Renamed Version Task"`);
 		});
@@ -85,7 +85,7 @@ test.describe("Task History Panel", () => {
 
 		await test.step("Create task and change status", async () => {
 			const output = server.cli('task create "Diff Task" -d "Check diff view" --priority low');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`task edit ${taskId} -s in-progress`);
 		});
 
@@ -117,7 +117,7 @@ test.describe("Task History Panel", () => {
 
 		await test.step("Create task with status and content changes", async () => {
 			const output = server.cli('task create "Filter Task" -d "Test filtering" --priority low');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`task edit ${taskId} -s in-progress`);
 			server.cli(`task edit ${taskId} -d "Updated for filter test"`);
 			server.cli(`task edit ${taskId} --priority high`);

--- a/ui/e2e/task-lifecycle.spec.ts
+++ b/ui/e2e/task-lifecycle.spec.ts
@@ -13,7 +13,7 @@ test.afterAll(() => {
 
 function createTask(title: string, extra = ""): string {
 	const output = server.cli(`task create "${title}" ${extra}`);
-	return output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+	return output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 }
 
 async function selectLifecycle(page: Page, value: string) {

--- a/ui/e2e/tasks.spec.ts
+++ b/ui/e2e/tasks.spec.ts
@@ -116,7 +116,7 @@ test.describe("Tasks Page", () => {
 	test("filters tasks by status", async ({ page }) => {
 		await test.step("Create tasks with different statuses", async () => {
 			const output = server.cli('task create "Done Task" -d "completed"');
-			const idMatch = output.match(/Created task\s+([a-z0-9]+)/i);
+			const idMatch = output.match(/Created task\s+([a-z0-9-]+)/i);
 			if (idMatch?.[1]) {
 				server.cli(`task edit ${idMatch[1]} -s done`);
 			}

--- a/ui/e2e/timer.spec.ts
+++ b/ui/e2e/timer.spec.ts
@@ -27,7 +27,7 @@ test.describe("Timer Start & Stop", () => {
 
 		await test.step("Create task", async () => {
 			const output = server.cli('task create "Build Feature" -d "Verify timer activation"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 		});
 
 		await test.step("Open task detail from kanban", async () => {
@@ -82,7 +82,7 @@ test.describe("Timer Start & Stop", () => {
 
 		await test.step("Create task and start timer via CLI", async () => {
 			const output = server.cli('task create "Write Tests" -d "Verify shutdown flow"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId}`);
 		});
 
@@ -127,7 +127,7 @@ test.describe("Timer Start & Stop", () => {
 
 		await test.step("Create task and start timer", async () => {
 			const output = server.cli('task create "Deploy App" -d "Verify header controls"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId}`);
 		});
 
@@ -158,7 +158,7 @@ test.describe("Timer Pause & Resume", () => {
 
 		await test.step("Create task and start timer", async () => {
 			const output = server.cli('task create "Code Review" -d "Verify workflow"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId}`);
 		});
 
@@ -201,7 +201,7 @@ test.describe("Timer Pause & Resume", () => {
 
 		await test.step("Create task and start timer", async () => {
 			const output = server.cli('task create "Fix Linting" -d "Verify header controls"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId}`);
 		});
 
@@ -248,7 +248,7 @@ test.describe("Timer Persistence", () => {
 
 		await test.step("Create task and start timer", async () => {
 			const output = server.cli('task create "Nav Task" -d "Persists across pages"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId}`);
 		});
 
@@ -284,7 +284,7 @@ test.describe("Timer Persistence", () => {
 
 		await test.step("Create task and start timer", async () => {
 			const output = server.cli('task create "Reload Task" -d "Survives reload"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId}`);
 		});
 
@@ -313,7 +313,7 @@ test.describe("Timer Persistence", () => {
 
 		await test.step("Create task and start timer via CLI", async () => {
 			const output = server.cli('task create "CLI Task" -d "Started via CLI"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId}`);
 		});
 
@@ -345,7 +345,7 @@ test.describe("Time Tracking Logs", () => {
 
 		await test.step("Create task and add time via CLI", async () => {
 			const output = server.cli('task create "Log Task" -d "Check time logs"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time add ${taskId} 30m`);
 		});
 
@@ -370,7 +370,7 @@ test.describe("Time Tracking Logs", () => {
 
 		await test.step("Create task with multiple manual entries", async () => {
 			const output = server.cli('task create "Multi Log" -d "Multiple entries"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time add ${taskId} 1h`);
 			server.cli(`time add ${taskId} 45m`);
 		});
@@ -396,7 +396,7 @@ test.describe("Time Tracking Logs", () => {
 
 		await test.step("Create task and start timer", async () => {
 			const output = server.cli('task create "Active Task" -d "Shows recording badge"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId}`);
 		});
 
@@ -425,7 +425,7 @@ test.describe("Timer Elapsed Time", () => {
 
 		await test.step("Create task and start timer", async () => {
 			const output = server.cli('task create "Counting" -d "Watch time tick"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId}`);
 		});
 
@@ -457,7 +457,7 @@ test.describe("Timer Elapsed Time", () => {
 
 		await test.step("Create task, start then pause timer", async () => {
 			const output = server.cli('task create "Frozen" -d "Time freezes when paused"');
-			taskId = output.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId = output.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId}`);
 			await page.waitForTimeout(500);
 			server.cli(`time pause ${taskId}`);
@@ -493,9 +493,9 @@ test.describe("Multiple Timers", () => {
 
 		await test.step("Create two tasks and start both timers", async () => {
 			const out1 = server.cli('task create "Task Alpha" -d "First timer"');
-			taskId1 = out1.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId1 = out1.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			const out2 = server.cli('task create "Task Beta" -d "Second timer"');
-			taskId2 = out2.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId2 = out2.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId1}`);
 			server.cli(`time start ${taskId2}`);
 		});
@@ -521,9 +521,9 @@ test.describe("Multiple Timers", () => {
 
 		await test.step("Create tasks and start timers", async () => {
 			const out1 = server.cli('task create "Batch One" -d "First"');
-			taskId1 = out1.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId1 = out1.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			const out2 = server.cli('task create "Batch Two" -d "Second"');
-			taskId2 = out2.match(/Created task\s+([a-z0-9]+)/i)?.[1] || "";
+			taskId2 = out2.match(/Created task\s+([a-z0-9-]+)/i)?.[1] || "";
 			server.cli(`time start ${taskId1}`);
 			server.cli(`time start ${taskId2}`);
 		});


### PR DESCRIPTION
## Description

Closes the gap that let documentation, agent skills, and user-facing hints describe a CLI the binary does not have. Four user-visible bugs are fixed, and the classes they belong to are now gated so they cannot come back.

**`--plain`, `--json` and `NO_COLOR` were silently ignored on write paths.** lipgloss v2 emits full ANSI and downsamples only at its writer, but this CLI prints through `fmt.Print*`, so the flags reached nothing. `SetPlainOutput` swaps the package-level styles, covering roughly 640 render sites from one choke point. cobra serves `--help` without `PersistentPreRun`, so the help path honors the flags separately. The guidelines claiming `--plain` errors on create/edit are removed; it never did.

**`knowns agents` told users to run a flag that does not exist.** It printed "Use 'knowns agents --sync'", which returns `unknown flag` and leaves no next step. The real command is `sync --instructions`.

**Two documented commands could not run.** `knowns memory add --category` (the subcommand is `create`) and `knowns template run --name` (the flag is `--var`). The first was in the README and four docs pages; `validate --sdd` was in the embedded `kn-verify` skill, so every agent running that skill hit an error.

**`ARCHITECTURE.md` described a TypeScript project.** 15 of the 24 files it named do not exist here. It is rewritten against the real Go tree, and every number in it (package count, command count, MCP tool count, Go version) was taken from the tree and checked.

**`runtime-memory` moved under `runtime`.** `knowns runtime memory` is now the discoverable path. The old top-level path stays runnable but hidden, because `runtimeinstall` baked it into hook scripts, the OpenCode plugin, and Kiro hook files already on users' machines, and doctor matches that exact string. `internal/cli/lifecycle.go` records the retirement schedule so a deprecated command cannot vanish without leaving a tombstone that names its replacement.

### The gates

- `tools/gendocs` renders `docs/en/cli-reference/` from the cobra tree. `make cli-docs-check` fails CI when they diverge.
- `TestCommandContract` snapshots the whole surface **including hidden commands**, which a human reference cannot cover, so renaming `__runtime run` or `runtime-memory hook` is a reviewed diff.
- `TestInstalledHookArgvResolves` installs every runtime adapter into a temporary HOME and resolves the argv `runtimeinstall` actually writes back against the live command tree. That argv is written by one version and executed by a later one, so it is a compatibility contract.
- The doc lint reads Go remediation strings and UI alerts too, not only markdown: 1050 invocations across docs, Go and TypeScript. It found the `agents --sync` bug above.

Machine-facing commands must never carry cobra's `Deprecated`: it prints through `OutOrStderr`, so it lands on stdout the moment anything calls `SetOut`, and adapters capturing combined output feed it into the agent's context. That rule has its own test.

## Related Issue

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] Other (please describe): CI gates coupling docs, skills and source to the command tree

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

Every gate was verified by reintroducing the bug it targets and confirming it fails, not only by watching it pass. Each of the five commits was checked out into a clean worktree and built and tested on its own.

## Additional Notes

**Commit order matters.** `fix(cli): point the agents hint at a command that exists` has to land before the gate commit. Reversed, the gate commit fails its own CI check, because `agents.go` still carried the bad hint at that point.

**The generated reference was produced against `HEAD`, not the working tree.** The working tree carries an unrelated in-flight `knowns runtime retry` feature (CLI, API and UI) that is not part of this PR. Generating from the working tree would have committed pages for a command absent from the branch, and `make cli-docs-check` would fail on a clean checkout of this PR. Three artifacts are therefore left uncommitted on purpose and belong with that feature when it lands: `docs/en/cli-reference/knowns_runtime_retry.md`, `docs/en/cli-reference/knowns_runtime.md`, and `internal/cli/testdata/command-contract.txt`. Running `make cli-docs` is all that is needed, and the gate will say so if it is forgotten.

**One pre-existing test failure is not addressed here.** `TestSearchChecksSkipWhenSemanticSearchDisabled` in `internal/doctor` fails identically at `HEAD` on a clean worktree; it depends on local Qdrant runtime state.

**Do not hand-edit** `docs/en/cli-reference/` or `internal/cli/testdata/command-contract.txt`. Run `make cli-docs`, which regenerates both.
